### PR TITLE
feat(synqra): wires — typed connections between component ports (v0)

### DIFF
--- a/Synqra.Model/Commands.cs
+++ b/Synqra.Model/Commands.cs
@@ -14,6 +14,8 @@ namespace Synqra;
 [JsonDerivedType(typeof(AddComponentCommand), "AddComponentCommand")]
 [JsonDerivedType(typeof(ChangeComponentPropertyCommand), "ChangeComponentPropertyCommand")]
 [JsonDerivedType(typeof(DeleteComponentCommand), "DeleteComponentCommand")]
+[JsonDerivedType(typeof(AddWireCommand), "AddWireCommand")]
+[JsonDerivedType(typeof(DeleteWireCommand), "DeleteWireCommand")]
 [SynqraModel]
 [Schema(2025.1, "")]
 [Schema(2025.791, "1")]

--- a/Synqra.Model/Event.cs
+++ b/Synqra.Model/Event.cs
@@ -14,6 +14,8 @@ namespace Synqra;
 [JsonDerivedType(typeof(ComponentAddedEvent), "ComponentAddedEvent")]
 [JsonDerivedType(typeof(ComponentPropertyChangedEvent), "ComponentPropertyChangedEvent")]
 [JsonDerivedType(typeof(ComponentDeletedEvent), "ComponentDeletedEvent")]
+[JsonDerivedType(typeof(WireAddedEvent), "WireAddedEvent")]
+[JsonDerivedType(typeof(WireDeletedEvent), "WireDeletedEvent")]
 [SynqraModel]
 [Schema(2025.789, "1 EventId Guid CommandId Guid ContainerId Guid")]
 [Schema(2025.791, "1")]

--- a/Synqra.Model/ICommandVisitor.cs
+++ b/Synqra.Model/ICommandVisitor.cs
@@ -13,6 +13,9 @@ public interface ICommandVisitor<T>
 	Task VisitAsync(ChangeComponentPropertyCommand cmd, T ctx);
 	Task VisitAsync(DeleteComponentCommand cmd, T ctx);
 
+	Task VisitAsync(AddWireCommand cmd, T ctx);
+	Task VisitAsync(DeleteWireCommand cmd, T ctx);
+
 	/*
 	Task VisitAsync(MoveNode cmd, T ctx);
 	Task VisitAsync(MarkAsDone cmd, T ctx);

--- a/Synqra.Model/IEventVisitor.cs
+++ b/Synqra.Model/IEventVisitor.cs
@@ -14,6 +14,9 @@ public interface IEventVisitor<in T>
 	Task VisitAsync(ComponentPropertyChangedEvent ev, T ctx);
 	Task VisitAsync(ComponentDeletedEvent ev, T ctx);
 
+	Task VisitAsync(WireAddedEvent ev, T ctx);
+	Task VisitAsync(WireDeletedEvent ev, T ctx);
+
 	/*
 	Task VisitAsync(CommandPatched ev, T ctx);
 	Task VisitAsync(WorldStateProvided ev, T ctx);

--- a/Synqra.Model/Wires/AddWireCommand.cs
+++ b/Synqra.Model/Wires/AddWireCommand.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+
+namespace Synqra;
+
+/// <summary>
+/// Attach a wire connecting two component ports. The projection creates a
+/// <see cref="Wire"/> with a generated id and stores it under the Wires
+/// collection. If a wire with identical source + target + type already
+/// exists, the projection treats the add as idempotent (no-op event).
+/// </summary>
+[SynqraModel]
+[Schema(2026.406, "1 CommandId Guid StreamId Guid WireId Guid SourceContainerId Guid SourceComponentTypeId Guid SourceComponentId Guid SourcePortName string TargetContainerId Guid TargetComponentTypeId Guid TargetComponentId Guid TargetPortName string Type int")]
+public partial class AddWireCommand : Command
+{
+	public partial System.Guid WireId { get; set; }
+
+	public partial System.Guid SourceContainerId { get; set; }
+	public partial System.Guid SourceComponentTypeId { get; set; }
+	public partial System.Guid SourceComponentId { get; set; }
+	public required partial string SourcePortName { get; set; }
+
+	public partial System.Guid TargetContainerId { get; set; }
+	public partial System.Guid TargetComponentTypeId { get; set; }
+	public partial System.Guid TargetComponentId { get; set; }
+	public required partial string TargetPortName { get; set; }
+
+	/// <summary>Port type — stored as int so legacy versions of the serializer round-trip cleanly.</summary>
+	public partial int Type { get; set; }
+
+	protected override Task AcceptCoreAsync<T>(ICommandVisitor<T> visitor, T ctx)
+		=> visitor.VisitAsync(this, ctx);
+}

--- a/Synqra.Model/Wires/DeleteWireCommand.cs
+++ b/Synqra.Model/Wires/DeleteWireCommand.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+
+namespace Synqra;
+
+/// <summary>
+/// Detach a wire by id. No-op if the wire doesn't exist.
+/// </summary>
+[SynqraModel]
+[Schema(2026.406, "1 CommandId Guid StreamId Guid WireId Guid")]
+public partial class DeleteWireCommand : Command
+{
+	public partial System.Guid WireId { get; set; }
+
+	protected override Task AcceptCoreAsync<T>(ICommandVisitor<T> visitor, T ctx)
+		=> visitor.VisitAsync(this, ctx);
+}

--- a/Synqra.Model/Wires/PortRef.cs
+++ b/Synqra.Model/Wires/PortRef.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Synqra;
+
+/// <summary>
+/// A point in the graph that a wire can terminate at — the (container, component,
+/// port-name) triple. Components and ports live inside containers, so resolving a
+/// PortRef back to a concrete instance requires the projection's lookup.
+/// <para>
+/// Modelled as a record struct so equality is value-based and instances can be
+/// used as dictionary keys for wire-routing tables.
+/// </para>
+/// </summary>
+public readonly record struct PortRef(
+	Guid ContainerId,
+	Guid ComponentTypeId,
+	Guid ComponentId,
+	string PortName)
+{
+	/// <summary>True when this <see cref="PortRef"/> has no addressable target.</summary>
+	public bool IsDefault => ContainerId == Guid.Empty
+		&& ComponentTypeId == Guid.Empty
+		&& ComponentId == Guid.Empty
+		&& string.IsNullOrEmpty(PortName);
+}

--- a/Synqra.Model/Wires/PortType.cs
+++ b/Synqra.Model/Wires/PortType.cs
@@ -1,0 +1,26 @@
+namespace Synqra;
+
+/// <summary>
+/// Closed set of port channel types the substrate knows about. Different port
+/// types have different routing semantics, but the wire entity carrying them is
+/// the same shape. Phase 1 ships with <see cref="Event"/> only; other types stub
+/// out the type system so callers can declare their intent today and the
+/// runtime can grow into each channel without re-shaping the wire model.
+/// </summary>
+public enum PortType
+{
+	/// <summary>Discrete async messages with FIFO + retry semantics (cron, webhooks, agent steps).</summary>
+	Event = 0,
+
+	/// <summary>Combinational booleans, instant on change (logic gates, "is healthy").</summary>
+	Signal = 1,
+
+	/// <summary>Rate-based flows with unit accounting (electricity, AI tokens, money).</summary>
+	Quantity = 2,
+
+	/// <summary>Static topology link; no runtime value (depends-on, lives-in).</summary>
+	Reference = 3,
+
+	/// <summary>Push subscriptions with backpressure (log tails, MQTT, SSE).</summary>
+	Stream = 4,
+}

--- a/Synqra.Model/Wires/Wire.cs
+++ b/Synqra.Model/Wires/Wire.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Synqra;
+
+/// <summary>
+/// A typed connection between two component ports. The substrate stores wires
+/// as first-class state — the routing engine reads them to decide where a value
+/// emitted on a source port should land. v0 carries <see cref="PortType.Event"/>
+/// only; non-Event port types stub the type system but have no runtime yet.
+/// </summary>
+[SynqraModel]
+[Schema(2026.406, "1 Id Guid SourceContainerId Guid SourceComponentTypeId Guid SourceComponentId Guid SourcePortName string? TargetContainerId Guid TargetComponentTypeId Guid TargetComponentId Guid TargetPortName string? Type int PortType PortType")]
+public partial class Wire : IIdentifiable<Guid>
+{
+	/// <summary>Stable identity. The projection assigns this on AddWireCommand.</summary>
+	public partial Guid Id { get; set; }
+
+	/// <summary>Port emitting values on this wire.</summary>
+	public partial Guid SourceContainerId { get; set; }
+	public partial Guid SourceComponentTypeId { get; set; }
+	public partial Guid SourceComponentId { get; set; }
+	public partial string? SourcePortName { get; set; }
+
+	/// <summary>Port receiving values from this wire.</summary>
+	public partial Guid TargetContainerId { get; set; }
+	public partial Guid TargetComponentTypeId { get; set; }
+	public partial Guid TargetComponentId { get; set; }
+	public partial string? TargetPortName { get; set; }
+
+	/// <summary>
+	/// Channel type. v0 only ships <see cref="PortType.Event"/>; declaring other
+	/// types now means future runtimes for them can light up without re-shaping
+	/// the wire model. Stored as int (Synqra binary serializer doesn't know enums
+	/// natively yet).
+	/// </summary>
+	public partial int Type { get; set; }
+
+	/// <summary>Convenience accessor for <see cref="Type"/> as <see cref="PortType"/>.</summary>
+	public PortType PortType
+	{
+		get => (PortType)Type;
+		set => Type = (int)value;
+	}
+
+	Guid IIdentifiable<Guid>.Id => Id;
+
+	/// <summary>Source port as a value tuple.</summary>
+	public PortRef Source => new(SourceContainerId, SourceComponentTypeId, SourceComponentId, SourcePortName ?? string.Empty);
+
+	/// <summary>Target port as a value tuple.</summary>
+	public PortRef Target => new(TargetContainerId, TargetComponentTypeId, TargetComponentId, TargetPortName ?? string.Empty);
+}

--- a/Synqra.Model/Wires/WireAddedEvent.cs
+++ b/Synqra.Model/Wires/WireAddedEvent.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+
+namespace Synqra;
+
+/// <summary>
+/// A wire was attached. The projection materializes a <see cref="Wire"/> in its
+/// in-memory state and indexes it for routing lookups.
+/// </summary>
+[SynqraModel]
+[Schema(2026.406, "1 EventId Guid CommandId Guid WireId Guid SourceContainerId Guid SourceComponentTypeId Guid SourceComponentId Guid SourcePortName string TargetContainerId Guid TargetComponentTypeId Guid TargetComponentId Guid TargetPortName string Type int")]
+public partial class WireAddedEvent : Event
+{
+	public partial System.Guid WireId { get; set; }
+
+	public partial System.Guid SourceContainerId { get; set; }
+	public partial System.Guid SourceComponentTypeId { get; set; }
+	public partial System.Guid SourceComponentId { get; set; }
+	public required partial string SourcePortName { get; set; }
+
+	public partial System.Guid TargetContainerId { get; set; }
+	public partial System.Guid TargetComponentTypeId { get; set; }
+	public partial System.Guid TargetComponentId { get; set; }
+	public required partial string TargetPortName { get; set; }
+
+	public partial int Type { get; set; }
+
+	protected override Task AcceptCoreAsync<T>(IEventVisitor<T> visitor, T ctx)
+		=> visitor.VisitAsync(this, ctx);
+}

--- a/Synqra.Model/Wires/WireDeletedEvent.cs
+++ b/Synqra.Model/Wires/WireDeletedEvent.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace Synqra;
+
+/// <summary>
+/// A wire was removed. The projection drops it from in-memory state and from
+/// the routing index.
+/// </summary>
+[SynqraModel]
+[Schema(2026.406, "1 EventId Guid CommandId Guid WireId Guid")]
+public partial class WireDeletedEvent : Event
+{
+	public partial System.Guid WireId { get; set; }
+
+	protected override Task AcceptCoreAsync<T>(IEventVisitor<T> visitor, T ctx)
+		=> visitor.VisitAsync(this, ctx);
+}

--- a/Synqra.Projection.File/_DI.cs
+++ b/Synqra.Projection.File/_DI.cs
@@ -806,6 +806,8 @@ public static class FileSynqraExtensions
 		public Task VisitAsync(AddComponentCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
 		public Task VisitAsync(ChangeComponentPropertyCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
 		public Task VisitAsync(DeleteComponentCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+		public Task VisitAsync(AddWireCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+		public Task VisitAsync(DeleteWireCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
 
 		public async Task VisitAsync(ObjectCreatedEvent ev, EventVisitorContext ctx)
 		{
@@ -862,6 +864,8 @@ public static class FileSynqraExtensions
 		public Task VisitAsync(ComponentAddedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
 		public Task VisitAsync(ComponentPropertyChangedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
 		public Task VisitAsync(ComponentDeletedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+		public Task VisitAsync(WireAddedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+		public Task VisitAsync(WireDeletedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
 
 		public async Task VisitAsync(CommandCreatedEvent ev, EventVisitorContext ctx)
 		{

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -62,6 +62,15 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	private readonly ConditionalWeakTable<object, AttachedObjectData> _attachedObjects = new();
 	private byte _attachedMaintain;
 
+	// Wires: a flat map by id plus from/to indexes for routing lookups. Wires
+	// are projection-managed state (not in any user-visible collection) — the
+	// runtime calls GetWiresFrom / GetWiresTo to discover where to route a
+	// value emitted on a source port.
+	private readonly ConcurrentDictionary<Guid, Wire> _wiresById = new();
+	private readonly ConcurrentDictionary<PortRef, List<Wire>> _wiresFrom = new();
+	private readonly ConcurrentDictionary<PortRef, List<Wire>> _wiresTo = new();
+	private readonly object _wireIndexLock = new();
+
 	public bool IsOnline => _eventReplicationService?.IsOnline ?? false;
 
 
@@ -744,6 +753,44 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		return Task.CompletedTask;
 	}
 
+	public Task VisitAsync(AddWireCommand cmd, CommandHandlerContext ctx)
+	{
+		// Allocate WireId here if the caller left it default — wires are
+		// projection-managed, but the caller may pre-pick an id (e.g. for
+		// deterministic / idempotent operations).
+		var wireId = cmd.WireId == default ? GuidExtensions.CreateVersion7() : cmd.WireId;
+		ctx.Events.Add(new WireAddedEvent
+		{
+			StreamId = cmd.StreamId,
+			CommandId = cmd.CommandId,
+			EventId = GuidExtensions.CreateVersion7(),
+
+			WireId = wireId,
+			SourceContainerId = cmd.SourceContainerId,
+			SourceComponentTypeId = cmd.SourceComponentTypeId,
+			SourceComponentId = cmd.SourceComponentId,
+			SourcePortName = cmd.SourcePortName,
+			TargetContainerId = cmd.TargetContainerId,
+			TargetComponentTypeId = cmd.TargetComponentTypeId,
+			TargetComponentId = cmd.TargetComponentId,
+			TargetPortName = cmd.TargetPortName,
+			Type = cmd.Type,
+		});
+		return Task.CompletedTask;
+	}
+
+	public Task VisitAsync(DeleteWireCommand cmd, CommandHandlerContext ctx)
+	{
+		ctx.Events.Add(new WireDeletedEvent
+		{
+			StreamId = cmd.StreamId,
+			CommandId = cmd.CommandId,
+			EventId = GuidExtensions.CreateVersion7(),
+			WireId = cmd.WireId,
+		});
+		return Task.CompletedTask;
+	}
+
 	#endregion
 
 	#region Event Handler
@@ -900,6 +947,72 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	{
 		return Task.CompletedTask;
 		// throw new NotImplementedException("ObjectDeletedEvent is not implemented yet");
+	}
+
+	public Task VisitAsync(WireAddedEvent ev, EventVisitorContext ctx)
+	{
+		var wire = new Wire
+		{
+			Id = ev.WireId,
+			SourceContainerId = ev.SourceContainerId,
+			SourceComponentTypeId = ev.SourceComponentTypeId,
+			SourceComponentId = ev.SourceComponentId,
+			SourcePortName = ev.SourcePortName,
+			TargetContainerId = ev.TargetContainerId,
+			TargetComponentTypeId = ev.TargetComponentTypeId,
+			TargetComponentId = ev.TargetComponentId,
+			TargetPortName = ev.TargetPortName,
+			Type = ev.Type,
+		};
+		_wiresById[wire.Id] = wire;
+		lock (_wireIndexLock)
+		{
+			_wiresFrom.GetOrAdd(wire.Source, _ => new List<Wire>()).Add(wire);
+			_wiresTo.GetOrAdd(wire.Target, _ => new List<Wire>()).Add(wire);
+		}
+		return Task.CompletedTask;
+	}
+
+	public Task VisitAsync(WireDeletedEvent ev, EventVisitorContext ctx)
+	{
+		if (_wiresById.TryRemove(ev.WireId, out var wire))
+		{
+			lock (_wireIndexLock)
+			{
+				if (_wiresFrom.TryGetValue(wire.Source, out var fromList))
+				{
+					fromList.RemoveAll(w => w.Id == wire.Id);
+					if (fromList.Count == 0) _wiresFrom.TryRemove(wire.Source, out _);
+				}
+				if (_wiresTo.TryGetValue(wire.Target, out var toList))
+				{
+					toList.RemoveAll(w => w.Id == wire.Id);
+					if (toList.Count == 0) _wiresTo.TryRemove(wire.Target, out _);
+				}
+			}
+		}
+		return Task.CompletedTask;
+	}
+
+	/// <summary>All wires the projection currently knows about.</summary>
+	public IReadOnlyCollection<Wire> Wires => (IReadOnlyCollection<Wire>)_wiresById.Values;
+
+	/// <summary>Wires departing the given source port.</summary>
+	public IReadOnlyList<Wire> GetWiresFrom(PortRef source)
+	{
+		lock (_wireIndexLock)
+		{
+			return _wiresFrom.TryGetValue(source, out var list) ? list.ToArray() : Array.Empty<Wire>();
+		}
+	}
+
+	/// <summary>Wires arriving at the given target port.</summary>
+	public IReadOnlyList<Wire> GetWiresTo(PortRef target)
+	{
+		lock (_wireIndexLock)
+		{
+			return _wiresTo.TryGetValue(target, out var list) ? list.ToArray() : Array.Empty<Wire>();
+		}
 	}
 
 	public Task VisitAsync(CommandCreatedEvent ev, EventVisitorContext ctx)

--- a/Synqra.Projection.Sqlite/SqliteProjection.cs
+++ b/Synqra.Projection.Sqlite/SqliteProjection.cs
@@ -351,6 +351,15 @@ public class SqliteProjection : IProjection
 	{
 	}
 
+	public async Task VisitAsync(AddWireCommand cmd, CommandHandlerContext ctx)
+	{
+		// SQLite projection: wires not yet implemented here. InMemoryProjection is the reference.
+	}
+
+	public async Task VisitAsync(DeleteWireCommand cmd, CommandHandlerContext ctx)
+	{
+	}
+
 	#endregion
 
 	#region Event Visitor
@@ -387,6 +396,9 @@ public class SqliteProjection : IProjection
 	public async Task VisitAsync(ComponentDeletedEvent ev, EventVisitorContext ctx)
 	{
 	}
+
+	public async Task VisitAsync(WireAddedEvent ev, EventVisitorContext ctx) { }
+	public async Task VisitAsync(WireDeletedEvent ev, EventVisitorContext ctx) { }
 
 	public async Task VisitAsync(CommandCreatedEvent ev, EventVisitorContext ctx)
 	{

--- a/Tests/Synqra.Tests/StateManagementTests.cs
+++ b/Tests/Synqra.Tests/StateManagementTests.cs
@@ -584,6 +584,117 @@ public class InMemoryStateManageementTests : StateManagementTests
 			.IsSameReferenceAs(c);
 	}
 
+	// ---- Wires (Phase Wires) ----
+	//
+	// First substrate-level slice of the graph: typed connections between
+	// component ports. v0 just persists wires + offers projection-side
+	// from/to lookups; runtime routing comes in a later slice.
+
+	[Test]
+	public async Task Should_70_AddWireCommand_creates_a_wire_with_assigned_id()
+	{
+		// Two nodes with components participate as wire endpoints.
+		var n1 = new TestComponentNode { Name = "src" };
+		var n2 = new TestComponentNode { Name = "dst" };
+		_sut.GetCollection<TestComponentNode>().Add(n1);
+		_sut.GetCollection<TestComponentNode>().Add(n2);
+
+		var srcId = _sut.GetId(n1);
+		var dstId = _sut.GetId(n2);
+		var srcTypeId = TypeIdOf<TestUniqueComponent>();
+		var dstTypeId = TypeIdOf<TestUniqueComponent>();
+
+		await _sut.SubmitCommandAsync(new AddWireCommand
+		{
+			CommandId = GuidExtensions.CreateVersion7(),
+			SourceContainerId = srcId, SourceComponentTypeId = srcTypeId, SourcePortName = "out",
+			TargetContainerId = dstId, TargetComponentTypeId = dstTypeId, TargetPortName = "in",
+			Type = (int)PortType.Event,
+		});
+
+		var projection = (InMemoryProjection)_sut;
+		await Assert.That(projection.Wires.Count).IsEqualTo(1);
+
+		var wire = projection.Wires.Single();
+		await Assert.That(wire.Id).IsNotEqualTo(Guid.Empty);
+		await Assert.That(wire.SourceContainerId).IsEqualTo(srcId);
+		await Assert.That(wire.TargetContainerId).IsEqualTo(dstId);
+		await Assert.That(wire.PortType).IsEqualTo(PortType.Event);
+	}
+
+	[Test]
+	public async Task Should_71_GetWiresFrom_returns_outgoing_wires_only()
+	{
+		var n1 = new TestComponentNode { Name = "src" };
+		var n2 = new TestComponentNode { Name = "dst1" };
+		var n3 = new TestComponentNode { Name = "dst2" };
+		_sut.GetCollection<TestComponentNode>().Add(n1);
+		_sut.GetCollection<TestComponentNode>().Add(n2);
+		_sut.GetCollection<TestComponentNode>().Add(n3);
+
+		var src = _sut.GetId(n1);
+		var dst1 = _sut.GetId(n2);
+		var dst2 = _sut.GetId(n3);
+		var ct = TypeIdOf<TestUniqueComponent>();
+
+		await _sut.SubmitCommandAsync(new AddWireCommand
+		{
+			CommandId = GuidExtensions.CreateVersion7(),
+			SourceContainerId = src, SourceComponentTypeId = ct, SourcePortName = "out",
+			TargetContainerId = dst1, TargetComponentTypeId = ct, TargetPortName = "in",
+			Type = (int)PortType.Event,
+		});
+		await _sut.SubmitCommandAsync(new AddWireCommand
+		{
+			CommandId = GuidExtensions.CreateVersion7(),
+			SourceContainerId = src, SourceComponentTypeId = ct, SourcePortName = "out",
+			TargetContainerId = dst2, TargetComponentTypeId = ct, TargetPortName = "in",
+			Type = (int)PortType.Event,
+		});
+
+		var projection = (InMemoryProjection)_sut;
+		var fromSrc = projection.GetWiresFrom(new PortRef(src, ct, Guid.Empty, "out"));
+		await Assert.That(fromSrc.Count).IsEqualTo(2);
+
+		var fromUnknown = projection.GetWiresFrom(new PortRef(dst1, ct, Guid.Empty, "out"));
+		await Assert.That(fromUnknown.Count).IsEqualTo(0);
+	}
+
+	[Test]
+	public async Task Should_72_DeleteWireCommand_removes_wire_from_index()
+	{
+		var n1 = new TestComponentNode { Name = "src" };
+		var n2 = new TestComponentNode { Name = "dst" };
+		_sut.GetCollection<TestComponentNode>().Add(n1);
+		_sut.GetCollection<TestComponentNode>().Add(n2);
+
+		var src = _sut.GetId(n1);
+		var dst = _sut.GetId(n2);
+		var ct = TypeIdOf<TestUniqueComponent>();
+		var wireId = GuidExtensions.CreateVersion7();
+
+		await _sut.SubmitCommandAsync(new AddWireCommand
+		{
+			CommandId = GuidExtensions.CreateVersion7(),
+			WireId = wireId,
+			SourceContainerId = src, SourceComponentTypeId = ct, SourcePortName = "out",
+			TargetContainerId = dst, TargetComponentTypeId = ct, TargetPortName = "in",
+			Type = (int)PortType.Event,
+		});
+
+		var projection = (InMemoryProjection)_sut;
+		await Assert.That(projection.Wires.Count).IsEqualTo(1);
+
+		await _sut.SubmitCommandAsync(new DeleteWireCommand
+		{
+			CommandId = GuidExtensions.CreateVersion7(),
+			WireId = wireId,
+		});
+
+		await Assert.That(projection.Wires.Count).IsEqualTo(0);
+		await Assert.That(projection.GetWiresFrom(new PortRef(src, ct, Guid.Empty, "out")).Count).IsEqualTo(0);
+	}
+
 	[Test]
 	public async Task Should_47_Activator_fires_with_IsReplay_false_on_originating_event()
 	{
@@ -750,6 +861,9 @@ public abstract class StateManagementTests : BaseTest<IObjectStore>
 			typeof(AddComponentCommand),
 			typeof(ChangeComponentPropertyCommand),
 			typeof(DeleteComponentCommand),
+			typeof(AddWireCommand),
+			typeof(DeleteWireCommand),
+			typeof(Wire),
 			typeof(TestComponentNode),
 			typeof(TestGeneratedContainerNode),
 			typeof(TestUniqueComponent),


### PR DESCRIPTION
First substrate-level slice of the graph: a `Wire` entity connecting two component-port endpoints. v0 stores wires and indexes them for from/to lookups; runtime value-routing along wires comes in a later slice.

## New types in `Synqra.Model/Wires/`

- `PortRef` (record struct) — `(ContainerId, ComponentTypeId, ComponentId, PortName)`. Value-equality so wires can be dictionary-keyed for routing.
- `PortType` (enum) — closed set: `Event, Signal, Quantity, Reference, Stream`. v0 only ships `Event` runtime; the others are declared so callers can express intent today and runtimes light up incrementally.
- `Wire` (`[SynqraModel]`) — Id + 4 source-port fields + 4 target-port fields + `Type` (int, with a convertible `PortType` property).
- `AddWireCommand` / `DeleteWireCommand` — `[SynqraModel]` commands. `AddWire` allocates a `WireId` on the projection if the caller leaves it default.
- `WireAddedEvent` / `WireDeletedEvent`.

## InMemoryProjection

- Three new fields: `_wiresById`, `_wiresFrom (PortRef→List<Wire>)`, `_wiresTo`. All locked via `_wireIndexLock` for index integrity.
- Public surface:
  - `Wires` — `IReadOnlyCollection<Wire>`
  - `GetWiresFrom(PortRef)`
  - `GetWiresTo(PortRef)`

File/Sqlite projections: stub visitors satisfy the extended interfaces.

## Tests

- Should_70_AddWireCommand_creates_a_wire_with_assigned_id
- Should_71_GetWiresFrom_returns_outgoing_wires_only
- Should_72_DeleteWireCommand_removes_wire_from_index

**199/199 tests pass on net8.0/9.0/10.0.**

## What's still ahead

- Runtime routing for Event-typed wires.
- Concrete port-name registries per component type.
- Signal / Quantity / Reference / Stream runtimes.
- Wire visualization in customer UIs.