### PR TITLE
Add Edge/DirectedEdge/UndirectedEdge — generic typed relations in the framework

### DIFF
--- a/Synqra.Model/Edges/DirectedEdge.cs
+++ b/Synqra.Model/Edges/DirectedEdge.cs
@@ -1,0 +1,11 @@
+namespace Synqra;
+
+/// <summary>
+/// Edge where A→B differs from B→A. A is the source/from end, B is the target/to end. Adds no
+/// stored fields of its own, so — like <see cref="ObjectDeletedEvent"/> — it is a plain
+/// subclass, not <c>[SynqraModel]</c>; it just inherits <see cref="Edge"/>'s bindable plumbing.
+/// </summary>
+public abstract class DirectedEdge : Edge
+{
+	public override EdgeKey StructuralKey => EdgeKey.Directed(GetType(), A, B);
+}

--- a/Synqra.Model/Edges/Edge.cs
+++ b/Synqra.Model/Edges/Edge.cs
@@ -1,0 +1,42 @@
+namespace Synqra;
+
+/// <summary>
+/// Base for a reified relation between two points in the model graph. An edge rides the normal
+/// object lifecycle — created via <see cref="CreateObjectCommand"/>/<see cref="ObjectCreatedEvent"/>
+/// like any other object, with its own store-assigned identity (no separate "EdgeId" field, same
+/// as a plain container object has none) — so it gets replication, concurrency and serialization
+/// for free. The projection recognizes <see cref="Edge"/>-derived objects on create and maintains
+/// an adjacency index (<see cref="IEdgeIndex"/>) plus structural dedup via <see cref="StructuralKey"/>.
+/// <para>
+/// Endpoints are stored flattened into scalar columns (the model-binding/SBX generators store
+/// columns, not structs) and surfaced as <see cref="A"/>/<see cref="B"/> via read-only
+/// expression-bodied accessors, which the generator does not treat as stored fields — same
+/// convention the original <c>Wire</c> type used. See plans/edges.md.
+/// </para>
+/// </summary>
+[SynqraModel]
+[Schema(2026.410, "1 AObjectId Guid AComponentTypeId Guid AComponentId Guid BObjectId Guid BComponentTypeId Guid BComponentId Guid")]
+public abstract partial class Edge : IIdentifiable<Guid>
+{
+	// Endpoint A (flattened — see remarks above).
+	public partial Guid AObjectId { get; set; }
+	public partial Guid AComponentTypeId { get; set; }
+	public partial Guid AComponentId { get; set; }
+
+	// Endpoint B.
+	public partial Guid BObjectId { get; set; }
+	public partial Guid BComponentTypeId { get; set; }
+	public partial Guid BComponentId { get; set; }
+
+	/// <summary>Store-assigned identity, like any other plain object.</summary>
+	Guid IIdentifiable<Guid>.Id => ((IBindableModel)this).Store?.GetId(this) ?? default;
+
+	/// <summary>Endpoint A as a value tuple.</summary>
+	public Ref A => new(AObjectId, AComponentTypeId, AComponentId);
+
+	/// <summary>Endpoint B as a value tuple.</summary>
+	public Ref B => new(BObjectId, BComponentTypeId, BComponentId);
+
+	/// <summary>Identity-independent dedup/upsert key. Directionality decides how A/B fold into it.</summary>
+	public abstract EdgeKey StructuralKey { get; }
+}

--- a/Synqra.Model/Edges/EdgeKey.cs
+++ b/Synqra.Model/Edges/EdgeKey.cs
@@ -1,0 +1,45 @@
+namespace Synqra;
+
+/// <summary>
+/// Identity-independent dedup/upsert key for an edge: "is there already an equivalent edge
+/// between these endpoints?" Distinct from <see cref="IIdentifiable{T}.Id"/> (the edge's own
+/// store-assigned identity) — two edges can never share a <see cref="Type"/>+endpoint key, but
+/// each still has its own identity for replication/deletion. Directed and undirected edges
+/// differ only in how the pair folds into this key (ordered vs. unordered).
+/// </summary>
+public readonly struct EdgeKey : IEquatable<EdgeKey>
+{
+	readonly Type _edgeType;
+	readonly Ref _x;
+	readonly Ref _y;
+
+	EdgeKey(Type edgeType, Ref x, Ref y)
+	{
+		_edgeType = edgeType;
+		_x = x;
+		_y = y;
+	}
+
+	/// <summary>A→B differs from B→A.</summary>
+	public static EdgeKey Directed(Type edgeType, Ref source, Ref target) => new(edgeType, source, target);
+
+	/// <summary>{A,B} == {B,A} — endpoints are folded into canonical order so the key is symmetric.</summary>
+	public static EdgeKey Undirected(Type edgeType, Ref a, Ref b)
+		=> RefOrder.Compare(a, b) <= 0 ? new(edgeType, a, b) : new(edgeType, b, a);
+
+	public bool Equals(EdgeKey other) => _edgeType == other._edgeType && _x.Equals(other._x) && _y.Equals(other._y);
+	public override bool Equals(object? obj) => obj is EdgeKey other && Equals(other);
+	public override int GetHashCode()
+	{
+		unchecked
+		{
+			var hash = _edgeType.GetHashCode();
+			hash = (hash * 397) ^ _x.GetHashCode();
+			hash = (hash * 397) ^ _y.GetHashCode();
+			return hash;
+		}
+	}
+
+	public static bool operator ==(EdgeKey left, EdgeKey right) => left.Equals(right);
+	public static bool operator !=(EdgeKey left, EdgeKey right) => !left.Equals(right);
+}

--- a/Synqra.Model/Edges/EdgeNav.cs
+++ b/Synqra.Model/Edges/EdgeNav.cs
@@ -1,0 +1,65 @@
+namespace Synqra;
+
+/// <summary>
+/// Hand-written edge-backed navigation — the "simple Parent property" pattern. A model exposes
+/// <c>node.Parent</c>/<c>node.Children</c> ergonomics by delegating a regular (non-partial,
+/// unpersisted) property to one of these one-liners, instead of hand-rolling dual-direction id
+/// lists with a lazy "_lookup" toggle. A future generator (see plans/edges.md, step 4) can emit
+/// the same call from an <c>[EdgeCollection]</c> attribute; this is the v1, hand-written version
+/// of the exact same idea — not a placeholder for it.
+/// </summary>
+public static class EdgeNav
+{
+	/// <summary>The (at most one) edge of type <typeparamref name="TEdge"/> pointing at <paramref name="node"/>, resolved to its source object.</summary>
+	public static T? SingleParent<T, TEdge>(T node) where T : class where TEdge : DirectedEdge
+		=> Parents<T, TEdge>(node).FirstOrDefault();
+
+	/// <summary>All objects with a <typeparamref name="TEdge"/> pointing at <paramref name="node"/>.</summary>
+	public static IReadOnlyList<T> Parents<T, TEdge>(T node) where T : class where TEdge : DirectedEdge
+	{
+		if (!TryGetIndex(node, out var store, out var index, out var me)) return [];
+		return index.EdgesTo(me).OfType<TEdge>()
+			.Select(e => Resolve<T>(store, e.A.ObjectId))
+			.OfType<T>()
+			.ToArray();
+	}
+
+	/// <summary>All objects <paramref name="node"/> points at via a <typeparamref name="TEdge"/>.</summary>
+	public static IReadOnlyList<T> Children<T, TEdge>(T node) where T : class where TEdge : DirectedEdge
+	{
+		if (!TryGetIndex(node, out var store, out var index, out var me)) return [];
+		return index.EdgesFrom(me).OfType<TEdge>()
+			.Select(e => Resolve<T>(store, e.B.ObjectId))
+			.OfType<T>()
+			.ToArray();
+	}
+
+	/// <summary>All objects connected to <paramref name="node"/> via a <typeparamref name="TEdge"/>, either side.</summary>
+	public static IReadOnlyList<T> Related<T, TEdge>(T node) where T : class where TEdge : UndirectedEdge
+	{
+		if (!TryGetIndex(node, out var store, out var index, out var me)) return [];
+		return index.EdgesFrom(me).OfType<TEdge>()
+			.Select(e => e.A == me ? e.B : e.A)
+			.Select(other => Resolve<T>(store, other.ObjectId))
+			.OfType<T>()
+			.ToArray();
+	}
+
+	static bool TryGetIndex<T>(T node, out IObjectStore store, out IEdgeIndex index, out Ref me) where T : class
+	{
+		store = null!;
+		index = null!;
+		me = default;
+		if (node is not IBindableModel { Store: { } attachedStore } || attachedStore is not IEdgeIndex edgeIndex)
+		{
+			return false;
+		}
+		store = attachedStore;
+		index = edgeIndex;
+		me = new Ref(attachedStore.GetId(node));
+		return true;
+	}
+
+	static T? Resolve<T>(IObjectStore store, Guid id) where T : class
+		=> store.GetCollection<T>().FirstOrDefault(n => store.GetId(n) == id);
+}

--- a/Synqra.Model/Edges/IEdgeIndex.cs
+++ b/Synqra.Model/Edges/IEdgeIndex.cs
@@ -1,0 +1,24 @@
+namespace Synqra;
+
+/// <summary>
+/// Adjacency index a projection maintains over <see cref="Edge"/>-derived objects. Replaces
+/// hand-rolled dual-direction id lists + a lazy "_lookup" toggle (see plans/edges.md) — the
+/// inverse direction is always a query here, never a second stored list.
+/// </summary>
+public interface IEdgeIndex
+{
+	/// <summary>Every edge currently known to the index.</summary>
+	IReadOnlyCollection<Edge> Edges { get; }
+
+	/// <summary>Directed: edges whose source (<see cref="Edge.A"/>) is <paramref name="r"/>. Undirected: edges incident to <paramref name="r"/>.</summary>
+	IReadOnlyList<Edge> EdgesFrom(Ref r);
+
+	/// <summary>Directed: edges whose target (<see cref="Edge.B"/>) is <paramref name="r"/>. Undirected: edges incident to <paramref name="r"/>.</summary>
+	IReadOnlyList<Edge> EdgesTo(Ref r);
+
+	/// <summary>Edges connecting <paramref name="a"/> and <paramref name="b"/> in either direction.</summary>
+	IReadOnlyList<Edge> EdgesBetween(Ref a, Ref b);
+
+	/// <summary>Looks up the (at most one) edge matching a structural key — the dedup/upsert lookup.</summary>
+	bool TryGetByKey(EdgeKey key, out Edge? edge);
+}

--- a/Synqra.Model/Edges/Ref.cs
+++ b/Synqra.Model/Edges/Ref.cs
@@ -1,0 +1,34 @@
+namespace Synqra;
+
+/// <summary>
+/// A point in the model graph an edge can terminate at: an object, optionally narrowed to one
+/// of its components. Object-to-object links (the common case) leave the component fields
+/// default. Value-based equality so instances key adjacency tables.
+/// <para>
+/// Deliberately has no port/channel concept — that is routing-specific (which named output on
+/// a component feeds which named input) and belongs on the consumer's concrete edge type, not
+/// on the framework's endpoint addressing. See plans/edges.md.
+/// </para>
+/// </summary>
+public readonly record struct Ref(
+	Guid ObjectId,
+	Guid ComponentTypeId = default,
+	Guid ComponentId = default)
+{
+	/// <summary>True when this endpoint addresses the object itself, not a specific component on it.</summary>
+	public bool IsObjectScoped => ComponentTypeId == default && ComponentId == default;
+
+	public bool IsDefault => ObjectId == default && IsObjectScoped;
+}
+
+/// <summary>Canonical ordering over <see cref="Ref"/>, used to normalize undirected edge keys.</summary>
+internal static class RefOrder
+{
+	public static int Compare(Ref a, Ref b)
+	{
+		var c = a.ObjectId.CompareTo(b.ObjectId);
+		if (c != 0) return c;
+		c = a.ComponentTypeId.CompareTo(b.ComponentTypeId);
+		return c != 0 ? c : a.ComponentId.CompareTo(b.ComponentId);
+	}
+}

--- a/Synqra.Model/Edges/UndirectedEdge.cs
+++ b/Synqra.Model/Edges/UndirectedEdge.cs
@@ -1,0 +1,13 @@
+namespace Synqra;
+
+/// <summary>
+/// Edge where {A,B} == {B,A} — direction carries no meaning. The stored A/B fields are NOT
+/// reordered at write time (the generator-emitted setters give no hook to intercept that); instead
+/// <see cref="StructuralKey"/> folds the pair into canonical order, which is the only place
+/// "unordered" needs to hold. <see cref="IEdgeIndex"/> queries treat an undirected edge as
+/// incident to both A and B regardless of which one a caller queries from.
+/// </summary>
+public abstract class UndirectedEdge : Edge
+{
+	public override EdgeKey StructuralKey => EdgeKey.Undirected(GetType(), A, B);
+}

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -38,7 +38,7 @@ public static class InMemoryStoreContextExtensions
 /// It can be used to replay events from scratch
 /// It can also be treated like EF DataContext
 /// </summary>
-public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<CommandHandlerContext>, IEventVisitor<EventVisitorContext>
+public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<CommandHandlerContext>, IEventVisitor<EventVisitorContext>, IEdgeIndex
 {
 	private static UTF8Encoding _utf8nobom = new UTF8Encoding(false, false);
 	static InMemoryProjection()
@@ -70,6 +70,12 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	private readonly ConcurrentDictionary<PortRef, List<Wire>> _wiresFrom = new();
 	private readonly ConcurrentDictionary<PortRef, List<Wire>> _wiresTo = new();
 	private readonly object _wireIndexLock = new();
+
+	// Edges: dedup by structural key plus a single by-ref incidence index. Inserted on
+	// ObjectCreatedEvent for any Edge-derived object — edges ride the plain object lifecycle,
+	// there is no dedicated edge command/event. See plans/edges.md.
+	private readonly ConcurrentDictionary<EdgeKey, Edge> _edgesByKey = new();
+	private readonly ConcurrentDictionary<Ref, List<Edge>> _edgesByRef = new();
 
 	public bool IsOnline => _eventReplicationService?.IsOnline ?? false;
 
@@ -905,6 +911,11 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		}
 		collection.AddByEvent(newItem);
 
+		if (newItem is Edge edge)
+		{
+			IndexEdge(ev, edge);
+		}
+
 		// Record the creation event as the target's "last applied event" so that
 		// the first generated-setter write to this fresh object can pre-condition
 		// against it via ExpectedLastEventId.
@@ -914,6 +925,49 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		}
 		return Task.CompletedTask;
 	}
+
+	/// <summary>
+	/// Registers a materialized <see cref="Edge"/> in the adjacency index, rejecting a
+	/// structural duplicate (same concrete type + endpoint pair) before it can be indexed.
+	/// Runs before the originating event reaches durable storage (see ProcessCommandAsync),
+	/// so a rejected edge is never persisted — same veto-as-exception pattern as
+	/// <see cref="IComponentsCollection.TryAdd"/> for ComponentAddedEvent.
+	/// </summary>
+	void IndexEdge(ObjectCreatedEvent ev, Edge edge)
+	{
+		var key = edge.StructuralKey;
+		if (!_edgesByKey.TryAdd(key, edge))
+		{
+			throw new InvalidOperationException(
+				$"ObjectCreatedEvent {ev.EventId} could not register a '{edge.GetType().Name}' edge — an equivalent edge already exists between the same endpoints.");
+		}
+		_edgesByRef.GetOrAdd(edge.A, _ => new List<Edge>()).Add(edge);
+		if (edge.B != edge.A)
+		{
+			_edgesByRef.GetOrAdd(edge.B, _ => new List<Edge>()).Add(edge);
+		}
+	}
+
+	// ---------------------------------------------------------------- IEdgeIndex
+
+	IReadOnlyCollection<Edge> IEdgeIndex.Edges => (IReadOnlyCollection<Edge>)_edgesByKey.Values;
+
+	IReadOnlyList<Edge> IEdgeIndex.EdgesFrom(Ref r) =>
+		_edgesByRef.TryGetValue(r, out var list)
+			? list.Where(e => e is UndirectedEdge || e.A == r).ToArray()
+			: Array.Empty<Edge>();
+
+	IReadOnlyList<Edge> IEdgeIndex.EdgesTo(Ref r) =>
+		_edgesByRef.TryGetValue(r, out var list)
+			? list.Where(e => e is UndirectedEdge || e.B == r).ToArray()
+			: Array.Empty<Edge>();
+
+	IReadOnlyList<Edge> IEdgeIndex.EdgesBetween(Ref a, Ref b) =>
+		_edgesByRef.TryGetValue(a, out var list)
+			? list.Where(e => (e.A == a && e.B == b) || (e.A == b && e.B == a)).ToArray()
+			: Array.Empty<Edge>();
+
+	bool IEdgeIndex.TryGetByKey(EdgeKey key, out Edge? edge) => _edgesByKey.TryGetValue(key, out edge);
 
 	public Task VisitAsync(ObjectPropertyChangedEvent ev, EventVisitorContext ctx)
 	{

--- a/Tests/Synqra.Tests/EdgesTests.cs
+++ b/Tests/Synqra.Tests/EdgesTests.cs
@@ -1,0 +1,228 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Synqra.BinarySerializer;
+using Synqra.Projection.InMemory;
+
+namespace Synqra.Tests;
+
+// ---- Sample edge/node models exercising every flavour the Todo solution's
+// IHierarchy/IMHierarchy/IMRHierarchy/IDependable family hand-rolled separately
+// (see plans/edges.md). One framework primitive (Edge/DirectedEdge/UndirectedEdge),
+// differentiated by concrete type, replaces all four.
+
+/// <summary>Generic parent→child edge. No uniqueness constraint in v1, so the same
+/// type serves both "single parent" (IHierarchy) and "multi parent" (IMHierarchy)
+/// callers — the difference is purely how many a caller happens to create. Carries
+/// <see cref="Order"/> as reified payload (IMRHierarchy's "relation has its own data").</summary>
+[SynqraModel]
+[Schema(2026.420, "1 AObjectId Guid AComponentTypeId Guid AComponentId Guid BObjectId Guid BComponentTypeId Guid BComponentId Guid Order double?")]
+public partial class HierarchyEdge : DirectedEdge
+{
+	public partial double? Order { get; set; }
+}
+
+/// <summary>Pure marker edge (IDependable's "blocks/blockedBy"). Adds no fields of its
+/// own, so — like <see cref="ObjectDeletedEvent"/> — it is a plain subclass.</summary>
+public sealed class DependsOn : DirectedEdge
+{
+}
+
+/// <summary>Undirected relation — absent from the Todo predecessor, new in this design.</summary>
+[SynqraModel]
+[Schema(2026.421, "1 AObjectId Guid AComponentTypeId Guid AComponentId Guid BObjectId Guid BComponentTypeId Guid BComponentId Guid Label string?")]
+public partial class RelatedTo : UndirectedEdge
+{
+	public partial string? Label { get; set; }
+}
+
+[SynqraModel]
+[Schema(2026.422, "1 Name string?")]
+public partial class TestGraphNode
+{
+	public partial string? Name { get; set; }
+
+	// The "simple Parent property" — one line each, no generated/hand-rolled id lists.
+	public TestGraphNode? Parent => EdgeNav.SingleParent<TestGraphNode, HierarchyEdge>(this);
+	public IReadOnlyList<TestGraphNode> Parents => EdgeNav.Parents<TestGraphNode, HierarchyEdge>(this);
+	public IReadOnlyList<TestGraphNode> Children => EdgeNav.Children<TestGraphNode, HierarchyEdge>(this);
+	public IReadOnlyList<TestGraphNode> BlockedBy => EdgeNav.Parents<TestGraphNode, DependsOn>(this);
+	public IReadOnlyList<TestGraphNode> Blocks => EdgeNav.Children<TestGraphNode, DependsOn>(this);
+	public IReadOnlyList<TestGraphNode> RelatedNodes => EdgeNav.Related<TestGraphNode, RelatedTo>(this);
+}
+
+public class EdgesTests
+{
+	static ServiceProvider BuildServices()
+	{
+		var services = new ServiceCollection();
+		services.AddLogging();
+		services.AddTypeMetadataProvider(
+			typeof(Command),
+			typeof(CreateObjectCommand),
+			typeof(ChangeObjectPropertyCommand),
+			typeof(TestGraphNode),
+			typeof(HierarchyEdge),
+			typeof(DependsOn),
+			typeof(RelatedTo)
+		);
+		services.AddSbxSerializer();
+		services.AddInMemorySynqraStore();
+		return services.BuildServiceProvider();
+	}
+
+	static TestGraphNode AddNode(IObjectStore store, string name)
+	{
+		var node = new TestGraphNode { Name = name };
+		store.GetCollection<TestGraphNode>().Add(node);
+		return node;
+	}
+
+	static Ref RefOf(IObjectStore store, object obj) => new(store.GetId(obj));
+
+	// ---- Flavour: IHierarchy (single parent) ----
+
+	[Test]
+	public async Task Should_navigate_single_parent_and_children()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+
+		var parent = AddNode(store, "parent");
+		var child = AddNode(store, "child");
+		store.GetCollection<HierarchyEdge>().Add(new HierarchyEdge { AObjectId = RefOf(store, parent).ObjectId, BObjectId = RefOf(store, child).ObjectId });
+
+		await Assert.That(child.Parent).IsNotNull();
+		await Assert.That(store.GetId(child.Parent!)).IsEqualTo(store.GetId(parent));
+		await Assert.That(parent.Children.Count).IsEqualTo(1);
+		await Assert.That(store.GetId(parent.Children[0])).IsEqualTo(store.GetId(child));
+	}
+
+	// ---- Flavour: IMHierarchy (multi-parent — same edge type, no constraint) ----
+
+	[Test]
+	public async Task Should_support_multiple_parents_via_the_same_edge_type()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+
+		var parentA = AddNode(store, "parentA");
+		var parentB = AddNode(store, "parentB");
+		var child = AddNode(store, "child");
+		store.GetCollection<HierarchyEdge>().Add(new HierarchyEdge { AObjectId = RefOf(store, parentA).ObjectId, BObjectId = RefOf(store, child).ObjectId });
+		store.GetCollection<HierarchyEdge>().Add(new HierarchyEdge { AObjectId = RefOf(store, parentB).ObjectId, BObjectId = RefOf(store, child).ObjectId });
+
+		await Assert.That(child.Parents.Count).IsEqualTo(2);
+		// SingleParent degrades to "first" once there's more than one — multi-parent callers use Parents, not Parent.
+		await Assert.That(child.Parent).IsNotNull();
+	}
+
+	// ---- Flavour: IMRHierarchy (the relation carries its own data) ----
+
+	[Test]
+	public async Task Should_carry_payload_on_the_edge_itself()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+
+		var parent = AddNode(store, "parent");
+		var child = AddNode(store, "child");
+		var edges = store.GetCollection<HierarchyEdge>();
+		edges.Add(new HierarchyEdge { AObjectId = RefOf(store, parent).ObjectId, BObjectId = RefOf(store, child).ObjectId, Order = 2.5 });
+
+		var stored = edges.Single();
+		await Assert.That(stored.Order).IsEqualTo(2.5);
+	}
+
+	// ---- Flavour: IDependable (a different edge type between the same endpoints coexists) ----
+
+	[Test]
+	public async Task Should_differentiate_coexisting_edge_types_between_the_same_endpoints()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+		var index = (IEdgeIndex)store;
+
+		var a = AddNode(store, "a");
+		var b = AddNode(store, "b");
+		store.GetCollection<HierarchyEdge>().Add(new HierarchyEdge { AObjectId = RefOf(store, a).ObjectId, BObjectId = RefOf(store, b).ObjectId });
+		store.GetCollection<DependsOn>().Add(new DependsOn { AObjectId = RefOf(store, a).ObjectId, BObjectId = RefOf(store, b).ObjectId });
+
+		var between = index.EdgesBetween(RefOf(store, a), RefOf(store, b));
+		await Assert.That(between.Count).IsEqualTo(2);
+		await Assert.That(between.OfType<HierarchyEdge>().Count()).IsEqualTo(1);
+		await Assert.That(between.OfType<DependsOn>().Count()).IsEqualTo(1);
+
+		await Assert.That(b.BlockedBy.Count).IsEqualTo(1);
+		await Assert.That(a.Blocks.Count).IsEqualTo(1);
+	}
+
+	// ---- Structural dedup ----
+
+	[Test]
+	public async Task Should_reject_a_structurally_duplicate_directed_edge()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+
+		var a = AddNode(store, "a");
+		var b = AddNode(store, "b");
+		store.GetCollection<HierarchyEdge>().Add(new HierarchyEdge { AObjectId = RefOf(store, a).ObjectId, BObjectId = RefOf(store, b).ObjectId });
+
+		var ex = await Assert.ThrowsAsync(async () =>
+		{
+			store.GetCollection<HierarchyEdge>().Add(new HierarchyEdge { AObjectId = RefOf(store, a).ObjectId, BObjectId = RefOf(store, b).ObjectId });
+		});
+		await Assert.That(ex is InvalidOperationException).IsTrue();
+	}
+
+	[Test]
+	public async Task Should_allow_the_reverse_direction_of_a_directed_edge_as_distinct()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+
+		var a = AddNode(store, "a");
+		var b = AddNode(store, "b");
+		store.GetCollection<HierarchyEdge>().Add(new HierarchyEdge { AObjectId = RefOf(store, a).ObjectId, BObjectId = RefOf(store, b).ObjectId });
+		// B -> A is a different structural key for a directed edge, so it must be accepted.
+		store.GetCollection<HierarchyEdge>().Add(new HierarchyEdge { AObjectId = RefOf(store, b).ObjectId, BObjectId = RefOf(store, a).ObjectId });
+
+		await Assert.That(store.GetCollection<HierarchyEdge>().Count).IsEqualTo(2);
+	}
+
+	// ---- Undirected: order-independent structural key ----
+
+	[Test]
+	public async Task Should_treat_undirected_edge_as_incident_from_either_endpoint()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+
+		var a = AddNode(store, "a");
+		var b = AddNode(store, "b");
+		store.GetCollection<RelatedTo>().Add(new RelatedTo { AObjectId = RefOf(store, a).ObjectId, BObjectId = RefOf(store, b).ObjectId, Label = "friends" });
+
+		await Assert.That(a.RelatedNodes.Count).IsEqualTo(1);
+		await Assert.That(store.GetId(a.RelatedNodes[0])).IsEqualTo(store.GetId(b));
+		await Assert.That(b.RelatedNodes.Count).IsEqualTo(1);
+		await Assert.That(store.GetId(b.RelatedNodes[0])).IsEqualTo(store.GetId(a));
+	}
+
+	[Test]
+	public async Task Should_reject_the_reverse_direction_of_an_undirected_edge_as_a_structural_duplicate()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+
+		var a = AddNode(store, "a");
+		var b = AddNode(store, "b");
+		store.GetCollection<RelatedTo>().Add(new RelatedTo { AObjectId = RefOf(store, a).ObjectId, BObjectId = RefOf(store, b).ObjectId });
+
+		// B-A is the SAME structural key as A-B for an undirected edge — must be rejected.
+		var ex = await Assert.ThrowsAsync(async () =>
+		{
+			store.GetCollection<RelatedTo>().Add(new RelatedTo { AObjectId = RefOf(store, b).ObjectId, BObjectId = RefOf(store, a).ObjectId });
+		});
+		await Assert.That(ex is InvalidOperationException).IsTrue();
+	}
+}

--- a/plans/edges.md
+++ b/plans/edges.md
@@ -1,0 +1,251 @@
+## Plan: Edges — generic typed relations in the framework
+
+Replace the reverted `Wire` (one over-specialized relation type) with a small framework
+primitive that every consumer's relation kind derives from. The design is validated by two
+predecessors: Quotaly's `Wire` (reified edge with component-port endpoints, but hardcoded to
+one shape) and the Todo solution's `IHierarchy`/`IMHierarchy`/`IMRHierarchy`/`IDependable`
+families (four hand-specializations of "directed reified edge + adjacency views", each paying a
+full materialization/clone/hash/dual-direction tax — see `Todo.Model/IHierarchy.cs`,
+`Todo.Model/TodoNode.cs`). This collapses all of that into one base hierarchy plus projection
+support.
+
+### Decisions
+
+1. **Edges live in Synqra, ports/routing live in the consumer.** "Wire" conflated three
+   concerns: the relationship (universal → framework), the addressing granularity (component
+   ports → general `Ref`), and the delivery semantics (`PortType`, runtime routing → consumer).
+   Only the first belongs in the framework.
+2. **An edge is an entity that rides the existing object lifecycle.** No `AddWireCommand` /
+   `WireAddedEvent`. An edge is a `[SynqraModel]` object created via `CreateObjectCommand` /
+   `ObjectCreatedEvent` like any other; the projection special-cases anything deriving from
+   `Edge` to maintain an adjacency index and structural dedup. This reuses
+   replication/concurrency/serialization for free and keeps the command/event surface unchanged.
+3. **Directionality is the base class; semantic type is the concrete subclass.** Two bases —
+   `DirectedEdge` and `UndirectedEdge` — differ only in how endpoints fold into the *structural
+   key*. The concrete subclass (the `_t` discriminator) is what distinguishes "depends-on" from
+   "parent-of"; it is not a new base class per relation kind.
+4. **Endpoints are a `Ref`, not a node id.** A `Ref` addresses an object, optionally narrowed to
+   a component and port. Node-to-node is the degenerate case (component fields empty). This
+   subsumes both Todo (`ParentId`/`ChildId` = object-only `Ref`) and Wire (full component-port
+   `Ref`).
+5. **Store one directed edge; expose named collections over the index.** The "collection types"
+   ergonomic (`node.Children`, `node.BlockedBy`) is preserved by *generating* adjacency-backed
+   collection views — the same way Synqra already generates component collections — instead of
+   hand-rolling dual-direction id+object lists with a `_lookup` toggle.
+
+### Separate the two equalities (the core correctness point)
+
+Todo's `IRelation.AddHash` folds `Id, ParentId, ChildId` — i.e. it hashes by **entity
+identity**, so it can never answer "is there already a parent edge A→B?". It never needed to.
+The framework needs both, kept distinct:
+
+- **Entity identity** = `EdgeId` (a Guid). Used by the log for update/delete. Always by id.
+- **Structural key** = identity-independent dedup/upsert key. *This* is where directionality
+  matters: directed folds endpoints ordered, undirected folds them as an unordered pair.
+
+### `Ref` — endpoint value type
+
+```csharp
+namespace Synqra;
+
+/// <summary>
+/// A point in the model graph an edge can terminate at. Addresses an object, optionally
+/// narrowed to a component and a named port. Object-to-object links leave the component
+/// fields default. Value-based equality so it can key adjacency tables.
+/// </summary>
+public readonly record struct Ref(
+    Guid ObjectId,
+    Guid ComponentTypeId = default,
+    Guid ComponentId = default,
+    string? Port = null)
+{
+    public bool IsObjectScoped => ComponentTypeId == default && ComponentId == default && string.IsNullOrEmpty(Port);
+    public bool IsDefault => ObjectId == default && IsObjectScoped;
+}
+```
+
+### `Edge` / `DirectedEdge` / `UndirectedEdge`
+
+Note the generator constraint (AGENTS.md "convenience property must NOT be persisted"): the
+model-binding/SBX generators store scalar columns, not structs. So — exactly as the reverted
+`Wire` did — flatten the two `Ref`s into scalar `[SynqraModel]` columns and expose `A`/`B` as
+**read-only expression-bodied** `Ref` accessors (the generator skips those, so they are not
+stamped into `[Schema]`). Do **not** hand-write `[Schema]` versions; the generator stamps them.
+
+```csharp
+namespace Synqra;
+
+/// <summary>
+/// Base for a reified relation between two points in the model graph. An edge is a first-class
+/// object (its own EdgeId, its own collection) so it carries identity, properties and the full
+/// object lifecycle. Endpoints are stored flattened and surfaced as <see cref="A"/>/<see cref="B"/>.
+/// </summary>
+[SynqraModel]
+public abstract partial class Edge : IIdentifiable<Guid>
+{
+    public partial Guid EdgeId { get; set; }
+
+    // Endpoint A (flattened — generator stores scalars, not the Ref struct).
+    public partial Guid AObjectId { get; set; }
+    public partial Guid AComponentTypeId { get; set; }
+    public partial Guid AComponentId { get; set; }
+    public partial string? APort { get; set; }
+
+    // Endpoint B.
+    public partial Guid BObjectId { get; set; }
+    public partial Guid BComponentTypeId { get; set; }
+    public partial Guid BComponentId { get; set; }
+    public partial string? BPort { get; set; }
+
+    Guid IIdentifiable<Guid>.Id => EdgeId;
+
+    /// <summary>Endpoint A as a value tuple. Read-only ⇒ not persisted, not in [Schema].</summary>
+    public Ref A => new(AObjectId, AComponentTypeId, AComponentId, APort);
+    public Ref B => new(BObjectId, BComponentTypeId, BComponentId, BPort);
+
+    /// <summary>Identity-independent dedup/upsert key. Directionality decides the fold.</summary>
+    public abstract EdgeKey StructuralKey { get; }
+}
+
+/// <summary>Edge where A→B differs from B→A. A = source, B = target. Ordered structural key.</summary>
+[SynqraModel]
+public abstract partial class DirectedEdge : Edge
+{
+    public override EdgeKey StructuralKey => EdgeKey.Directed(GetType(), A, B);
+}
+
+/// <summary>
+/// Edge where {A,B} == {B,A}. Endpoints are normalized to canonical order at write time so the
+/// stored event is deterministic and the index needs only a single insertion. Unordered key.
+/// </summary>
+[SynqraModel]
+public abstract partial class UndirectedEdge : Edge
+{
+    public override EdgeKey StructuralKey => EdgeKey.Undirected(GetType(), A, B);
+}
+```
+
+`EdgeKey` does the folding and is the dedup currency:
+
+```csharp
+namespace Synqra;
+
+public readonly record struct EdgeKey
+{
+    private readonly Type _edgeType;
+    private readonly Ref _x;   // for directed: source; for undirected: the canonical-lesser endpoint
+    private readonly Ref _y;
+
+    private EdgeKey(Type edgeType, Ref x, Ref y) { _edgeType = edgeType; _x = x; _y = y; }
+
+    public static EdgeKey Directed(Type edgeType, Ref source, Ref target)
+        => new(edgeType, source, target);
+
+    public static EdgeKey Undirected(Type edgeType, Ref a, Ref b)
+        => RefOrder.Compare(a, b) <= 0 ? new(edgeType, a, b) : new(edgeType, b, a);
+
+    // record-struct equality/hash over (_edgeType, _x, _y) gives:
+    //   directed   → ordered identity (A→B ≠ B→A)
+    //   undirected → unordered identity (already canonicalized)
+}
+```
+
+### Projection: adjacency index (replaces Todo's `_lookup`)
+
+When the projection materializes/deletes an object that is an `Edge`, it maintains an index in
+addition to the normal object collection. This is exactly the reverted `_wiresFrom`/`_wiresTo`
+pattern, generalized off `Ref` and gated by structural dedup.
+
+```csharp
+namespace Synqra;
+
+public interface IEdgeIndex
+{
+    /// <summary>Directed: edges whose source is <paramref name="a"/>. Undirected: incident to a.</summary>
+    IReadOnlyList<Edge> EdgesFrom(Ref a);
+    /// <summary>Directed: edges whose target is <paramref name="b"/>. Undirected: incident to b.</summary>
+    IReadOnlyList<Edge> EdgesTo(Ref b);
+    IReadOnlyList<Edge> EdgesBetween(Ref a, Ref b);
+    bool TryGetByKey(EdgeKey key, out Edge edge);
+}
+```
+
+- Insertion checks `StructuralKey`; a duplicate is rejected (surfaced like an
+  `ICanAddComponent` veto rather than thrown, so replay is idempotent).
+- The inverse direction is a *query*, never a second stored list — this removes Todo's
+  `Parents`+`Children` / `BlockedBy`+`Blocks` dual-write and its consistency bugs.
+
+### Generated collection views (the "collection types" bridge)
+
+The consumer keeps `node.Children` ergonomics; the generator backs the property with an index
+query instead of a hand-rolled lazy list. One attributed partial property replaces ~40 lines of
+`…Ids` / `…Created` / `…UnsetIfEmpty` / `_lookup` plumbing per direction.
+
+```csharp
+[SynqraModel]
+public partial class TodoNode
+{
+    [EdgeCollection(typeof(HierarchyEdge), End.Source)]   // this node is the source ⇒ its children
+    public partial IReadOnlyCollection<TodoNode> Children { get; }
+
+    [EdgeCollection(typeof(HierarchyEdge), End.Target)]   // this node is the target ⇒ its parents
+    public partial IReadOnlyCollection<TodoNode> Parents { get; }
+
+    [EdgeCollection(typeof(DependsOn), End.Target)]
+    public partial IReadOnlyCollection<TodoNode> BlockedBy { get; }
+}
+```
+
+### Constraints & ordering
+
+- **Tree = directed edge + uniqueness.** `IHierarchy` (single-parent) is `HierarchyEdge` with
+  "≤ 1 inbound edge per node", expressed as an edge-level constraint
+  (e.g. `[EdgeConstraint(MaxInbound = 1)]`). `IMHierarchy`/`IMRHierarchy` are the same edge
+  without the constraint.
+- **Order belongs on the edge, not the node.** Todo's `IOrderable.Order` sits on the node, which
+  is a single-parent assumption leaking — in a multi-parent graph a child's sibling order differs
+  per parent. Put `double Order` on `HierarchyEdge`. (Sibling ordering then reads off the inbound
+  edge for a given parent.)
+
+### Old → new mapping
+
+| Predecessor | New |
+|---|---|
+| Todo `IRelation` (`Id`, `ParentId`, `ChildId`, `Extra`) | `DirectedEdge` subclass (`EdgeId`, `A`/`B`, derived props) |
+| Todo `ParentId`/`ChildId` (object-only) | `Ref` with only `ObjectId` set |
+| Todo `IHierarchy` (single parent) | `HierarchyEdge` + `MaxInbound = 1` |
+| Todo `IMHierarchy`/`IMRHierarchy` | `HierarchyEdge`, no constraint |
+| Todo `IDependable` (blocks/blockedBy) | `DependsOn : DirectedEdge`; `Blocks`/`BlockedBy` = `EdgesFrom`/`EdgesTo` |
+| Todo `_lookup`/`FindRelsByIds` + dual id-lists | `IEdgeIndex` + generated `[EdgeCollection]` views |
+| Quotaly `Wire` (component-port endpoints) | `GraphWire : DirectedEdge` adding `Port`/`PortType` (consumer) |
+| Quotaly `PortRef` | framework `Ref` |
+| Quotaly `PortType`, runtime routing | stays in the consumer's graph runtime |
+
+### Steps
+
+1. Add `Ref` and `EdgeKey` (+ `RefOrder` canonical comparer) to `Synqra.Model`.
+2. Add `Edge` / `DirectedEdge` / `UndirectedEdge` `[SynqraModel]` bases (flattened endpoints,
+   read-only `A`/`B`, abstract `StructuralKey`). Let the generator stamp `[Schema]`.
+3. Teach `InMemoryProjection` to recognize `Edge`-derived objects on
+   create/delete and maintain `IEdgeIndex` + structural dedup (port the reverted
+   `_wiresFrom`/`_wiresTo` code off `Ref`).
+4. Add the `[EdgeCollection]` attribute + generator support for adjacency-backed read-only
+   collection properties.
+5. Port a vertical slice to prove it: re-express Quotaly's scene links as a
+   `SceneLink : DirectedEdge` (or `UndirectedEdge`) in the consumer; re-express SimpleV1's wire
+   as `GraphWire : DirectedEdge` with `Port`/`PortType` consumer-side.
+6. (Deferred) Cascade-on-endpoint-delete — depends on object-delete existing in the projection
+   (currently a no-op; see `NodesController` "node deletion intentionally absent" comment). Until
+   then, queries filter edges whose endpoints no longer resolve (as Quotaly's `IsOwnedBy` already
+   did).
+
+### Open questions (need a decision before coding)
+
+1. **Serialization of endpoints** — confirm we flatten to scalars now (recommended, matches
+   `Wire`), versus teaching the SBX generator a `Ref` column type. Flatten now, revisit later.
+2. **Dedup placement** — reject duplicate `StructuralKey` in the projection (idempotent replay,
+   recommended) vs. throwing from the add path.
+3. **Undirected normalization** — canonicalize `A`/`B` at construction (deterministic event,
+   recommended) vs. only at index/compare time.
+4. **Scope of v1** — ship `Ref` + edge bases + index + generated collections; defer constraints
+   (`MaxInbound`) and cascade. Agree the cut line.


### PR DESCRIPTION
## Summary
- Replaces the reverted `Wire` (one over-specialized relation type) with a small framework primitive every consumer's relation kind can derive from. Design write-up: [plans/edges.md](plans/edges.md).
- Validated against two predecessors: Quotaly's `Wire` (reified edge, component-port endpoints, one hardcoded shape) and the Todo solution's `IHierarchy`/`IMHierarchy`/`IMRHierarchy`/`IDependable` family (four hand-specialized "directed reified edge + adjacency views", each paying its own materialization/clone/hash/dual-direction tax).
- `Ref` addresses an object, optionally narrowed to a component — deliberately **no port/channel concept**; that's routing-specific and stays on the consumer's concrete edge type (e.g. a future `GraphWire`), not the framework's endpoint addressing.
- `Edge` rides the plain object lifecycle (`CreateObjectCommand`/`ObjectCreatedEvent`) with **no separate `EdgeId`** — identity is the normal store-assigned object id, same as any other plain object.
- `DirectedEdge`/`UndirectedEdge` differ only in how `A`/`B` fold into the identity-independent `StructuralKey`; the concrete subclass (the `_t` discriminator) differentiates relation kinds, not a new base class per kind.
- `InMemoryProjection` recognizes `Edge`-derived objects on create, rejects a structural duplicate before the event reaches storage (same veto-as-exception pattern as `ComponentAddedEvent`/`IComponentsCollection.TryAdd`), and maintains a single by-ref incidence index (`EdgesFrom`/`EdgesTo`/`EdgesBetween`) instead of dual-direction id lists + a lazy lookup toggle.
- `EdgeNav` is the hand-written v1 of the "simple Parent property" ergonomic — one line per direction (`node.Parent`, `node.Children`, ...), no per-type generated/hand-rolled plumbing. A generator can emit the same call from an `[EdgeCollection]` attribute later (deferred — see plan).
- This repo's `Wire`/`PortRef`/`PortType` are untouched; this PR is independent of (and does not require) the separate wires-revert PR.

## Test plan
- [x] `EdgesTests.cs` covers every flavour the Todo predecessor hand-rolled separately: single- and multi-parent (same edge type, no uniqueness constraint in v1), a reified edge carrying its own payload, two edge types coexisting between the same endpoints, structural dedup for both directed and undirected edges, and undirected incidence from either endpoint.
- [x] `dotnet build` — 0 errors (with `Wire` still present on `master-quotaly`)
- [x] `dotnet test Tests/Synqra.Tests -f net10.0` — 119/119 passing