### PR TITLE
fix(tests): prevent BasicModelSyncronizationTests from running in parallel

### DIFF
--- a/Tests/Synqra.Tests/Syncronization/BasicModelSyncronizationTests.cs
+++ b/Tests/Synqra.Tests/Syncronization/BasicModelSyncronizationTests.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 
 namespace Synqra.Tests.Syncronization;
 
+[NotInParallel]
 internal class BasicModelSyncronizationTests : BaseTest
 {
 	SynqraTestNode _nodeMaster;


### PR DESCRIPTION
## Summary
- `BasicModelSyncronizationTests` spins up three real `SynqraTestNode` hosts with sockets and background replication workers, but was missing `[NotInParallel]` - unlike sibling host/socket-spinning test classes, and contrary to the convention documented in `AGENTS.md` ("use `[NotInParallel]` when a test spins servers, sockets, or shared background workers").
- Without it, running this class alongside other tests under CPU-constrained conditions (matching CI) reliably reproduces a property revert: e.g. `Should_15_have_node_with_model` observes a stale `"Task 1"` value instead of the latest update.
- Note: the port-allocation race in `SynqraTestNode` was already fixed separately (binding to `127.0.0.1:0` and reading back the OS-assigned port via `Started`/`Port`) - that fix landed in `e7699f3` and is unrelated to this flake.

## Test plan
- [x] Reproduced the flake locally via `DOTNET_PROCESSOR_COUNT=2` to simulate a constrained CI runner (failed within the first repro batch pre-fix).
- [x] After adding `[NotInParallel]`, ran 25/25 clean repeated runs under the same constrained-CPU conditions.
- [x] Ran the full local test suite under constrained CPU: 111/111 passing.

Generated with Claude Code