### PR TITLE
feat(synqra): Phase B-2 — collection-side generator (StoreBoundComponentsCollection)

### DIFF
--- a/Synqra.CodeGeneration/ModelBindingGenerator.cs
+++ b/Synqra.CodeGeneration/ModelBindingGenerator.cs
@@ -503,6 +503,22 @@ public class ModelBindingGenerator : IIncrementalGenerator
 			bool isComponent = classData.Data.AllInterfaces.Any(i =>
 				i.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::Synqra.IComponent");
 
+			// Container detection: an IComponentContainer-implementing class. The
+			// generator emits a `Components` property backed by a
+			// StoreBoundComponentsCollection — its ICollection<T>.Add/Remove route
+			// through AddComponentCommand/DeleteComponentCommand when the container
+			// is store-attached. We only emit when the user has NOT manually
+			// declared a Components member (existing manual-collection consumers
+			// remain unchanged).
+			bool isContainer = classData.Data.AllInterfaces.Any(i =>
+				i.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::Synqra.IComponentContainer");
+			bool userDeclaredComponents = classData.Clazz.Members
+				.OfType<PropertyDeclarationSyntax>()
+				.Any(p => p.Identifier.Text == "Components")
+				|| classData.Data.GetMembers("Components")
+					.Any(s => s is IPropertySymbol or IFieldSymbol);
+			bool emitComponentsCollection = isContainer && !userDeclaredComponents;
+
 			// Setter-template fragments. These are interpolated into the property
 			// template below — same physical template, two emitted variants.
 			string commandTypeName        = isComponent ? "ChangeComponentPropertyCommand" : "ChangeObjectPropertyCommand";
@@ -697,9 +713,36 @@ public class ModelBindingGenerator : IIncrementalGenerator
 		}
 		__store = store;
 		__collectionId = collectionId;
+		{{(emitComponentsCollection ? "EnsureComponentsWrapper().Attach(store, collectionId);" : "")}}
 		OnAttached();
 	}
 """);
+				if (emitComponentsCollection)
+				{
+					body.AppendLine($$"""
+
+	// IComponentContainer: generator-emitted Components property. Backed by
+	// StoreBoundComponentsCollection so that user-driven `.Components.Add(c)` /
+	// `.Components.Remove(c)` produce AddComponentCommand / DeleteComponentCommand
+	// when the container is store-attached; the projection's event-apply path
+	// reaches the inner data via TryAdd / BypassRemove and stays command-free.
+	// Field is lazily allocated because `this` is unavailable in field initializers.
+	private global::Synqra.StoreBoundComponentsCollection? __components;
+
+	public global::Synqra.IComponentsCollection Components => EnsureComponentsWrapper();
+
+	global::Synqra.StoreBoundComponentsCollection EnsureComponentsWrapper()
+	{
+		var existing = __components;
+		if (existing is not null) return existing;
+		var wrapper = new global::Synqra.StoreBoundComponentsCollection(this);
+		// Thread-safe one-time assign; in a race the loser's allocation is discarded.
+		var prior = global::System.Threading.Interlocked.CompareExchange(
+			ref __components, wrapper, null);
+		return prior ?? wrapper;
+	}
+""");
+				}
 				if (isComponent)
 				{
 					body.AppendLine($$"""

--- a/Synqra.Model/Components/ComponentsCollection.cs
+++ b/Synqra.Model/Components/ComponentsCollection.cs
@@ -54,7 +54,12 @@ public sealed class ComponentsCollection : IComponentsCollection
 		return true;
 	}
 
-	public bool Remove(IComponent component)
+	// Base ComponentsCollection has no command channel — both Remove and
+	// BypassRemove just mutate the inner data. StoreBoundComponentsCollection
+	// wraps this and overrides ICollection<T>.Remove to emit a command.
+	public bool Remove(IComponent component) => BypassRemove(component);
+
+	public bool BypassRemove(IComponent component)
 	{
 		var index = _components.IndexOf(component);
 		if (index < 0) return false;

--- a/Synqra.Model/Components/IComponentsCollection.cs
+++ b/Synqra.Model/Components/IComponentsCollection.cs
@@ -37,6 +37,22 @@ public interface IComponentsCollection : ICollection<IComponent>
 	/// distinguish acceptance from rejection without throwing.
 	/// (<see cref="ICollection{T}.Add"/> returns <c>void</c>; this variant exposes
 	/// the success bit.)
+	/// <para>
+	/// Critically, <see cref="TryAdd"/> is also the <i>command bypass</i> path:
+	/// generator-emitted wrappers route <see cref="ICollection{T}.Add"/> through
+	/// the command channel when the container is attached to a store, but always
+	/// route <see cref="TryAdd"/> directly into the inner data structure. The
+	/// projection calls <see cref="TryAdd"/> when applying
+	/// <see cref="ComponentAddedEvent"/> so it does not produce a recursive command.
+	/// </para>
 	/// </summary>
 	bool TryAdd(IComponent component);
+
+	/// <summary>
+	/// Command-bypass removal counterpart to <see cref="TryAdd"/>. Used by the
+	/// projection when applying <see cref="ComponentDeletedEvent"/>. User code
+	/// should use <see cref="ICollection{T}.Remove"/> instead, which routes
+	/// through the command channel when the container is store-attached.
+	/// </summary>
+	bool BypassRemove(IComponent component);
 }

--- a/Synqra.Model/Components/StoreBoundComponentsCollection.cs
+++ b/Synqra.Model/Components/StoreBoundComponentsCollection.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Synqra;
+
+/// <summary>
+/// Generator-emitted wrapper around <see cref="ComponentsCollection"/> that routes
+/// user-driven <see cref="ICollection{T}.Add"/> and <see cref="ICollection{T}.Remove"/>
+/// through the Synqra command channel when the host container is attached to a store.
+/// <para>
+/// Same pattern as the generator-emitted property setter:
+/// </para>
+/// <list type="bullet">
+///   <item>Pre-attach (no store) — direct mutation of the inner data structure so
+///     code paths like collection initializers work before the container is added
+///     to its <c>StoreCollection</c>.</item>
+///   <item>Post-attach (store present) — emit <see cref="AddComponentCommand"/> /
+///     <see cref="DeleteComponentCommand"/>; the projection's event-apply path
+///     then mutates state via <see cref="IComponentsCollection.TryAdd"/> /
+///     <see cref="IComponentsCollection.BypassRemove"/>.</item>
+/// </list>
+/// <para>
+/// Optimistic-concurrency precondition probes the <i>container's</i> last event id
+/// — components inherit their container's conflict boundary, matching the
+/// per-target precondition semantics elsewhere in the substrate.
+/// </para>
+/// </summary>
+public sealed class StoreBoundComponentsCollection : IComponentsCollection
+{
+	readonly ComponentsCollection _inner = new();
+	readonly object _container;
+
+	IObjectStore? _store;
+	Guid _containerCollectionId;
+
+	public StoreBoundComponentsCollection(object container)
+	{
+		_container = container ?? throw new ArgumentNullException(nameof(container));
+	}
+
+	/// <summary>
+	/// Records the linkage to the projection. Called by the generator-emitted
+	/// <see cref="IBindableModel.Attach"/> implementation on the host container.
+	/// We deliberately do NOT resolve the container's id here — at the moment
+	/// <see cref="IBindableModel.Attach"/> runs, the StoreCollection has not yet
+	/// finished registering the host with the projection, so
+	/// <c>store.GetId(container)</c> would throw. Instead we capture only the
+	/// store + collection id and re-resolve the container's id on each
+	/// command emit.
+	/// </summary>
+	public void Attach(IObjectStore store, Guid containerCollectionId)
+	{
+		_store = store ?? throw new ArgumentNullException(nameof(store));
+		_containerCollectionId = containerCollectionId;
+	}
+
+	public int Count => _inner.Count;
+	public bool IsReadOnly => false;
+	public IEnumerator<IComponent> GetEnumerator() => _inner.GetEnumerator();
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	public IComponent? GetUniqueComponent(Type uniqueComponentType) => _inner.GetUniqueComponent(uniqueComponentType);
+	public bool CanAddComponent(Type componentType) => _inner.CanAddComponent(componentType);
+	public bool Contains(IComponent item) => _inner.Contains(item);
+	public void CopyTo(IComponent[] array, int arrayIndex) => _inner.CopyTo(array, arrayIndex);
+	public void Clear() => _inner.Clear();
+
+	// Bypass paths — used by the projection's event-apply visitors.
+	public bool TryAdd(IComponent component) => _inner.TryAdd(component);
+	public bool BypassRemove(IComponent component) => _inner.BypassRemove(component);
+
+	// User paths — go through the command channel when the container is attached.
+	void ICollection<IComponent>.Add(IComponent component)
+	{
+		if (component is null) throw new ArgumentNullException(nameof(component));
+		if (_store is null)
+		{
+			// Pre-attach (e.g. collection initializer in the container ctor body).
+			if (!_inner.TryAdd(component))
+			{
+				throw new InvalidOperationException(
+					$"Component '{component.GetType().Name}' cannot be added: uniqueness or veto check failed.");
+			}
+			return;
+		}
+		EmitAddCommand(component);
+	}
+
+	public bool Remove(IComponent component)
+	{
+		if (component is null) throw new ArgumentNullException(nameof(component));
+		if (_store is null)
+		{
+			return _inner.BypassRemove(component);
+		}
+		return EmitRemoveCommand(component);
+	}
+
+	void EmitAddCommand(IComponent component)
+	{
+		var containerId = _store!.GetId(_container);
+		var containerTypeId = _store.TypeMetadataProvider.GetTypeMetadata(_container.GetType()).TypeId;
+		var componentTypeId = _store.TypeMetadataProvider.GetTypeMetadata(component.GetType()).TypeId;
+		var componentId = component is IIdentifiable<Guid> id ? id.Id : Guid.Empty;
+		var task = _store.SubmitCommandAsync(
+			new AddComponentCommand
+			{
+				CommandId = GuidExtensions.CreateVersion7(),
+				StreamId = SynqraGuids.SynqraRootStreamId,
+				CollectionId = _containerCollectionId,
+				TargetId = containerId,
+				TargetTypeId = containerTypeId,
+				ComponentTypeId = componentTypeId,
+				ComponentId = componentId,
+				Data = component,
+			},
+			new CommandSubmissionOptions { ExpectedLastEventId = _store.GetLastEventId(containerId) });
+		if (!OperatingSystem.IsBrowser())
+		{
+			task.GetAwaiter().GetResult();
+		}
+	}
+
+	bool EmitRemoveCommand(IComponent component)
+	{
+		var containerId = _store!.GetId(_container);
+		var containerTypeId = _store.TypeMetadataProvider.GetTypeMetadata(_container.GetType()).TypeId;
+		var componentTypeId = _store.TypeMetadataProvider.GetTypeMetadata(component.GetType()).TypeId;
+		var componentId = component is IIdentifiable<Guid> id ? id.Id : Guid.Empty;
+		var task = _store.SubmitCommandAsync(
+			new DeleteComponentCommand
+			{
+				CommandId = GuidExtensions.CreateVersion7(),
+				StreamId = SynqraGuids.SynqraRootStreamId,
+				CollectionId = _containerCollectionId,
+				TargetId = containerId,
+				TargetTypeId = containerTypeId,
+				ComponentTypeId = componentTypeId,
+				ComponentId = componentId,
+			},
+			new CommandSubmissionOptions { ExpectedLastEventId = _store.GetLastEventId(containerId) });
+		if (!OperatingSystem.IsBrowser())
+		{
+			task.GetAwaiter().GetResult();
+		}
+		return true;
+	}
+}

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -1007,7 +1007,11 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		var container = ResolveContainer(ev.TargetId);
 		var component = ResolveComponent(container, ev);
 
-		if (!container.Components.Remove(component))
+		// BypassRemove rather than Remove: when the container is wrapped in
+		// StoreBoundComponentsCollection, the ICollection<T>.Remove path emits a
+		// command. The projection is APPLYING an event, so it must skip the command
+		// channel — otherwise it would generate a recursive delete command.
+		if (!container.Components.BypassRemove(component))
 		{
 			throw new InvalidOperationException(
 				$"ComponentDeletedEvent {ev.EventId}: component instance was located but the collection refused to remove it. The event stream is inconsistent.");

--- a/Tests/Synqra.Tests/StateManagementTests.cs
+++ b/Tests/Synqra.Tests/StateManagementTests.cs
@@ -509,6 +509,81 @@ public class InMemoryStateManageementTests : StateManagementTests
 		await Assert.That(afterComponentWrite).IsNotEqualTo(afterUnrelatedWrite);
 	}
 
+	// ---- Phase B-2: generator-emitted Components collection (StoreBoundComponentsCollection) ----
+	//
+	// These exercise the symmetric mirror of Phase B's setter-side generator —
+	// `container.Components.Add(c)` emits AddComponentCommand and
+	// `container.Components.Remove(c)` emits DeleteComponentCommand when the
+	// container is store-attached. The projection's event-apply path goes
+	// through TryAdd / BypassRemove so it never produces a recursive command.
+
+	[Test]
+	public async Task Should_60_Components_Add_emits_AddComponentCommand_when_attached()
+	{
+		var node = new TestGeneratedContainerNode { Name = "g1" };
+		_sut.GetCollection<TestGeneratedContainerNode>().Add(node);
+
+		var commandsBefore = _sut.GetCollection<Command>().OfType<AddComponentCommand>().Count();
+
+		var c = new TestUniqueComponent { Subject = "from generator" };
+		node.Components.Add(c); // generator-emitted path
+
+		var acs = _sut.GetCollection<Command>().OfType<AddComponentCommand>().ToArray();
+		await Assert.That(acs.Length).IsEqualTo(commandsBefore + 1);
+
+		var emitted = acs.Last();
+		await Assert.That(emitted.TargetId).IsEqualTo(_sut.GetId(node));
+		await Assert.That(emitted.ComponentTypeId).IsEqualTo(TypeIdOf<TestUniqueComponent>());
+		await Assert.That(emitted.ComponentId).IsEqualTo(Guid.Empty);
+
+		var attached = node.Components.GetUniqueComponent(typeof(TestUniqueComponent));
+		await Assert.That(attached).IsSameReferenceAs(c);
+	}
+
+	[Test]
+	public async Task Should_61_Components_Remove_emits_DeleteComponentCommand_when_attached()
+	{
+		var node = new TestGeneratedContainerNode { Name = "g2" };
+		_sut.GetCollection<TestGeneratedContainerNode>().Add(node);
+
+		var c = new TestUniqueComponent { Subject = "doomed" };
+		node.Components.Add(c);
+		await Assert.That(node.Components.Count).IsEqualTo(1);
+
+		var commandsBefore = _sut.GetCollection<Command>().OfType<DeleteComponentCommand>().Count();
+		node.Components.Remove(c);
+
+		var dcs = _sut.GetCollection<Command>().OfType<DeleteComponentCommand>().ToArray();
+		await Assert.That(dcs.Length).IsEqualTo(commandsBefore + 1);
+
+		var emitted = dcs.Last();
+		await Assert.That(emitted.TargetId).IsEqualTo(_sut.GetId(node));
+		await Assert.That(emitted.ComponentTypeId).IsEqualTo(TypeIdOf<TestUniqueComponent>());
+
+		await Assert.That(node.Components.Count).IsEqualTo(0);
+	}
+
+	[Test]
+	public async Task Should_62_Components_Add_pre_attach_falls_back_to_direct_mutation()
+	{
+		// Before the node is added to its store-collection, the wrapper has
+		// no store linkage — Add should mutate the inner data directly, just
+		// like the property setter does for early initializer-style code.
+		var node = new TestGeneratedContainerNode { Name = "g3" };
+		var c = new TestUniqueComponent { Subject = "early" };
+		node.Components.Add(c);
+		await Assert.That(node.Components.Count).IsEqualTo(1);
+
+		// No commands should have been issued — there was no store yet.
+		// (We can't observe "no AddComponentCommand related to this node"
+		// because the command collection is global; just verify the node's
+		// state ended up correct.)
+		_sut.GetCollection<TestGeneratedContainerNode>().Add(node);
+		await Assert.That(node.Components.Count).IsEqualTo(1);
+		await Assert.That(node.Components.GetUniqueComponent(typeof(TestUniqueComponent)))
+			.IsSameReferenceAs(c);
+	}
+
 	[Test]
 	public async Task Should_47_Activator_fires_with_IsReplay_false_on_originating_event()
 	{
@@ -676,6 +751,7 @@ public abstract class StateManagementTests : BaseTest<IObjectStore>
 			typeof(ChangeComponentPropertyCommand),
 			typeof(DeleteComponentCommand),
 			typeof(TestComponentNode),
+			typeof(TestGeneratedContainerNode),
 			typeof(TestUniqueComponent),
 			typeof(TestTaggingComponent),
 			typeof(TestActivatableComponent),
@@ -1002,7 +1078,8 @@ public partial class StorableModel
 
 // ---- Component substrate test fixtures (used by InMemoryStateManageementTests) ----
 
-/// <summary>Container exposing a manually-backed components collection (generator integration is Phase B).</summary>
+/// <summary>Container exposing a manually-backed components collection. Kept on the manual path so
+/// Phase A/B tests continue to exercise that code path (user code can still bring its own collection).</summary>
 [SynqraModel]
 [Schema(2026.405, "1 Name string?")]
 public partial class TestComponentNode : IComponentContainer
@@ -1013,6 +1090,15 @@ public partial class TestComponentNode : IComponentContainer
 
 	[JsonIgnore]
 	public IComponentsCollection Components => _components;
+}
+
+/// <summary>Container that does NOT declare Components — generator emits the wrapper.
+/// Exercises Phase B-2 (StoreBoundComponentsCollection routing).</summary>
+[SynqraModel]
+[Schema(2026.405, "1 Name string?")]
+public partial class TestGeneratedContainerNode : IComponentContainer
+{
+	public partial string? Name { get; set; }
 }
 
 /// <summary>Unique-by-class component: at most one instance per container.</summary>


### PR DESCRIPTION
Closes the symmetric mirror of Phase B's setter side: a `[SynqraModel]` class implementing `IComponentContainer` now gets a generator-emitted `Components` property backed by `StoreBoundComponentsCollection`. Users write `node.Components.Add(c)` / `node.Components.Remove(c)` and the wrapper emits `AddComponentCommand` / `DeleteComponentCommand` at the right times.

## New surface in Synqra.Model

- `StoreBoundComponentsCollection` — wraps an inner `ComponentsCollection`. `ICollection<IComponent>.Add`/`Remove` route through the command channel when the host container is store-attached; pre-attach calls fall back to direct mutation (so collection-initializer-style code works in ctors). Container id / type id are resolved **lazily at command-emit time** — at `IBindableModel.Attach()` the `StoreCollection` has not yet finished registering the host, so eager lookup throws.
- `IComponentsCollection.BypassRemove` — new interface member; symmetric counterpart to `TryAdd`. The projection's event-apply path uses it on `ComponentDeletedEvent` to avoid producing a recursive delete command.
- `ComponentsCollection.Remove` now delegates to `BypassRemove` (both are direct on the base type — the routing distinction only matters for the wrapper).

## InMemoryProjection

- `VisitAsync(ComponentDeletedEvent)` switched to `BypassRemove` so the wrapper's `Remove` can safely emit commands without recursing through event-apply.

## Generator (ModelBindingGenerator)

- Detects `IComponentContainer` by FQN.
- Suppresses emission when the class already declares a `Components` member (manual-collection consumers like the existing test `TestComponentNode` continue to work unchanged).
- When emitted:
  - `private StoreBoundComponentsCollection? __components;`
  - `public IComponentsCollection Components => EnsureComponentsWrapper();`
  - Thread-safe lazy init via `Interlocked.CompareExchange` (field init can't use `this`, so we lazy-allocate on first read).
  - `IBindableModel.Attach` now calls `EnsureComponentsWrapper().Attach(store, collectionId)`.

## Tests

- New `TestGeneratedContainerNode` that implements `IComponentContainer` but does NOT declare `Components` — exercises the generated path.
- `Should_60_Components_Add_emits_AddComponentCommand_when_attached`
- `Should_61_Components_Remove_emits_DeleteComponentCommand_when_attached`
- `Should_62_Components_Add_pre_attach_falls_back_to_direct_mutation`

**196/196 tests pass on net8.0, net9.0, net10.0. Quotaly.Web builds clean.**