### PR TITLE
fix(synqra): make Wire.PortType read-only so generator skips it

### DIFF
--- a/Synqra.Model/Wires/Wire.cs
+++ b/Synqra.Model/Wires/Wire.cs
@@ -9,7 +9,7 @@ namespace Synqra;
 /// only; non-Event port types stub the type system but have no runtime yet.
 /// </summary>
 [SynqraModel]
-[Schema(2026.406, "1 Id Guid SourceContainerId Guid SourceComponentTypeId Guid SourceComponentId Guid SourcePortName string? TargetContainerId Guid TargetComponentTypeId Guid TargetComponentId Guid TargetPortName string? Type int PortType PortType")]
+[Schema(2026.406, "1 Id Guid SourceContainerId Guid SourceComponentTypeId Guid SourceComponentId Guid SourcePortName string? TargetContainerId Guid TargetComponentTypeId Guid TargetComponentId Guid TargetPortName string? Type int")]
 public partial class Wire : IIdentifiable<Guid>
 {
 	/// <summary>Stable identity. The projection assigns this on AddWireCommand.</summary>
@@ -35,12 +35,8 @@ public partial class Wire : IIdentifiable<Guid>
 	/// </summary>
 	public partial int Type { get; set; }
 
-	/// <summary>Convenience accessor for <see cref="Type"/> as <see cref="PortType"/>.</summary>
-	public PortType PortType
-	{
-		get => (PortType)Type;
-		set => Type = (int)value;
-	}
+	/// <summary>Convenience accessor for <see cref="Type"/> as <see cref="PortType"/>. Read-only; set <see cref="Type"/> directly.</summary>
+	public PortType PortType => (PortType)Type;
 
 	Guid IIdentifiable<Guid>.Id => Id;
 


### PR DESCRIPTION
Follow-up to #72.

CI (build #12208) failed because the generator emitted serialization referencing `_portType`, which does not exist. Root cause: `PortType PortType { get; set; }` is non-partial, so there is no backing field, yet the model-binding generator treats any public `{ get; set; }` property as a stored field.

Fix: drop the setter so the convenience accessor is read-only (mirrors `Source`/`Target`). Callers set `Type = (int)portType` directly. The `[Schema]` token `PortType PortType` is also removed; the generator is the authority and will not re-stamp it now that the property no longer looks stored.

Tests: 199/199 still green on net8/9/10.