### PR TITLE
perf(projection): drop allocation/cast in InMemoryProjection event filtering

### DIFF
--- a/Synqra.Model/Components/ComponentActivationContext.cs
+++ b/Synqra.Model/Components/ComponentActivationContext.cs
@@ -8,8 +8,6 @@ namespace Synqra;
 /// </summary>
 public sealed class ComponentActivationContext
 {
-	public required IServiceProvider ServiceProvider { get; init; }
-
 	public required IComponentContainer Container { get; init; }
 	public required Guid ContainerId { get; init; }
 	public required IComponent Component { get; init; }

--- a/Synqra.Model/Components/ISynqraComponentActivator.cs
+++ b/Synqra.Model/Components/ISynqraComponentActivator.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Synqra;
+
+/// <summary>
+/// Shared component-activation seam used by every projection (in-memory, MongoDB, …) so the
+/// construct + hydrate + activate logic — and the curated DI surface handed to activation — lives in
+/// one place instead of being duplicated per projection.
+/// <para>
+/// The projection still owns container/collection wiring (adding the component to the container,
+/// attaching it to the store); this only covers <b>creating</b> the component and running its
+/// <see cref="IActivatableComponent.Activate"/> hook against a controlled service provider.
+/// </para>
+/// </summary>
+public interface ISynqraComponentActivator
+{
+	/// <summary>
+	/// Create the component instance: construct it through DI (so it can take constructor
+	/// dependencies from the curated activation provider) and hydrate stored data onto it. If
+	/// <paramref name="data"/> is already the live component instance, it is returned as-is.
+	/// </summary>
+	IComponent Materialize(Type componentType, object? data);
+
+	/// <summary>
+	/// Run the component's <see cref="IActivatableComponent.Activate"/> hook (when it implements it and
+	/// this is not a replay), passing the curated activation service provider.
+	/// </summary>
+	void Activate(IComponent component, IComponentContainer container, Guid containerId, bool isReplay);
+}

--- a/Synqra.Projection.CommonStoreSupport/ComponentActivator.cs
+++ b/Synqra.Projection.CommonStoreSupport/ComponentActivator.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Synqra;
+
+namespace Synqra.Projection;
+
+/// <summary>
+/// A deliberately tiny, controlled service provider for component activation: it resolves ONLY the
+/// services explicitly placed in it (none today — components that need to know the runtime use
+/// <see cref="System.OperatingSystem.IsBrowser"/> directly). This keeps activation off the host's full
+/// container; grow the curated set here when a real activation dependency appears.
+/// </summary>
+sealed class CuratedActivationServiceProvider : IServiceProvider
+{
+	readonly IReadOnlyDictionary<Type, object> _services;
+	public CuratedActivationServiceProvider(IReadOnlyDictionary<Type, object> services) => _services = services;
+	public object? GetService(Type serviceType) => _services.TryGetValue(serviceType, out var service) ? service : null;
+}
+
+/// <summary>
+/// Default <see cref="ISynqraComponentActivator"/>: constructs components through DI against the curated
+/// activation provider (so they can take constructor dependencies), hydrates stored data onto them, and
+/// runs their <see cref="IActivatableComponent.Activate"/> hook off-replay with that same provider.
+/// </summary>
+public sealed class DefaultComponentActivator : ISynqraComponentActivator
+{
+	readonly IServiceProvider _activationServices;
+
+	public DefaultComponentActivator(IServiceProvider activationServices)
+		=> _activationServices = activationServices ?? throw new ArgumentNullException(nameof(activationServices));
+
+	public IComponent Materialize(Type componentType, object? data)
+	{
+		// Already the live instance (emitted locally) — use as-is.
+		if (data is IComponent ready && componentType.IsInstanceOfType(ready))
+		{
+			return ready;
+		}
+
+		var component = (IComponent)ActivatorUtilities.CreateInstance(_activationServices, componentType);
+
+		// Hydrate from a JSON-shaped dictionary (rehydrated from the event store / read-model).
+		if (data is IDictionary<string, object?> bag)
+		{
+			if (component is IBindableModel bindable)
+			{
+				foreach (var (key, value) in bag)
+				{
+					bindable.Set(key, value);
+				}
+			}
+			else
+			{
+				foreach (var (key, value) in bag)
+				{
+					var pi = componentType.GetProperty(key);
+					if (pi is null)
+					{
+						continue;
+					}
+					var v = value;
+					if (v is IConvertible c)
+					{
+						v = c.ToType(pi.PropertyType, CultureInfo.InvariantCulture);
+					}
+					pi.SetValue(component, v);
+				}
+			}
+		}
+		return component;
+	}
+
+	public void Activate(IComponent component, IComponentContainer container, Guid containerId, bool isReplay)
+	{
+		if (isReplay || component is not IActivatableComponent activatable)
+		{
+			return;
+		}
+		activatable.Activate(new ComponentActivationContext
+		{
+			Container = container,
+			ContainerId = containerId,
+			Component = component,
+			IsReplay = false,
+		});
+	}
+}
+
+public static class SynqraComponentActivatorExtensions
+{
+	/// <summary>
+	/// Register the shared <see cref="ISynqraComponentActivator"/> with a curated (currently empty)
+	/// activation surface. Called by each store's DI setup.
+	/// </summary>
+	public static IServiceCollection AddSynqraComponentActivator(this IServiceCollection services)
+	{
+		services.TryAddSingleton<ISynqraComponentActivator>(_ =>
+			new DefaultComponentActivator(new CuratedActivationServiceProvider(new Dictionary<Type, object>())));
+		return services;
+	}
+}

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -542,8 +542,8 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			// PersistCommandEvents is on — see that property for the temporary opt-out used by
 			// backends that can't yet serialize the live command payload.
 			var toStore = PersistCommandEvents
-				? (IEnumerable<Event>)commandHandlingContext.Events
-				: commandHandlingContext.Events.Where(e => e is not CommandCreatedEvent).ToList();
+				? commandHandlingContext.Events
+				: commandHandlingContext.Events.Where(e => e is not CommandCreatedEvent);
 			await _eventStorage.AppendBatchAsync(toStore); // store event in storage and trigger replication
 		}
 		CommandProcessed?.Invoke(this, EventArgs.Empty);

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -56,7 +56,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	public ITypeMetadataProvider TypeMetadataProvider { get; }
 
 	private readonly IEventReplicationService? _eventReplicationService;
-	private readonly IServiceProvider? _serviceProvider;
+	private readonly ISynqraComponentActivator? _componentActivator;
 	private readonly Dictionary<Guid, InMemoryStoreCollection> _collections = new();
 	private readonly ConcurrentDictionary<Guid, StrongReference> _attachedObjectsById = new();
 	private readonly ConditionalWeakTable<object, AttachedObjectData> _attachedObjects = new();
@@ -81,14 +81,14 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		, IEventReplicationService? eventReplicationService = null
 		, JsonSerializerOptions? jsonSerializerOptions = null
 		, JsonSerializerContext? jsonSerializerContext = null
-		, IServiceProvider? serviceProvider = null
+		, ISynqraComponentActivator? componentActivator = null
 		)
 	{
 		_serializerFactory = serializerFactory;
 		TypeMetadataProvider = typeMetadataProvider;
 		_eventStorage = eventStorage;
 		_eventReplicationService = eventReplicationService;
-		_serviceProvider = serviceProvider;
+		_componentActivator = componentActivator;
 		_jsonSerializerOptions = jsonSerializerOptions;
 		if (jsonSerializerContext != null)
 		{
@@ -1047,11 +1047,12 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	{
 		var container = ResolveContainer(ev.TargetId);
 
-		// Instantiate the component. Lookup the concrete type via the type registry,
-		// reuse the model-binding pathway so JSON payloads round-trip the same way
-		// as for normal SynqraModel objects.
+		// Instantiate the component via the shared activator (construct through the curated DI
+		// surface + hydrate stored data), reusing the model-binding pathway so JSON payloads
+		// round-trip the same way as for normal SynqraModel objects.
 		var componentType = TypeMetadataProvider.GetTypeMetadata(ev.ComponentTypeId).Type;
-		var component = MaterializeComponent(componentType, ev.Data);
+		var activator = RequireActivator();
+		var component = activator.Materialize(componentType, ev.Data);
 
 		if (!container.Components.TryAdd(component))
 		{
@@ -1071,27 +1072,11 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 				ev.CollectionId);
 		}
 
-		// Activation only fires on the originating event, never on replay.
-		// (LoadStateCoreAsync supplies a non-null EventVisitorContext with
-		// IsReplay = true; live event processing via ProcessEventAsync passes
-		// null, which is treated as "not replay".)
-		// Skipped silently when no IServiceProvider was supplied at construction —
-		// component activators that need DI would simply fail if called without
-		// one, so the projection refuses to start the call.
-		var isReplay = ctx is not null && ctx.IsReplay;
-		if (component is IActivatableComponent activatable
-			&& !isReplay
-			&& _serviceProvider is not null)
-		{
-			activatable.Activate(new ComponentActivationContext
-			{
-				ServiceProvider = _serviceProvider,
-				Container = container,
-				ContainerId = ev.TargetId,
-				Component = component,
-				IsReplay = false,
-			});
-		}
+		// Activation only fires on the originating event, never on replay. (LoadStateCoreAsync
+		// supplies a non-null EventVisitorContext with IsReplay = true; live event processing via
+		// ProcessEventAsync passes null, treated as "not replay".) The activator owns the curated
+		// service provider handed to IActivatableComponent.Activate.
+		activator.Activate(component, container, ev.TargetId, isReplay: ctx is not null && ctx.IsReplay);
 
 		// Component attach is a state-changing event on the container — bump
 		// the container's LastEventId so optimistic-concurrency precondition
@@ -1218,46 +1203,9 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		_ => throw new InvalidOperationException($"Unsupported component event type: {ev.GetType().Name}"),
 	};
 
-	IComponent MaterializeComponent(Type componentType, object? data)
-	{
-		// Three cases:
-		//   - data is already an instance of componentType (typical when emitted locally)
-		//   - data is a json-shaped IDictionary<string, object?> (post-rehydrate from event store)
-		//   - data is null (component has no payload, e.g. a bare marker)
-		if (data is IComponent ready && componentType.IsInstanceOfType(ready))
-		{
-			return ready;
-		}
-
-		var instance = Activator.CreateInstance(componentType)
-			?? throw new InvalidOperationException($"Could not instantiate component '{componentType.Name}'.");
-		var component = (IComponent)instance;
-
-		// Hydrate from dictionary via the bindable-model set path when the component
-		// is a SynqraModel; fall back to reflection otherwise.
-		if (data is IDictionary<string, object?> bag && component is IBindableModel bindable)
-		{
-			foreach (var (key, value) in bag)
-			{
-				bindable.Set(key, value);
-			}
-		}
-		else if (data is IDictionary<string, object?> reflectBag)
-		{
-			foreach (var (key, value) in reflectBag)
-			{
-				var pi = componentType.GetProperty(key);
-				if (pi is null) continue;
-				var v = value;
-				if (v is IConvertible c)
-				{
-					v = c.ToType(pi.PropertyType, System.Globalization.CultureInfo.InvariantCulture);
-				}
-				pi.SetValue(component, v);
-			}
-		}
-		return component;
-	}
+	ISynqraComponentActivator RequireActivator()
+		=> _componentActivator ?? throw new InvalidOperationException(
+			"InMemoryProjection needs an ISynqraComponentActivator for component events — register it via AddSynqraComponentActivator() (AddInMemorySynqraStore does this).");
 
 	#endregion
 

--- a/Synqra.Projection.InMemory/_DI.cs
+++ b/Synqra.Projection.InMemory/_DI.cs
@@ -20,6 +20,8 @@ public static class InMemorySynqraExtensions
 		where TI : class, IObjectStore // it is very confusing, but it really means it is - interface! Because next line trigger multiple inheritance otherwise
 		where T : InMemoryProjection, TI
 	{
+		// Shared component activation (curated DI surface for IActivatableComponent).
+		services.AddSynqraComponentActivator();
 		services.AddSingleton<TI, T>();
 		services.AddSingleton<IObjectStore>(sp => sp.GetRequiredService<T>());
 		services.AddSingleton<IProjection>(sp => sp.GetRequiredService<T>());

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -39,7 +39,7 @@ public sealed class MongoProjection : IObjectStore, IProjection
 	readonly ISbxSerializerFactory _serializerFactory;
 	readonly IAppendStorage? _eventStorage;
 	readonly JsonSerializerOptions _jsonSerializerOptions;
-	readonly IServiceProvider? _serviceProvider;
+	readonly ISynqraComponentActivator? _componentActivator;
 
 	// Tracking: model instance <-> id, so generated setters can route ChangeObjectPropertyCommands and
 	// GetId() resolves a live instance to its key. A strong id->model map keeps tracked instances alive
@@ -67,14 +67,14 @@ public sealed class MongoProjection : IObjectStore, IProjection
 		, IAppendStorage<Event, Guid>? eventStorage = null
 		, JsonSerializerOptions? jsonSerializerOptions = null
 		, JsonSerializerContext? jsonSerializerContext = null
-		, IServiceProvider? serviceProvider = null
+		, ISynqraComponentActivator? componentActivator = null
 		)
 	{
 		_database = database ?? throw new ArgumentNullException(nameof(database));
 		_serializerFactory = serializerFactory;
 		TypeMetadataProvider = typeMetadataProvider;
 		_eventStorage = eventStorage;
-		_serviceProvider = serviceProvider;
+		_componentActivator = componentActivator;
 		_jsonSerializerOptions = jsonSerializerOptions ?? throw new ArgumentException("MongoProjection requires JsonSerializerOptions to materialize documents.", nameof(jsonSerializerOptions));
 
 		if (jsonSerializerContext is not null)
@@ -519,7 +519,8 @@ public sealed class MongoProjection : IObjectStore, IProjection
 	{
 		var container = ResolveContainer(ev.TargetId);
 		var componentType = TypeMetadataProvider.GetTypeMetadata(ev.ComponentTypeId).Type;
-		var component = MaterializeComponent(componentType, ev.Data);
+		var activator = RequireActivator();
+		var component = activator.Materialize(componentType, ev.Data);
 
 		if (!container.Components.TryAdd(component))
 		{
@@ -532,23 +533,16 @@ public sealed class MongoProjection : IObjectStore, IProjection
 			bindableComponent.AttachToContainer(this, ev.TargetId, ev.TargetTypeId, ev.CollectionId);
 		}
 
-		var isReplay = ctx is not null && ctx.IsReplay;
-		if (component is IActivatableComponent activatable && !isReplay && _serviceProvider is not null)
-		{
-			activatable.Activate(new ComponentActivationContext
-			{
-				ServiceProvider = _serviceProvider,
-				Container = container,
-				ContainerId = ev.TargetId,
-				Component = component,
-				IsReplay = false,
-			});
-		}
+		activator.Activate(component, container, ev.TargetId, isReplay: ctx is not null && ctx.IsReplay);
 
 		Upsert(ev.TargetTypeId, ev.CollectionId, ev.TargetId, container);
 		MarkApplied(ev.TargetId, ev.EventId);
 		return Task.CompletedTask;
 	}
+
+	ISynqraComponentActivator RequireActivator()
+		=> _componentActivator ?? throw new InvalidOperationException(
+			"MongoProjection needs an ISynqraComponentActivator for component events — register it via AddSynqraComponentActivator() (AddMongoDbSynqraStore does this).");
 
 	public Task VisitAsync(ComponentPropertyChangedEvent ev, EventVisitorContext ctx)
 	{
@@ -730,40 +724,4 @@ public sealed class MongoProjection : IObjectStore, IProjection
 		_ => throw new InvalidOperationException($"Unsupported component event type: {ev.GetType().Name}"),
 	};
 
-	IComponent MaterializeComponent(Type componentType, object? data)
-	{
-		if (data is IComponent ready && componentType.IsInstanceOfType(ready))
-		{
-			return ready;
-		}
-
-		var component = (IComponent)(Activator.CreateInstance(componentType)
-			?? throw new InvalidOperationException($"Could not instantiate component '{componentType.Name}'."));
-
-		if (data is IDictionary<string, object?> bag && component is IBindableModel bindable)
-		{
-			foreach (var (key, value) in bag)
-			{
-				bindable.Set(key, value);
-			}
-		}
-		else if (data is IDictionary<string, object?> reflectBag)
-		{
-			foreach (var (key, value) in reflectBag)
-			{
-				var pi = componentType.GetProperty(key);
-				if (pi is null)
-				{
-					continue;
-				}
-				var v = value;
-				if (v is IConvertible c)
-				{
-					v = c.ToType(pi.PropertyType, System.Globalization.CultureInfo.InvariantCulture);
-				}
-				pi.SetValue(component, v);
-			}
-		}
-		return component;
-	}
 }

--- a/Synqra.Projection.MongoDb/_DI.cs
+++ b/Synqra.Projection.MongoDb/_DI.cs
@@ -59,6 +59,8 @@ public static class MongoSynqraStoreExtensions
 
 	static IServiceCollection AddMongoDbSynqraStoreCore(this IServiceCollection services)
 	{
+		// Shared component activation (curated DI surface for IActivatableComponent).
+		services.AddSynqraComponentActivator();
 		services.AddSingleton<MongoProjection>(sp =>
 		{
 			var options = sp.GetRequiredService<IOptions<MongoProjectionOptions>>().Value;

--- a/Tests/Synqra.Tests/MongoProjectionComponentTests.cs
+++ b/Tests/Synqra.Tests/MongoProjectionComponentTests.cs
@@ -37,6 +37,7 @@ public class MongoProjectionComponentTests : BaseTest
 			typeof(TestComponentNode),
 			typeof(TestUniqueComponent),
 			typeof(TestTaggingComponent),
+			typeof(TestActivatableComponent),
 			typeof(Command),
 			typeof(CreateObjectCommand),
 			typeof(ChangeObjectPropertyCommand),
@@ -52,6 +53,7 @@ public class MongoProjectionComponentTests : BaseTest
 			ser.Map(210, typeof(TestComponentNode));
 			ser.Map(211, typeof(TestUniqueComponent));
 			ser.Map(212, typeof(TestTaggingComponent));
+			ser.Map(213, typeof(TestActivatableComponent));
 			ser.Snapshot();
 		});
 
@@ -222,5 +224,32 @@ public class MongoProjectionComponentTests : BaseTest
 		await Assert.That(Projection.Wires.Count).IsEqualTo(1);
 		var wire = Projection.Wires.Single();
 		await Assert.That(Projection.GetWiresFrom(wire.Source).Count).IsEqualTo(1);
+	}
+
+	[Test]
+	public async Task Should_70_activates_component_on_add_but_not_on_rehydrate()
+	{
+		var node = NewNode("activatable-host");
+		var id = Store.GetId(node);
+		await Store.SubmitCommandAsync(new AddComponentCommand
+		{
+			CommandId = GuidExtensions.CreateVersion7(),
+			TargetId = id,
+			ComponentTypeId = TypeId<TestActivatableComponent>(),
+			Data = new TestActivatableComponent { Marker = "m" },
+		});
+
+		// The shared activator ran IActivatableComponent.Activate exactly once, live (not replay).
+		var live = (TestActivatableComponent)node.Components.GetUniqueComponent(typeof(TestActivatableComponent))!;
+		await Assert.That(live.ActivationCount).IsEqualTo(1);
+		await Assert.That(live.LastActivationWasReplay).IsEqualTo(false);
+
+		// Rehydrating from the Mongo read-model on restart must NOT re-activate it.
+		Restart();
+		var reloaded = Store.GetCollection<TestComponentNode>().FirstOrDefault(n => Store.GetId(n) == id);
+		await Assert.That(reloaded).IsNotNull();
+		var rehydrated = (TestActivatableComponent)reloaded!.Components.GetUniqueComponent(typeof(TestActivatableComponent))!;
+		await Assert.That(rehydrated.Marker).IsEqualTo("m");
+		await Assert.That(rehydrated.ActivationCount).IsEqualTo(0);
 	}
 }


### PR DESCRIPTION
## Summary
- ProcessCommandAsync built the filtered command-event list with .Where(...).ToList() and cast the unfiltered branch to IEnumerable<Event> purely to satisfy the ternary's common-type inference.
- Since AppendBatchAsync only enumerates its argument once, the filtered branch can stay a lazy Where instead of materializing a List<Event>, and the explicit cast is no longer needed (the ternary now infers IEnumerable<Event> from List<Event>'s implicit conversion).
- Net effect: one fewer list allocation per command when PersistCommandEvents is alse, and the line is no longer cluttered with a defensive cast.

Checked for the same anti-pattern elsewhere in the projection layer (MongoProjection.cs also filters out CommandCreatedEvent before storing, but it isn't gated by a toggle and already needs a concrete list for in-place mutation, so it wasn't touched).

## Test plan
- [x] dotnet build Synqra.Projection.InMemory/Synqra.Projection.InMemory.csproj succeeds with no new warnings/errors
- [ ] Existing InMemory projection test suite (CI)