### PR TITLE
Fix race condition in SynqraJsonTypeInfoResolver discriminator registration

### DIFF
--- a/Synqra.Model/ObjectConverter.cs
+++ b/Synqra.Model/ObjectConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Synqra.BinarySerializer;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -267,7 +268,7 @@ public class SynqraJsonTypeInfoResolver : DefaultJsonTypeInfoResolver
 		typeof(IBindableModel),
 	};
 
-	static Dictionary<string, Type> _descriminators = new ();
+	static ConcurrentDictionary<string, Type> _descriminators = new ();
 
 	public static void RegisterGeneratedModel(Type type)
 	{


### PR DESCRIPTION
## Summary
- `SynqraJsonTypeInfoResolver._descriminators` was a plain `Dictionary<string, Type>` mutated by `RegisterGeneratedModel` (write) and read by `GetByDiscriminator` (`TryGetValue`) with no synchronization between either path.
- Under CPU-constrained parallel test execution, multiple test classes (e.g. `JsonlStorageTests`, `AppendStorageTests`, `TestsAppendStorageFile`) call `RegisterGeneratedModel` concurrently for the same generated model type via `SampleJsonSerializerContext.get_DefaultOptions()`, causing `Dictionary.TryInsert` to throw `IndexOutOfRangeException` from concurrent mutation. One repro run produced 93 cascading test failures all rooted in this single exception.
- Fix: switched `_descriminators` to `ConcurrentDictionary<string, Type>`, making both the write (`_descriminators[type.Name] = type`) and the read (`TryGetValue`) thread-safe without extra locking.

## Test plan
- [x] `dotnet build Synqra.Model` - 0 errors
- [x] Repro confirmed via `DOTNET_PROCESSOR_COUNT=2 dotnet test Tests/Synqra.Tests` (full suite, unfiltered, parallel test classes)
- [x] Ran the full suite 15x in a row under `DOTNET_PROCESSOR_COUNT=2` post-fix - 0 failures across all runs (111/111 passing each time)

Generated with Claude Code
