### PR TITLE
Fix vulnerable SQLitePCLRaw transitive dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,13 @@
 ﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <!-- System packages -->
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Runtime" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="System.Threading.AccessControl" Version="10.0.8" />
     <PackageVersion Include="System.Threading.Tasks" Version="4.3.0" />
     <!-- Microsoft.Extensions packages -->
@@ -18,7 +19,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     <!-- Microsoft.AspNetCore packages -->
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
     <!-- Microsoft.Data packages -->
@@ -29,9 +30,11 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tasks" Version="10.0.3" />
+    <!-- Pinned above the version EF Core/Microsoft.Data.Sqlite resolve transitively to pick up the SQLite fix for CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <!-- Microsoft.CodeAnalysis packages -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <!-- Microsoft.NET packages -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <!-- Microsoft.TypeScript -->


### PR DESCRIPTION
## Summary
- Pin `SQLitePCLRaw.bundle_e_sqlite3` to 3.0.3 to fix SQLite memory corruption (CVE-2025-6965, GHSA-2m69-gcr7-jv3q)
- Enable `CentralPackageTransitivePinningEnabled` globally so the pin above actually takes effect for EF Core/Microsoft.Data.Sqlite transitive resolution
- Enabling transitive pinning surfaced several pre-existing stale central-package pins as downgrade errors; bumped them to the versions already required transitively rather than scoping the fix to individual projects:
  - `Microsoft.CodeAnalysis.CSharp` 4.14.0 -> 5.0.0 (required by `Microsoft.EntityFrameworkCore.Design` 10.0.3)
  - `Microsoft.AspNetCore.Components.Web` 10.0.0 -> 10.0.3 (required by `Microsoft.AspNetCore.Components.WebAssembly`)
  - `System.Text.Json` 10.0.0 -> 10.0.8 (required by `Microsoft.Extensions.Hosting`)

## Test plan
- [x] `dotnet build Synqra.sln` succeeds with 0 errors
- [x] `dotnet test Synqra.sln` passes 111/111 real unit tests (unrelated Playwright/localhost test excluded)
- [x] `dotnet list package --vulnerable --include-transitive` reports no vulnerabilities across all projects