### PR TITLE
Add regression test for safe float formatting/parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,39 @@ Core abstractions you will see repeatedly:
 - `Contoso`
   Example/demo app spanning model, projection, web host, WASM, and Playwright.
 
+## Git Worktree Setup Gotcha (submodule + linked worktrees)
+
+**Do not start an agent session rooted at this repo (`external/Synqra`) with a "create worktree"
+option enabled.** Synqra is a git submodule of Quotaly, and its main checkout is an *absorbed*
+gitdir (`external/Synqra/.git` is a file, not a directory). Absorbed submodule gitdirs rely on an
+explicit `core.worktree` setting to know where their one true working tree lives. When a worktree
+is created directly against this submodule's gitdir (`Quotaly/.git/modules/external/Synqra/...`)
+instead of against the Quotaly superproject, the linked worktree inherits that `core.worktree`
+setting and resolves it relative to its own (deeper) `$GIT_DIR` — landing one directory short, at
+the bare `.git/modules/...` path instead of the real worktree directory. The working directory then
+appears to contain nothing but `.git`/`.claude`, and `git status` lists git-internal plumbing files
+(`objects/`, `refs/`, `hooks/`, etc.) as "untracked" — even though the index and HEAD are correct and
+no data was lost.
+
+**If you are an agent and detect you are operating in a linked worktree rooted at this submodule**
+(working directory matches `external/Synqra/.claude/worktrees/<name>` or similar, i.e. the session
+was *not* rooted at the Quotaly superproject) — **stop and tell the user**, rather than silently
+working around it. Worktrees created against the superproject (`Quotaly` itself) do not hit this
+bug, because git computes a fresh, correct `core.worktree` per superproject-worktree instead of
+inheriting a shared one. Ask the user to recreate the session rooted at the Quotaly superproject
+with the worktree option there instead.
+
+If you must continue in a broken submodule-rooted worktree anyway (e.g. user asks you to proceed),
+the one-time per-worktree fix is:
+
+```
+git config --worktree core.worktree "<absolute-path-to-this-worktree>"
+git checkout -- .
+```
+
+This only touches this worktree's `config.worktree` (requires `extensions.worktreeConfig = true`,
+already set) — it does not affect the main checkout or other worktrees.
+
 ## Toolchain And Build
 
 - SDK is pinned by `global.json` to `.NET SDK 10.0.100`.

--- a/Synqra.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/Synqra.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -194,6 +194,24 @@ public partial class SampleComponent : IComponent
 		Assert.That(result.Errors, Is.Empty, string.Join(Environment.NewLine, result.Errors));
 	}
 
+	[Test]
+	public void Should_compare_floats_safely()
+	{
+		for (int i = 0; i < 1000; i++)
+		{
+			float f1 = float.Round(9999.0f + (i / 1000.0f), 3);
+			string s1 = f1.ToString("0000.000");
+
+			string s2 = $"9999.{i:000}";
+			var f2 = float.Parse(s2);
+
+			Console.WriteLine($"{s1} ({f1}) == {s2} ({f2})");
+
+			Assert.That(s1, Is.EqualTo(s2));
+			Assert.That(f1, Is.EqualTo(f2));
+		}
+	}
+
 	private static (string[] GeneratedSources, Diagnostic[] Errors) RunGenerator(string source)
 	{
 		var generator = new ModelBindingGenerator();


### PR DESCRIPTION
## Summary
- Adds `Should_compare_floats_safely` near the schema-generator tests, asserting `float.Round(...).ToString("0000.000")` round-trips exactly through `float.Parse` for 1000 values in the 9999.000-9999.999 range.
- Documents a submodule-worktree `core.worktree` gotcha in AGENTS.md (agents creating a session rooted directly at this submodule, instead of the Quotaly superproject, could hit a misresolved worktree).

## Test plan
- [x] `dotnet test Synqra.SourceGenerator.Tests` passes locally including the new test