### PR TITLE
feat(model): replace loose object Data with strict ObjectData contract

### DIFF
--- a/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
@@ -53,7 +53,6 @@ public static class MongoEventClassMaps
 
 			PatchObjectSerializerDefaults();
 			RegisterJsonIgnoreConvention();
-			RegisterObjectDataSerializer();
 
 			if (!BsonClassMap.IsClassMapRegistered(typeof(Event)))
 			{
@@ -171,26 +170,17 @@ public static class MongoEventClassMaps
 	/// bypassing <see cref="ObjectData.From(object, ISet{string}?)"/>'s exclude list, still
 	/// can't leak a duplicate copy of fields the event already carries explicitly into Mongo.
 	/// </summary>
-	static void RegisterObjectDataSerializer()
+	sealed class LinkDataSerializer : SerializerBase<ObjectData>
 	{
-		try
-		{
-			BsonSerializer.RegisterSerializer(new ObjectDataSerializer());
-		}
-		catch (BsonSerializationException)
-		{
-		}
-	}
+		static readonly string[] WellKnown = [nameof(Link.LinkId), nameof(Link.SourceId), nameof(Link.TargetId)];
 
-	class ObjectDataSerializer : SerializerBase<ObjectData>
-	{
 		public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, ObjectData value)
 		{
 			var writer = context.Writer;
 			writer.WriteStartDocument();
 			foreach (var (key, val) in value)
 			{
-				if (!ShouldWrite(key))
+				if (Array.IndexOf(WellKnown, key) >= 0)
 				{
 					continue;
 				}
@@ -213,15 +203,6 @@ public static class MongoEventClassMaps
 			reader.ReadEndDocument();
 			return result;
 		}
-
-		protected virtual bool ShouldWrite(string key) => true;
-	}
-
-	sealed class LinkDataSerializer : ObjectDataSerializer
-	{
-		static readonly string[] WellKnown = [nameof(Link.LinkId), nameof(Link.SourceId), nameof(Link.TargetId)];
-
-		protected override bool ShouldWrite(string key) => Array.IndexOf(WellKnown, key) < 0;
 	}
 
 	static void RegisterDerived<T>(string discriminator, Action<BsonClassMap<T>>? configure = null)

--- a/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
@@ -226,8 +226,8 @@ public static class MongoEventClassMaps
 		{
 			cm.AutoMap();
 			cm.SetDiscriminator(discriminator);
-			// e.g. ObjectCreatedEvent.MaterializedObject is the in-memory materialized object,
-			// marked [JsonIgnore] — it must not be persisted into the durable log.
+			// e.g. SingleObjectCommand.TargetObject is [JsonIgnore] — it must not be
+			// persisted into the durable log.
 			UnmapJsonIgnored(cm);
 			configure?.Invoke(cm);
 		});

--- a/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
@@ -226,7 +226,7 @@ public static class MongoEventClassMaps
 		{
 			cm.AutoMap();
 			cm.SetDiscriminator(discriminator);
-			// e.g. ObjectCreatedEvent.DataObject is the in-memory materialized object,
+			// e.g. ObjectCreatedEvent.MaterializedObject is the in-memory materialized object,
 			// marked [JsonIgnore] — it must not be persisted into the durable log.
 			UnmapJsonIgnored(cm);
 			configure?.Invoke(cm);

--- a/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
@@ -53,6 +53,7 @@ public static class MongoEventClassMaps
 
 			PatchObjectSerializerDefaults();
 			RegisterJsonIgnoreConvention();
+			RegisterObjectDataSerializer();
 
 			if (!BsonClassMap.IsClassMapRegistered(typeof(Event)))
 			{
@@ -81,8 +82,7 @@ public static class MongoEventClassMaps
 			// a [BsonId] attribute on the model itself: Synqra.Model has no MongoDB dependency, and
 			// every other storage backend (in-memory, SBX files) addresses a link by this same LinkId
 			// property without needing it singled out as "the" id — that's a Mongo-only document
-			// convention. LinkDataSerializer's own well-known-field strip (LinkAddedEvent.Data) accounts
-			// for this rename too — see its WellKnown list.
+			// convention.
 			if (!BsonClassMap.IsClassMapRegistered(typeof(Link)))
 			{
 				BsonClassMap.RegisterClassMap<Link>(cm =>
@@ -101,11 +101,12 @@ public static class MongoEventClassMaps
 			RegisterDerived<ComponentDeletedEvent>("ComponentDeletedEvent");
 			RegisterDerived<LinkRemovedEvent>("LinkRemovedEvent");
 
-			// LinkAddedEvent gets a member-scoped serializer on Data so the embedded link drops the
-			// three well-known fields (_id/LinkId, SourceId, TargetId) it would otherwise duplicate
-			// (see LinkDataSerializer). This keeps the Link class map's own field SET untouched —
-			// unlike a global convention, so MongoProjection's native link collection can still persist
-			// _id/SourceId/TargetId for querying.
+			// LinkAddedEvent.Data is the canonical ObjectData bag (see ObjectData.From's exclude param
+			// and Link.WellKnownDataFields) — LinkId/SourceId/TargetId never enter it at construction
+			// time, so there's nothing left for a class-map-level fix to strip. LinkDataSerializer stays
+			// registered as a defensive backstop: a member-scoped serializer (not a Link-class-map-wide
+			// convention, which would also clobber MongoProjection's native "Links" collection) in case
+			// a future caller ever builds Data by hand without going through ObjectData.From's exclude.
 			RegisterDerived<LinkAddedEvent>("LinkAddedEvent", cm =>
 				cm.GetMemberMap(e => e.Data).SetSerializer(new LinkDataSerializer()));
 
@@ -120,29 +121,21 @@ public static class MongoEventClassMaps
 	/// <item>
 	/// Strips every <see cref="JsonIgnoreAttribute"/>-marked member. Without this, a dynamic
 	/// <c>object</c>-typed event member that carries a live model instance (e.g.
-	/// <see cref="LinkAddedEvent.Data"/> holding a concrete <c>Link</c> subclass) gets auto-mapped
-	/// <em>implicitly</em> the first time BSON encounters it, and that implicit auto-map never runs
-	/// <see cref="UnmapJsonIgnored"/> — only the types this class explicitly calls
-	/// <see cref="RegisterDerived{T}"/> for get that treatment. A consumer-defined Link subclass is
-	/// exactly such a type: the framework has no way to know about it ahead of time, so per-type
-	/// registration can't cover it, but a convention applies to every AutoMap call, explicit or
-	/// implicit, uniformly.
+	/// <c>AddComponentCommand.LiveComponent</c>/<c>ComponentAddedEvent.LiveComponent</c>, holding a
+	/// concrete <c>IComponent</c> subclass) gets auto-mapped <em>implicitly</em> the first time BSON
+	/// encounters it, and that implicit auto-map never runs <see cref="UnmapJsonIgnored"/> — only the
+	/// types this class explicitly calls <see cref="RegisterDerived{T}"/> for get that treatment. A
+	/// consumer-defined component/link subclass is exactly such a type: the framework has no way to
+	/// know about it ahead of time, so per-type registration can't cover it, but a convention applies
+	/// to every AutoMap call, explicit or implicit, uniformly.
 	/// </item>
 	/// <item>
 	/// Skips writing a member at all when its value is null (the driver's built-in
 	/// <see cref="IgnoreIfNullConvention"/>). Most event fields that aren't always populated for a
-	/// given event kind (e.g. <see cref="ObjectCreatedEvent.Data"/>, never set by the current
-	/// command-handling path) are nullable reference types, so without this every document carries
-	/// an explicit <c>"Field": null</c> for each one that happens not to apply.
+	/// given event kind are nullable reference types, so without this every document carries an
+	/// explicit <c>"Field": null</c> for each one that happens not to apply.
 	/// </item>
 	/// </list>
-	/// <para>
-	/// Note: the redundancy where <see cref="LinkAddedEvent.Data"/> (a concrete <c>Link</c>) would
-	/// duplicate the three well-known fields the event already carries explicitly is handled NOT here
-	/// (a global Link-class-map strip would also clobber <c>MongoProjection</c>'s native link storage,
-	/// which needs those fields to query) but by a member-scoped <see cref="LinkDataSerializer"/> on the
-	/// <c>Data</c> member alone — see its registration in <see cref="Register"/>.
-	/// </para>
 	/// </summary>
 	static void RegisterJsonIgnoreConvention()
 	{
@@ -167,52 +160,68 @@ public static class MongoEventClassMaps
 	}
 
 	/// <summary>
-	/// Member-scoped BSON serializer for <see cref="LinkAddedEvent.Data"/> (the link instance).
-	/// Serializes the link natively through the normal <c>object</c> serializer — so a consumer's
-	/// concrete <c>Link</c> subtype keeps its own extra fields and its <c>_t</c> discriminator — then
-	/// drops the three well-known fields (<see cref="Link.LinkId"/> — written as <c>_id</c>, since the
-	/// shared <c>Link</c> class map maps it as the id member, see <see cref="Register"/> —
-	/// <see cref="Link.SourceId"/>/<see cref="Link.TargetId"/>) from the resulting sub-document,
-	/// because the event already carries them as explicit top-level fields. Because it's attached to
-	/// this one member rather than the <c>Link</c> class map, it never affects how a <c>Link</c> is
-	/// serialized anywhere else — notably <c>MongoProjection</c>'s native "Links" collection, which
-	/// must keep those very fields to query by endpoint. On replay the materialized link re-stamps
-	/// LinkId/SourceId/TargetId from the event's own explicit fields, so the stripped fields are never
-	/// read back from Data.
+	/// Member-scoped BSON serializer for <see cref="LinkAddedEvent.Data"/>, the canonical
+	/// <see cref="ObjectData"/> bag. <see cref="ObjectData.From(object, ISet{string}?)"/>
+	/// already excludes <see cref="Link.WellKnownDataFields"/> (LinkId/SourceId/TargetId) at
+	/// construction time — <see cref="LinkCollections"/>'s submit path always goes through it — so in
+	/// the normal case this serializer's strip below never finds anything to remove. It's kept as a
+	/// defensive backstop: a member-scoped serializer (not a global <c>Link</c>-class-map convention,
+	/// which would also clobber <c>MongoProjection</c>'s native "Links" collection, since that needs
+	/// those very fields to query by endpoint) so a future caller who builds <c>Data</c> by hand,
+	/// bypassing <see cref="ObjectData.From(object, ISet{string}?)"/>'s exclude list, still
+	/// can't leak a duplicate copy of fields the event already carries explicitly into Mongo.
 	/// </summary>
-	sealed class LinkDataSerializer : SerializerBase<object>
+	static void RegisterObjectDataSerializer()
 	{
-		static readonly string[] WellKnown = ["_id", nameof(Link.SourceId), nameof(Link.TargetId)];
-
-		// Looked up lazily so it resolves the patched, fully-open object serializer (see
-		// PatchObjectSerializerDefaults) rather than whatever might exist at type-init time.
-		IBsonSerializer? _objectSerializer;
-		IBsonSerializer ObjectSerializer => _objectSerializer ??= BsonSerializer.LookupSerializer(typeof(object));
-
-		public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value)
+		try
 		{
-			if (value is null)
-			{
-				context.Writer.WriteNull();
-				return;
-			}
+			BsonSerializer.RegisterSerializer(new ObjectDataSerializer());
+		}
+		catch (BsonSerializationException)
+		{
+		}
+	}
 
-			// Serialize the link to a throwaway document (carries _t + every mapped field), then strip
-			// the three the event already owns and write what's left to the real output.
-			var doc = new BsonDocument();
-			using (var docWriter = new BsonDocumentWriter(doc))
+	class ObjectDataSerializer : SerializerBase<ObjectData>
+	{
+		public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, ObjectData value)
+		{
+			var writer = context.Writer;
+			writer.WriteStartDocument();
+			foreach (var (key, val) in value)
 			{
-				ObjectSerializer.Serialize(BsonSerializationContext.CreateRoot(docWriter), args, value);
+				if (!ShouldWrite(key))
+				{
+					continue;
+				}
+				writer.WriteName(key);
+				BsonSerializer.Serialize(writer, typeof(object), val);
 			}
-			foreach (var name in WellKnown)
-			{
-				doc.Remove(name);
-			}
-			BsonDocumentSerializer.Instance.Serialize(context, args, doc);
+			writer.WriteEndDocument();
 		}
 
-		public override object Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
-			=> ObjectSerializer.Deserialize(context, args);
+		public override ObjectData Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+		{
+			var reader = context.Reader;
+			var result = new ObjectData();
+			reader.ReadStartDocument();
+			while (reader.ReadBsonType() != BsonType.EndOfDocument)
+			{
+				var name = reader.ReadName();
+				result[name] = BsonSerializer.Deserialize<object>(reader);
+			}
+			reader.ReadEndDocument();
+			return result;
+		}
+
+		protected virtual bool ShouldWrite(string key) => true;
+	}
+
+	sealed class LinkDataSerializer : ObjectDataSerializer
+	{
+		static readonly string[] WellKnown = [nameof(Link.LinkId), nameof(Link.SourceId), nameof(Link.TargetId)];
+
+		protected override bool ShouldWrite(string key) => Array.IndexOf(WellKnown, key) < 0;
 	}
 
 	static void RegisterDerived<T>(string discriminator, Action<BsonClassMap<T>>? configure = null)
@@ -254,9 +263,8 @@ public static class MongoEventClassMaps
 	/// Forces two ambient MongoDB defaults that the public API cannot reliably change once the
 	/// process has started, by reaching into <see cref="BsonSerializer"/>/<see cref="ObjectSerializer"/>
 	/// internals and overwriting them directly rather than asking nicely. Both fixes are needed for
-	/// any <c>object</c>-typed event member that carries a live, concrete payload — e.g.
-	/// <see cref="LinkAddedEvent.Data"/> (the link instance itself, mirroring
-	/// <see cref="ComponentAddedEvent.Data"/>'s contract) or a boxed <see cref="Guid"/> like
+	/// any <c>object</c>-typed value Mongo has to serialize without a known concrete type — e.g. each
+	/// boxed value inside an <see cref="ObjectData"/> bag, or a boxed <see cref="Guid"/> like
 	/// <see cref="ObjectPropertyChangedEvent.NewValue"/>:
 	/// <list type="number">
 	/// <item>

--- a/Synqra.BinarySerializer.SourceGenerator/SbxBindingGenerator.cs
+++ b/Synqra.BinarySerializer.SourceGenerator/SbxBindingGenerator.cs
@@ -320,6 +320,13 @@ public class SbxBindingGenerator : IIncrementalGenerator
 			{
 				return "Dict<string, object>";
 			}
+			// Concrete IDictionary-derived types (e.g. ObjectData : Dictionary<string, object?>)
+			// must be detected as dictionaries here, before the IEnumerable fallback below would
+			// otherwise mis-classify them as List<KeyValuePair<,>> (Dictionary implements both).
+			if (TryGetIDictionaryKeyAndElement(named, out var namedDictKey, out var namedDictElem))
+			{
+				return $"Dict<{namedDictKey}, {namedDictElem}>";
+			}
 			foreach (var i in named.AllInterfaces)
 			{
 				DebugLog($"[Type {debug}] °1 Detected Interface: {i}");
@@ -845,7 +852,22 @@ public class SbxBindingGenerator : IIncrementalGenerator
 				var target = (!doesSupportField && SymbolEqualityComparer.Default.Equals(pro.ContainingType, containingType))
 					? GetFieldName(pro)
 					: "this." + pro.Name;
-				body.AppendLine($"\t\t\t{target} = ({FQN(pro.Type)})serializer.Deserialize{DeserializeMethod(pro.Type, debug: containingType.Name)}(in buffer, ref pos);");
+				var method = DeserializeMethod(pro.Type, debug: containingType.Name);
+				var call = $"serializer.Deserialize{method}(in buffer, ref pos)";
+				if (method != null && method.StartsWith("Dict<")
+					&& pro.Type is INamedTypeSymbol dictType
+					&& dictType.TypeKind == TypeKind.Class
+					&& dictType.Name != "Dictionary")
+				{
+					// Concrete IDictionary-derived target (e.g. ObjectData): DeserializeDict returns a
+					// plain Dictionary, so copy-construct the target type rather than casting — a cast
+					// would throw because the runtime object isn't an instance of the subclass.
+					body.AppendLine($"\t\t\t{target} = new {FQN(pro.Type)}({call});");
+				}
+				else
+				{
+					body.AppendLine($"\t\t\t{target} = ({FQN(pro.Type)}){call};");
+				}
 			}
 			body.AppendLine($"\t\t}}");
 			els = "else ";

--- a/Synqra.Model/Commands.cs
+++ b/Synqra.Model/Commands.cs
@@ -87,12 +87,12 @@ public abstract partial class SingleObjectCommand : Command
 [Schema(2025.798, "1 CommandId Guid ContainerId Guid TargetTypeId Guid CollectionId Guid TargetId Guid Data object")]
 [Schema(2025.799, "1 CommandId Guid ContainerId Guid TargetTypeId Guid CollectionId Guid TargetId Guid Data IBindableModel")]
 [Schema(2025.800, "1 CommandId Guid ContainerId Guid TargetTypeId Guid CollectionId Guid TargetId Guid Data object")]
-[Schema(2026.198, "1 CommandId Guid StreamId Guid TargetTypeId Guid CollectionId Guid TargetId Guid Data object")]
+[Schema(2026.198, "1 CommandId Guid StreamId Guid TargetTypeId Guid CollectionId Guid TargetId Guid Data ObjectData")]
 public partial class CreateObjectCommand : SingleObjectCommand
 {
 	protected override Task AcceptCoreAsync<T>(ICommandVisitor<T> visitor, T ctx) => visitor.VisitAsync(this, ctx);
 
-	public partial object Data { get; set; }
+	public required partial ObjectData Data { get; set; }
 }
 
 [SynqraModel]

--- a/Synqra.Model/Components/AddComponentCommand.cs
+++ b/Synqra.Model/Components/AddComponentCommand.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Synqra;
@@ -14,7 +15,7 @@ namespace Synqra;
 /// </para>
 /// </summary>
 [SynqraModel]
-[Schema(2026.405, "1 CommandId Guid StreamId Guid TargetTypeId Guid CollectionId Guid TargetId Guid ComponentTypeId Guid ComponentId Guid Data object?")]
+[Schema(2026.405, "1 CommandId Guid StreamId Guid TargetTypeId Guid CollectionId Guid TargetId Guid ComponentTypeId Guid ComponentId Guid Data ObjectData")]
 public partial class AddComponentCommand : SingleObjectCommand
 {
 	/// <summary>Synqra type-id of the component implementation being attached.</summary>
@@ -28,10 +29,23 @@ public partial class AddComponentCommand : SingleObjectCommand
 	public partial System.Guid ComponentId { get; set; }
 
 	/// <summary>
-	/// Initial payload for the component. Interpreted by the projection's
-	/// type-aware deserialization path; treated as opaque on the wire.
+	/// Canonical property bag for the component's payload — see <see cref="ObjectData"/>. Interpreted
+	/// by the projection's type-aware hydration path on replay; on the in-process create path,
+	/// <see cref="LiveComponent"/> is used instead (see its remarks for why).
 	/// </summary>
-	public partial object? Data { get; set; }
+	public required partial ObjectData Data { get; set; }
+
+	/// <summary>
+	/// The actual component instance the caller is holding, for the in-process create path. Unlike
+	/// <see cref="CreateObjectCommand.Data"/>/<see cref="ObjectCreatedEvent"/> (where the collection's
+	/// Add() attaches the live instance before submitting, so the projection's own attach-tracking
+	/// already resolves back to it), components have no equivalent pre-attach step — the projection
+	/// must get the caller's actual reference back from here so its generated property setters keep
+	/// routing subsequent writes through the store instead of silently mutating an orphaned copy.
+	/// Never serialized; null means "replay, rebuild purely from <see cref="Data"/>".
+	/// </summary>
+	[JsonIgnore]
+	public object? LiveComponent { get; set; }
 
 	protected override Task AcceptCoreAsync<T>(ICommandVisitor<T> visitor, T ctx)
 		=> visitor.VisitAsync(this, ctx);

--- a/Synqra.Model/Components/ComponentAddedEvent.cs
+++ b/Synqra.Model/Components/ComponentAddedEvent.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Synqra;
@@ -9,12 +10,18 @@ namespace Synqra;
 /// and (when applicable) firing <see cref="IActivatableComponent.Activate"/>.
 /// </summary>
 [SynqraModel]
-[Schema(2026.405, "1 EventId Guid CommandId Guid TargetId Guid TargetTypeId Guid CollectionId Guid ComponentTypeId Guid ComponentId Guid Data object?")]
+[Schema(2026.405, "1 EventId Guid CommandId Guid TargetId Guid TargetTypeId Guid CollectionId Guid ComponentTypeId Guid ComponentId Guid Data ObjectData")]
 public partial class ComponentAddedEvent : SingleObjectEvent
 {
 	public partial System.Guid ComponentTypeId { get; set; }
 	public partial System.Guid ComponentId { get; set; }
-	public partial object? Data { get; set; }
+
+	/// <summary>Canonical property bag for the component's payload — see <see cref="AddComponentCommand.Data"/>'s remarks.</summary>
+	public required partial ObjectData Data { get; set; }
+
+	/// <summary>The in-process create path's live instance — see <see cref="AddComponentCommand.LiveComponent"/>'s remarks. Never serialized.</summary>
+	[JsonIgnore]
+	public object? LiveComponent { get; set; }
 
 	protected override Task AcceptCoreAsync<T>(IEventVisitor<T> visitor, T ctx)
 		=> visitor.VisitAsync(this, ctx);

--- a/Synqra.Model/Components/StoreBoundComponentsCollection.cs
+++ b/Synqra.Model/Components/StoreBoundComponentsCollection.cs
@@ -112,7 +112,8 @@ public sealed class StoreBoundComponentsCollection : IComponentsCollection
 				TargetTypeId = containerTypeId,
 				ComponentTypeId = componentTypeId,
 				ComponentId = componentId,
-				Data = component,
+				Data = ObjectData.From(component),
+				LiveComponent = component,
 			},
 			new CommandSubmissionOptions { ExpectedLastEventId = _store.GetLastEventId(containerId) });
 		if (!OperatingSystem.IsBrowser())

--- a/Synqra.Model/Links/AddLinkCommand.cs
+++ b/Synqra.Model/Links/AddLinkCommand.cs
@@ -15,17 +15,16 @@ namespace Synqra;
 /// just to learn what a link connects.
 /// </para>
 /// <para>
-/// <see cref="Data"/> carries the link instance itself: the live object when submitted locally
-/// (matching <see cref="AddComponentCommand.Data"/>'s contract — which also redundantly carries
-/// the component's own id), or its serialized form on replay, resolved via <see cref="LinkTypeId"/>.
-/// This is where a concrete link subtype's <i>own</i> properties (e.g. <c>WeightedLink.Order</c>)
-/// travel; <see cref="SourceId"/>/<see cref="TargetId"/> being on the link instance too is
-/// redundant with the explicit fields above, not a second source of truth — the explicit fields
-/// win (see <see cref="LinkAddedEvent"/>'s remarks).
+/// <see cref="Data"/> is the canonical property bag (see <see cref="ObjectData"/>) for a concrete
+/// link subtype's <i>own</i> properties (e.g. <c>WeightedLink.Order</c>) — built via
+/// <see cref="ObjectData.From(object, ISet{string}?)"/> excluding
+/// <see cref="Link.WellKnownDataFields"/>, so <see cref="SourceId"/>/<see cref="TargetId"/> being on
+/// the link instance too never gets duplicated into the bag; the explicit fields above are the only
+/// copy (see <see cref="LinkAddedEvent"/>'s remarks).
 /// </para>
 /// </summary>
 [SynqraModel]
-[Schema(2026.501, "1 CommandId Guid StreamId Guid LinkTypeId Guid LinkId Guid SourceId Guid TargetId Guid Data object?")]
+[Schema(2026.501, "1 CommandId Guid StreamId Guid LinkTypeId Guid LinkId Guid SourceId Guid TargetId Guid Data ObjectData")]
 public partial class AddLinkCommand : Command
 {
 	/// <summary>Synqra type-id of the concrete link class being created.</summary>
@@ -40,8 +39,8 @@ public partial class AddLinkCommand : Command
 	/// <summary>Identity of the object at the link's target/to end. Mandatory.</summary>
 	public partial System.Guid TargetId { get; set; }
 
-	/// <summary>The link instance (or its rehydrated form on replay) — carries the concrete subtype's own properties, if any.</summary>
-	public partial object? Data { get; set; }
+	/// <summary>The concrete link subtype's own extra properties, if any — never LinkId/SourceId/TargetId (see remarks).</summary>
+	public required partial ObjectData Data { get; set; }
 
 	protected override Task AcceptCoreAsync<T>(ICommandVisitor<T> visitor, T ctx)
 		=> visitor.VisitAsync(this, ctx);

--- a/Synqra.Model/Links/Link.cs
+++ b/Synqra.Model/Links/Link.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Synqra;
 
 /// <summary>
@@ -56,4 +58,14 @@ public abstract partial class Link : IIdentifiable<Guid>
 		}
 		return ((IBindableModel)this).Store?.ResolveObject(id);
 	}
+
+	/// <summary>
+	/// Property names every concrete <see cref="Link"/> always carries that are already explicit,
+	/// top-level fields on <see cref="AddLinkCommand"/>/<see cref="LinkAddedEvent"/> — pass to
+	/// <see cref="ObjectData.From(object, ISet{string}?)"/> when normalizing a link instance
+	/// into <see cref="AddLinkCommand.Data"/> so the bag only ever carries a concrete subtype's own
+	/// extra properties (e.g. <c>WeightedLink.Order</c>), not a second copy of these three.
+	/// </summary>
+	public static readonly ISet<string> WellKnownDataFields =
+		new HashSet<string> { nameof(LinkId), nameof(SourceId), nameof(TargetId) };
 }

--- a/Synqra.Model/Links/LinkAddedEvent.cs
+++ b/Synqra.Model/Links/LinkAddedEvent.cs
@@ -17,7 +17,7 @@ namespace Synqra;
 /// </para>
 /// </summary>
 [SynqraModel]
-[Schema(2026.502, "1 EventId Guid CommandId Guid LinkTypeId Guid LinkId Guid SourceId Guid TargetId Guid Data object?")]
+[Schema(2026.502, "1 EventId Guid CommandId Guid LinkTypeId Guid LinkId Guid SourceId Guid TargetId Guid Data ObjectData")]
 public partial class LinkAddedEvent : Event
 {
 	public partial System.Guid LinkTypeId { get; set; }
@@ -29,8 +29,8 @@ public partial class LinkAddedEvent : Event
 	/// <summary>Identity of the object at the link's target/to end. Mandatory, authoritative over whatever <see cref="Data"/> carries.</summary>
 	public partial System.Guid TargetId { get; set; }
 
-	/// <summary>The link instance (or its rehydrated form on replay) — carries the concrete subtype's own properties, if any.</summary>
-	public partial object? Data { get; set; }
+	/// <summary>The concrete link subtype's own extra properties, if any — never LinkId/SourceId/TargetId (see <see cref="AddLinkCommand"/>'s remarks).</summary>
+	public required partial ObjectData Data { get; set; }
 
 	protected override Task AcceptCoreAsync<T>(IEventVisitor<T> visitor, T ctx)
 		=> visitor.VisitAsync(this, ctx);

--- a/Synqra.Model/Links/LinkCollections.cs
+++ b/Synqra.Model/Links/LinkCollections.cs
@@ -205,7 +205,7 @@ public abstract class LinkNavCollectionBase<TItem, TLink> : ICollection<TItem>, 
 			LinkId = link.LinkId,
 			SourceId = link.SourceId,
 			TargetId = link.TargetId,
-			Data = link,
+			Data = ObjectData.From(link, Link.WellKnownDataFields),
 		});
 		RunSync(task);
 	}

--- a/Synqra.Model/ObjectCreatedEvent.cs
+++ b/Synqra.Model/ObjectCreatedEvent.cs
@@ -25,36 +25,23 @@ namespace Synqra;
 [Schema(2026.167, "1 EventId Guid CommandId Guid ContainerId Guid TargetId Guid TargetTypeId Guid CollectionId Guid Data object? DataObject object?")]
 [Schema(2026.168, "1 EventId Guid CommandId Guid TargetId Guid TargetTypeId Guid CollectionId Guid Data object?")]
 [Schema(2026.169, "1 EventId Guid CommandId Guid ContainerId Guid TargetId Guid TargetTypeId Guid CollectionId Guid Data object? DataObject object?")]
-[Schema(2026.170, "1 EventId Guid CommandId Guid TargetId Guid TargetTypeId Guid CollectionId Guid Data object?")]
+[Schema(2026.170, "1 EventId Guid CommandId Guid TargetId Guid TargetTypeId Guid CollectionId Guid Data ObjectData")]
 public partial class ObjectCreatedEvent : SingleObjectEvent
 {
-	// public partial IDictionary<string, object?>? Data { get; set; }
-	public partial object? Data { get; set; }
+	/// <summary>
+	/// Canonical property-bag payload for the created object — always present, though it may be
+	/// empty. The locally-emitted create path additionally carries the live instance in
+	/// <see cref="MaterializedObject"/> so the projection can skip rebuilding from this bag.
+	/// </summary>
+	public required partial ObjectData Data { get; set; }
 
+	/// <summary>
+	/// In-memory materialized instance, set on the locally-emitted create path so the
+	/// projection can attach the very object the caller created instead of rebuilding it
+	/// from <see cref="Data"/>. Never serialized — it is a process-local optimization only.
+	/// </summary>
 	[JsonIgnore]
-	public object? DataObject { get; set; } // InMemory materialized object
-
-	partial void OnDataChanging(object? oldValue, object? value)
-	{
-		if (value is IDictionary<string, object?> dict)
-		{
-			throw new NotImplementedException();
-		}
-		else if (value is string s)
-		{
-			throw new NotImplementedException();
-		}
-		else if (value is IBindableModel bm)
-		{
-			// This is allowed for now. Caution - it is not read only and might be changed after the event is created, which can lead to unexpected behavior.
-			// It is recommended to use immutable data structures for event data to ensure consistency and reliability.
-		}
-		else
-		{
-			// PoCo is also allowed for now, because there are already existing tests
-			// throw new NotImplementedException();
-		}
-	}
+	public object? MaterializedObject { get; set; }
 
 	protected override Task AcceptCoreAsync<T>(IEventVisitor<T> visitor, T ctx) => visitor.VisitAsync(this, ctx);
 }

--- a/Synqra.Model/ObjectCreatedEvent.cs
+++ b/Synqra.Model/ObjectCreatedEvent.cs
@@ -30,18 +30,10 @@ public partial class ObjectCreatedEvent : SingleObjectEvent
 {
 	/// <summary>
 	/// Canonical property-bag payload for the created object — always present, though it may be
-	/// empty. The locally-emitted create path additionally carries the live instance in
-	/// <see cref="MaterializedObject"/> so the projection can skip rebuilding from this bag.
+	/// empty. Projections rebuild the live instance from this bag on replay; on the locally-emitted
+	/// create path they instead reuse the instance they already tracked via their own Attach call.
 	/// </summary>
 	public required partial ObjectData Data { get; set; }
-
-	/// <summary>
-	/// In-memory materialized instance, set on the locally-emitted create path so the
-	/// projection can attach the very object the caller created instead of rebuilding it
-	/// from <see cref="Data"/>. Never serialized — it is a process-local optimization only.
-	/// </summary>
-	[JsonIgnore]
-	public object? MaterializedObject { get; set; }
 
 	protected override Task AcceptCoreAsync<T>(IEventVisitor<T> visitor, T ctx) => visitor.VisitAsync(this, ctx);
 }

--- a/Synqra.Model/ObjectData.cs
+++ b/Synqra.Model/ObjectData.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace Synqra;
 
@@ -10,6 +11,7 @@ namespace Synqra;
 /// SBX binary serializer's existing <c>IDictionary&lt;string, object?&gt;</c> detection
 /// picks it up without bespoke generator support.
 /// </summary>
+[JsonConverter(typeof(ObjectDataJsonConverter))]
 public sealed class ObjectData : Dictionary<string, object?>
 {
 	public ObjectData()
@@ -32,24 +34,36 @@ public sealed class ObjectData : Dictionary<string, object?>
 	/// Normalizes a creation payload into the canonical property-bag shape. Accepts an
 	/// already-canonical <see cref="ObjectData"/>, any other <see cref="IDictionary{String, Object}"/>,
 	/// or a POCO/anonymous-object/<see cref="IBindableModel"/> instance — reflecting its
-	/// readable+writable properties and skipping ones still at their type's default value.
-	/// This is the single normalization site; consumers (reducers, projections) only ever see
-	/// the resulting dictionary and never need to branch on the original input's shape.
+	/// readable+writable, non-<see cref="JsonIgnoreAttribute"/> properties and skipping ones still
+	/// at their type's default value. This is the single normalization site; consumers (reducers,
+	/// projections) only ever see the resulting dictionary and never need to branch on the original
+	/// input's shape.
 	/// </summary>
-	public static ObjectData From(object source)
+	/// <param name="exclude">
+	/// Property names to omit even if present on <paramref name="source"/> — for fields that are
+	/// already explicit, structural members elsewhere on the wrapping command/event (e.g. a link's
+	/// own <c>LinkId</c>/<c>SourceId</c>/<c>TargetId</c>, already top-level fields on
+	/// <c>AddLinkCommand</c>/<c>LinkAddedEvent</c>; carrying them again inside the bag would just be
+	/// a second, driftable copy of the same value).
+	/// </param>
+	public static ObjectData From(object source, ISet<string>? exclude = null)
 	{
 		switch (source)
 		{
 			case null:
 				throw new ArgumentNullException(nameof(source));
 			case ObjectData already:
-				return already;
+				return exclude is null ? already : Filtered(already, exclude);
 			case IDictionary<string, object?> dict:
-				return new ObjectData(dict);
+				return Filtered(dict, exclude);
 			default:
 				var result = new ObjectData();
 				foreach (var pro in source.GetType().GetProperties().Where(p => p.CanRead && p.CanWrite))
 				{
+					if (exclude?.Contains(pro.Name) == true || HasJsonIgnore(pro))
+					{
+						continue;
+					}
 					var value = pro.GetValue(source);
 					if (Equals(value, pro.PropertyType.GetDefault()))
 					{
@@ -60,4 +74,20 @@ public sealed class ObjectData : Dictionary<string, object?>
 				return result;
 		}
 	}
+
+	static ObjectData Filtered(IEnumerable<KeyValuePair<string, object?>> source, ISet<string>? exclude)
+	{
+		var result = new ObjectData();
+		foreach (var kvp in source)
+		{
+			if (exclude?.Contains(kvp.Key) != true)
+			{
+				result[kvp.Key] = kvp.Value;
+			}
+		}
+		return result;
+	}
+
+	static bool HasJsonIgnore(System.Reflection.PropertyInfo property) =>
+		property.GetCustomAttributes(typeof(JsonIgnoreAttribute), inherit: true).Length > 0;
 }

--- a/Synqra.Model/ObjectData.cs
+++ b/Synqra.Model/ObjectData.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+
+namespace Synqra;
+
+/// <summary>
+/// Canonical property-bag shape for the payload of object-creation commands/events
+/// (<see cref="CreateObjectCommand.Data"/>, <see cref="ObjectCreatedEvent.Data"/>).
+/// Backed by <see cref="Dictionary{TKey, TValue}"/> (rather than an ordered list) so
+/// it stays compatible with per-property "extra"/overflow handling later, and so the
+/// SBX binary serializer's existing <c>IDictionary&lt;string, object?&gt;</c> detection
+/// picks it up without bespoke generator support.
+/// </summary>
+public sealed class ObjectData : Dictionary<string, object?>
+{
+	public ObjectData()
+	{
+	}
+
+	public ObjectData(IDictionary<string, object?> source) : base(source)
+	{
+	}
+
+	public ObjectData(IEnumerable<KeyValuePair<string, object?>> source)
+	{
+		foreach (var kvp in source)
+		{
+			this[kvp.Key] = kvp.Value;
+		}
+	}
+
+	/// <summary>
+	/// Normalizes a creation payload into the canonical property-bag shape. Accepts an
+	/// already-canonical <see cref="ObjectData"/>, any other <see cref="IDictionary{String, Object}"/>,
+	/// or a POCO/anonymous-object/<see cref="IBindableModel"/> instance — reflecting its
+	/// readable+writable properties and skipping ones still at their type's default value.
+	/// This is the single normalization site; consumers (reducers, projections) only ever see
+	/// the resulting dictionary and never need to branch on the original input's shape.
+	/// </summary>
+	public static ObjectData From(object source)
+	{
+		switch (source)
+		{
+			case null:
+				throw new ArgumentNullException(nameof(source));
+			case ObjectData already:
+				return already;
+			case IDictionary<string, object?> dict:
+				return new ObjectData(dict);
+			default:
+				var result = new ObjectData();
+				foreach (var pro in source.GetType().GetProperties().Where(p => p.CanRead && p.CanWrite))
+				{
+					var value = pro.GetValue(source);
+					if (Equals(value, pro.PropertyType.GetDefault()))
+					{
+						continue;
+					}
+					result[pro.Name] = value;
+				}
+				return result;
+		}
+	}
+}

--- a/Synqra.Model/ObjectDataJsonConverter.cs
+++ b/Synqra.Model/ObjectDataJsonConverter.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Synqra;
+
+public sealed class ObjectDataJsonConverter : JsonConverter<ObjectData>
+{
+	public override ObjectData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		if (reader.TokenType != JsonTokenType.StartObject)
+		{
+			throw new JsonException($"Expected {JsonTokenType.StartObject}, got {reader.TokenType}");
+		}
+
+		var result = new ObjectData();
+		while (reader.Read())
+		{
+			if (reader.TokenType == JsonTokenType.EndObject)
+			{
+				return result;
+			}
+			if (reader.TokenType != JsonTokenType.PropertyName)
+			{
+				throw new JsonException($"Expected {JsonTokenType.PropertyName}, got {reader.TokenType}");
+			}
+
+			var name = reader.GetString() ?? throw new JsonException("ObjectData property name was null");
+			if (!reader.Read())
+			{
+				throw new JsonException("Unexpected end of ObjectData JSON");
+			}
+			result[name] = JsonSerializer.Deserialize<object?>(ref reader, options);
+		}
+
+		throw new JsonException("Unexpected end of ObjectData JSON");
+	}
+
+	public override void Write(Utf8JsonWriter writer, ObjectData value, JsonSerializerOptions options)
+	{
+		writer.WriteStartObject();
+		foreach (var kvp in value)
+		{
+			writer.WritePropertyName(kvp.Key);
+			JsonSerializer.Serialize(writer, kvp.Value, options);
+		}
+		writer.WriteEndObject();
+	}
+}

--- a/Synqra.Projection.CommonStoreSupport/ComponentAndLinkApplyHelpers.cs
+++ b/Synqra.Projection.CommonStoreSupport/ComponentAndLinkApplyHelpers.cs
@@ -1,6 +1,41 @@
 namespace Synqra.Projection;
 
 /// <summary>
+/// Applies a canonical <see cref="ObjectData"/> property bag onto a freshly-created instance — the
+/// one hydration routine every "materialize from replay" path (object, component, link) shares.
+/// Uses the bindable-model <c>Set</c> path for SynqraModel types (no reflection); falls back to
+/// reflection for plain POCOs, converting <see cref="IConvertible"/> values to each target
+/// property's declared type.
+/// </summary>
+public static class ObjectDataApplyHelpers
+{
+	public static void HydrateFromData(object instance, Type type, ObjectData data)
+	{
+		if (instance is IBindableModel bindable)
+		{
+			foreach (var (key, value) in data)
+			{
+				bindable.Set(key, value);
+			}
+		}
+		else
+		{
+			foreach (var (key, value) in data)
+			{
+				var pi = type.GetProperty(key);
+				if (pi is null) continue;
+				var v = value;
+				if (v is IConvertible c)
+				{
+					v = c.ToType(pi.PropertyType, System.Globalization.CultureInfo.InvariantCulture);
+				}
+				pi.SetValue(instance, v);
+			}
+		}
+	}
+}
+
+/// <summary>
 /// Pure materialization/addressing logic shared by every projection's component event-apply path
 /// (<see cref="InMemory.InMemoryProjection"/>, <see cref="MongoDb.MongoProjection"/> — referenced by
 /// namespace in this doc comment only; this project doesn't depend on either). Each projection still
@@ -86,29 +121,7 @@ public static class ComponentApplyHelpers
 			?? throw new InvalidOperationException($"Could not instantiate component '{componentType.Name}'.");
 		var component = (IComponent)instance;
 
-		// Hydrate via the bindable-model Set path when the component is a SynqraModel; fall back to
-		// reflection otherwise.
-		if (component is IBindableModel bindable)
-		{
-			foreach (var (key, value) in data)
-			{
-				bindable.Set(key, value);
-			}
-		}
-		else
-		{
-			foreach (var (key, value) in data)
-			{
-				var pi = componentType.GetProperty(key);
-				if (pi is null) continue;
-				var v = value;
-				if (v is IConvertible c)
-				{
-					v = c.ToType(pi.PropertyType, System.Globalization.CultureInfo.InvariantCulture);
-				}
-				pi.SetValue(component, v);
-			}
-		}
+		ObjectDataApplyHelpers.HydrateFromData(component, componentType, data);
 		return component;
 	}
 }
@@ -130,27 +143,7 @@ public static class LinkApplyHelpers
 		var instance = (Link)(Activator.CreateInstance(linkType)
 			?? throw new InvalidOperationException($"Could not instantiate link '{linkType.Name}'."));
 
-		if (instance is IBindableModel bindable)
-		{
-			foreach (var (key, value) in data)
-			{
-				bindable.Set(key, value);
-			}
-		}
-		else
-		{
-			foreach (var (key, value) in data)
-			{
-				var pi = linkType.GetProperty(key);
-				if (pi is null) continue;
-				var v = value;
-				if (v is IConvertible c)
-				{
-					v = c.ToType(pi.PropertyType, System.Globalization.CultureInfo.InvariantCulture);
-				}
-				pi.SetValue(instance, v);
-			}
-		}
+		ObjectDataApplyHelpers.HydrateFromData(instance, linkType, data);
 		return instance;
 	}
 }

--- a/Synqra.Projection.CommonStoreSupport/ComponentAndLinkApplyHelpers.cs
+++ b/Synqra.Projection.CommonStoreSupport/ComponentAndLinkApplyHelpers.cs
@@ -68,13 +68,16 @@ public static class ComponentApplyHelpers
 	};
 
 	/// <summary>
-	/// Three cases: <paramref name="data"/> is already an instance of <paramref name="componentType"/>
-	/// (typical when emitted locally); a json-shaped <see cref="IDictionary{TKey, TValue}"/>
-	/// (post-rehydrate from the event store); or null (component has no payload, e.g. a bare marker).
+	/// Two cases: <paramref name="liveInstance"/> is already an instance of <paramref name="componentType"/>
+	/// (the in-process create path — the caller's own component must come back, not a copy, since the
+	/// generated property setters on whatever <see cref="AttachToContainer"/>-equivalent wiring runs next
+	/// route subsequent writes through it; a fresh copy would leave the caller's reference permanently
+	/// detached from the store); or it's absent (replay/cross-process), so a fresh instance is constructed
+	/// and hydrated from <paramref name="data"/>, the canonical property bag.
 	/// </summary>
-	public static IComponent MaterializeComponent(Type componentType, object? data)
+	public static IComponent MaterializeComponent(Type componentType, object? liveInstance, ObjectData data)
 	{
-		if (data is IComponent ready && componentType.IsInstanceOfType(ready))
+		if (liveInstance is IComponent ready && componentType.IsInstanceOfType(ready))
 		{
 			return ready;
 		}
@@ -83,18 +86,18 @@ public static class ComponentApplyHelpers
 			?? throw new InvalidOperationException($"Could not instantiate component '{componentType.Name}'.");
 		var component = (IComponent)instance;
 
-		// Hydrate from dictionary via the bindable-model set path when the component is a
-		// SynqraModel; fall back to reflection otherwise.
-		if (data is IDictionary<string, object?> bag && component is IBindableModel bindable)
+		// Hydrate via the bindable-model Set path when the component is a SynqraModel; fall back to
+		// reflection otherwise.
+		if (component is IBindableModel bindable)
 		{
-			foreach (var (key, value) in bag)
+			foreach (var (key, value) in data)
 			{
 				bindable.Set(key, value);
 			}
 		}
-		else if (data is IDictionary<string, object?> reflectBag)
+		else
 		{
-			foreach (var (key, value) in reflectBag)
+			foreach (var (key, value) in data)
 			{
 				var pi = componentType.GetProperty(key);
 				if (pi is null) continue;
@@ -113,27 +116,30 @@ public static class ComponentApplyHelpers
 /// <summary>Pure materialization logic shared by every projection's link event-apply path.</summary>
 public static class LinkApplyHelpers
 {
-	/// <summary>Same three-case materialization <see cref="ComponentApplyHelpers.MaterializeComponent"/> uses: live instance, json-shaped dict, or fresh instance with no payload.</summary>
-	public static Link MaterializeLink(Type linkType, object? data)
+	/// <summary>
+	/// Always constructs a fresh instance and hydrates it from <paramref name="data"/> — no "reuse the
+	/// live instance" fast path, unlike <see cref="ComponentApplyHelpers.MaterializeComponent"/>, because
+	/// nothing downstream of link creation relies on reference identity: every nav-collection read
+	/// re-queries the store's <c>ILinkIndex</c> rather than caching the caller's submitted instance, and
+	/// links have no post-creation property-change command. <c>LinkId</c>/<c>SourceId</c>/<c>TargetId</c>
+	/// are re-stamped from the event's own explicit fields by the caller regardless of what
+	/// <paramref name="data"/> carries (see <c>LinkAddedEvent</c>'s remarks).
+	/// </summary>
+	public static Link MaterializeLink(Type linkType, ObjectData data)
 	{
-		if (data is Link ready && linkType.IsInstanceOfType(ready))
-		{
-			return ready;
-		}
-
 		var instance = (Link)(Activator.CreateInstance(linkType)
 			?? throw new InvalidOperationException($"Could not instantiate link '{linkType.Name}'."));
 
-		if (data is IDictionary<string, object?> bag && instance is IBindableModel bindable)
+		if (instance is IBindableModel bindable)
 		{
-			foreach (var (key, value) in bag)
+			foreach (var (key, value) in data)
 			{
 				bindable.Set(key, value);
 			}
 		}
-		else if (data is IDictionary<string, object?> reflectBag)
+		else
 		{
-			foreach (var (key, value) in reflectBag)
+			foreach (var (key, value) in data)
 			{
 				var pi = linkType.GetProperty(key);
 				if (pi is null) continue;

--- a/Synqra.Projection.File/_DI.cs
+++ b/Synqra.Projection.File/_DI.cs
@@ -716,7 +716,6 @@ public static class FileSynqraExtensions
 				TargetTypeId = cmd.TargetTypeId,
 				TargetId = cmd.TargetId,
 				Data = cmd.Data,
-				MaterializedObject = cmd.TargetObject ?? throw new ArgumentException(nameof(cmd)), // or may be entire object
 			};
 			ctx.Events.Add(created);
 
@@ -800,16 +799,17 @@ public static class FileSynqraExtensions
 
 		public async Task VisitAsync(ObjectCreatedEvent ev, EventVisitorContext ctx)
 		{
-			if (ev.MaterializedObject == null)
-			{
-				throw new NotImplementedException();
-			}
+			// Locally-emitted create path: the collection's Add() already attached this exact
+			// instance before submitting the command, so it's already tracked under this id.
+			// Replay without a prior Attach isn't supported by this projection yet.
+			var model = _objectStore.GetAttachedObject(ev.TargetId)
+				?? throw new NotImplementedException("ObjectCreatedEvent replay without an attached instance is not yet supported by the File projection.");
 			await _appendStores.ItemAppendStorage.AppendAsync(new Item
 			{
 				ObjectId = ev.TargetId,
 				StreamId = ev.StreamId,
 				CollectionId = ev.CollectionId,
-				Blob = ev.MaterializedObject,
+				Blob = model,
 			});
 		}
 

--- a/Synqra.Projection.File/_DI.cs
+++ b/Synqra.Projection.File/_DI.cs
@@ -484,7 +484,7 @@ public static class FileSynqraExtensions
 				TargetTypeId = _store.TypeMetadataProvider.GetTypeMetadata(typeof(T)).TypeId,
 				CommandId = _store.GuidGenerator.CreateVersion7(), // This is a new object, so we generate a new command Id
 				TargetId = attachedData.Id,
-				Data = item,
+				Data = ObjectData.From(item),
 				TargetObject = item,
 			});
 			if (!OperatingSystem.IsBrowser())
@@ -716,41 +716,30 @@ public static class FileSynqraExtensions
 				TargetTypeId = cmd.TargetTypeId,
 				TargetId = cmd.TargetId,
 				Data = cmd.Data,
-				DataObject = cmd.TargetObject ?? throw new ArgumentException(nameof(cmd)), // or may be entire object
+				MaterializedObject = cmd.TargetObject ?? throw new ArgumentException(nameof(cmd)), // or may be entire object
 			};
 			ctx.Events.Add(created);
 
-			if (false && cmd.Data is IBindableModel bm)
+			// cmd.Data is the canonical property bag (normalized by ObjectData.From at the command
+			// boundary, defaults already filtered) — fan it out into one change event per entry.
+			foreach (var (propertyName, value) in cmd.Data)
 			{
-
-			}
-			else
-			{
-				var pros = cmd.Data.GetType().GetProperties().Where(x => x.CanWrite && x.CanRead);
-				foreach (var pro in pros)
+				if (value is null)
 				{
-					var value = pro.GetValue(cmd.Data);
-					// SynqraTypeExtensions
-					if (Equals(value, pro.PropertyType.GetDefault()))
-					{
-						continue;
-					}
-					if (value != null)
-					{
-						ctx.Events.Add(new ObjectPropertyChangedEvent
-						{
-							StreamId = cmd.StreamId,
-							CommandId = cmd.CommandId,
-							CollectionId = cmd.CollectionId,
-							EventId = GuidExtensions.CreateVersion7(),
-							TargetTypeId = cmd.TargetTypeId,
-							TargetId = cmd.TargetId,
-							PropertyName = pro.Name,
-							OldValue = null,
-							NewValue = value,
-						});
-					}
+					continue;
 				}
+				ctx.Events.Add(new ObjectPropertyChangedEvent
+				{
+					StreamId = cmd.StreamId,
+					CommandId = cmd.CommandId,
+					CollectionId = cmd.CollectionId,
+					EventId = GuidExtensions.CreateVersion7(),
+					TargetTypeId = cmd.TargetTypeId,
+					TargetId = cmd.TargetId,
+					PropertyName = propertyName,
+					OldValue = null,
+					NewValue = value,
+				});
 			}
 
 			/*
@@ -811,7 +800,7 @@ public static class FileSynqraExtensions
 
 		public async Task VisitAsync(ObjectCreatedEvent ev, EventVisitorContext ctx)
 		{
-			if (ev.DataObject == null)
+			if (ev.MaterializedObject == null)
 			{
 				throw new NotImplementedException();
 			}
@@ -820,7 +809,7 @@ public static class FileSynqraExtensions
 				ObjectId = ev.TargetId,
 				StreamId = ev.StreamId,
 				CollectionId = ev.CollectionId,
-				Blob = ev.DataObject,
+				Blob = ev.MaterializedObject,
 			});
 		}
 

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -622,7 +622,6 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			TargetId = cmd.TargetId,
 			Data = cmd.Data,
 			// DataString = cmd.DataJson, // if json is cached here, let's use it to save on serialization
-			MaterializedObject = cmd.TargetObject, // or may be entire object
 		};
 		ctx.Events.Add(created);
 
@@ -832,13 +831,10 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		}
 
 		object newItem;
-		if (ev.MaterializedObject != null)
+		if (TryGetModel(ev.TargetId, out var data))
 		{
-			// Locally-emitted create path: attach the very instance the caller created.
-			newItem = ev.MaterializedObject;
-		}
-		else if (TryGetModel(ev.TargetId, out var data))
-		{
+			// Locally-emitted create path: the collection's Add() already attached this exact
+			// instance before submitting the command, so it's already tracked under this id.
 			newItem = data.Model;
 		}
 		else

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -620,51 +620,33 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			CommandId = cmd.CommandId,
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
-			// Data = cmd.Data,
+			Data = cmd.Data,
 			// DataString = cmd.DataJson, // if json is cached here, let's use it to save on serialization
-			DataObject = cmd.TargetObject, // or may be entire object
+			MaterializedObject = cmd.TargetObject, // or may be entire object
 		};
 		ctx.Events.Add(created);
 
-		if (false && cmd.TargetObject is IBindableModel bm) // I just found it out while debugging, do not remember why originally, but it is likely because it is not implemented yet (and still not)
+		// cmd.Data is the canonical property bag (already normalized by ObjectData.From at the
+		// command boundary, with default-valued properties filtered out), so we just fan it out
+		// into one ObjectPropertyChangedEvent per non-null entry — no reflection, no type-sniffing.
+		foreach (var (propertyName, value) in cmd.Data)
 		{
-			
-		}
-		else
-		{
-			var pros = cmd.Data.GetType().GetProperties().Where(x => x.CanWrite && x.CanRead);
-			foreach (var pro in pros)
+			if (value is null)
 			{
-				// Skip computed/navigation accessors flagged as non-persisted (e.g. an edge's typed
-				// Source/Target, which merely project the scalar id columns). Persisting them would
-				// emit the whole referenced object as a property value and, on replay, set it before
-				// the scalar ids — corrupting reconstruction.
-				if (pro.GetCustomAttributes(typeof(JsonIgnoreAttribute), inherit: true).Length > 0)
-				{
-					continue;
-				}
-				var value = pro.GetValue(cmd.Data);
-				// SynqraTypeExtensions
-				if (Equals(value, pro.PropertyType.GetDefault()))
-				{
-					continue;
-				}
-				if (value != null)
-				{
-					ctx.Events.Add(new ObjectPropertyChangedEvent
-					{
-						StreamId = cmd.StreamId,
-						CommandId = cmd.CommandId,
-						CollectionId = cmd.CollectionId,
-						EventId = GuidExtensions.CreateVersion7(),
-						TargetTypeId = cmd.TargetTypeId,
-						TargetId = cmd.TargetId,
-						PropertyName = pro.Name,
-						OldValue = null,
-						NewValue = value,
-					});
-				}
+				continue;
 			}
+			ctx.Events.Add(new ObjectPropertyChangedEvent
+			{
+				StreamId = cmd.StreamId,
+				CommandId = cmd.CommandId,
+				CollectionId = cmd.CollectionId,
+				EventId = GuidExtensions.CreateVersion7(),
+				TargetTypeId = cmd.TargetTypeId,
+				TargetId = cmd.TargetId,
+				PropertyName = propertyName,
+				OldValue = null,
+				NewValue = value,
+			});
 		}
 
 		/*
@@ -850,27 +832,24 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		}
 
 		object newItem;
-		if (ev.DataObject != null)
+		if (ev.MaterializedObject != null)
 		{
-			newItem = ev.DataObject;
+			// Locally-emitted create path: attach the very instance the caller created.
+			newItem = ev.MaterializedObject;
 		}
 		else if (TryGetModel(ev.TargetId, out var data))
 		{
 			newItem = data.Model;
 		}
-		/*
-		else if (ev.DataString != null)
-		{
-			newItem = JsonSerializer.Deserialize(ev.DataString, typeMetadata.Type, _jsonSerializerOptions);
-		}
-		*/
-		else if (ev.Data != null)
-		{
-			newItem = ev.Data; //JsonSerializer.Deserialize(JsonSerializer.Serialize<IDictionary<string, object?>?>(ev.Data, _jsonSerializerOptions), typeMetadata.Type, _jsonSerializerOptions);
-		}
 		else
 		{
-			newItem = Activator.CreateInstance(typeMetadata.Type);
+			// Replayed/deserialized event: rebuild the instance from the canonical property bag.
+			newItem = Activator.CreateInstance(typeMetadata.Type)
+				?? throw new InvalidOperationException($"Could not instantiate '{typeMetadata.Type.Name}'.");
+			if (ev.Data.Count > 0)
+			{
+				HydrateFromData(newItem, typeMetadata.Type, ev.Data);
+			}
 		}
 
 		/*
@@ -1214,6 +1193,34 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	{
 		TryGetModel(targetId, out var data);
 		return ComponentApplyHelpers.ResolveContainer(data.Model, targetId);
+	}
+
+	// Apply a canonical property bag onto a freshly-created instance. Uses the bindable-model
+	// Set path for SynqraModel objects (no reflection) and falls back to reflection for plain
+	// POCOs, converting IConvertible values to each target property's type.
+	static void HydrateFromData(object instance, Type type, ObjectData data)
+	{
+		if (instance is IBindableModel bindable)
+		{
+			foreach (var (key, value) in data)
+			{
+				bindable.Set(key, value);
+			}
+		}
+		else
+		{
+			foreach (var (key, value) in data)
+			{
+				var pi = type.GetProperty(key);
+				if (pi is null) continue;
+				var v = value;
+				if (v is IConvertible c)
+				{
+					v = c.ToType(pi.PropertyType, System.Globalization.CultureInfo.InvariantCulture);
+				}
+				pi.SetValue(instance, v);
+			}
+		}
 	}
 
 	#endregion

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -720,6 +720,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			ComponentTypeId = cmd.ComponentTypeId,
 			ComponentId = cmd.ComponentId,
 			Data = cmd.Data,
+			LiveComponent = cmd.LiveComponent,
 		});
 		return Task.CompletedTask;
 	}
@@ -1073,7 +1074,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		// reuse the model-binding pathway so JSON payloads round-trip the same way
 		// as for normal SynqraModel objects.
 		var componentType = TypeMetadataProvider.GetTypeMetadata(ev.ComponentTypeId).Type;
-		var component = ComponentApplyHelpers.MaterializeComponent(componentType, ev.Data);
+		var component = ComponentApplyHelpers.MaterializeComponent(componentType, ev.LiveComponent, ev.Data);
 
 		if (!container.Components.TryAdd(component))
 		{

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -845,7 +845,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 				?? throw new InvalidOperationException($"Could not instantiate '{typeMetadata.Type.Name}'.");
 			if (ev.Data.Count > 0)
 			{
-				HydrateFromData(newItem, typeMetadata.Type, ev.Data);
+				ObjectDataApplyHelpers.HydrateFromData(newItem, typeMetadata.Type, ev.Data);
 			}
 		}
 
@@ -1190,34 +1190,6 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	{
 		TryGetModel(targetId, out var data);
 		return ComponentApplyHelpers.ResolveContainer(data.Model, targetId);
-	}
-
-	// Apply a canonical property bag onto a freshly-created instance. Uses the bindable-model
-	// Set path for SynqraModel objects (no reflection) and falls back to reflection for plain
-	// POCOs, converting IConvertible values to each target property's type.
-	static void HydrateFromData(object instance, Type type, ObjectData data)
-	{
-		if (instance is IBindableModel bindable)
-		{
-			foreach (var (key, value) in data)
-			{
-				bindable.Set(key, value);
-			}
-		}
-		else
-		{
-			foreach (var (key, value) in data)
-			{
-				var pi = type.GetProperty(key);
-				if (pi is null) continue;
-				var v = value;
-				if (v is IConvertible c)
-				{
-					v = c.ToType(pi.PropertyType, System.Globalization.CultureInfo.InvariantCulture);
-				}
-				pi.SetValue(instance, v);
-			}
-		}
 	}
 
 	#endregion

--- a/Synqra.Projection.InMemory/StoreCollection.cs
+++ b/Synqra.Projection.InMemory/StoreCollection.cs
@@ -138,8 +138,7 @@ internal class InMemoryStoreCollection<[DynamicallyAccessedMembers(DynamicallyAc
 			TargetTypeId = _store.TypeMetadataProvider.GetTypeMetadata(typeof(T)).TypeId,
 			CommandId = GuidExtensions.CreateVersion7(), // This is a new object, so we generate a new command Id
 			TargetId = attachedData.Id,
-			Data = item, // data?.Count > 0 ? data : null,
-						 // DataJson = dataJson,
+			Data = ObjectData.From(item),
 			TargetObject = item,
 		});
 		if (OperatingSystem.IsBrowser())

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -339,15 +339,16 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			CommandId = cmd.CommandId,
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
-			DataObject = cmd.TargetObject,
+			Data = cmd.Data,
+			MaterializedObject = cmd.TargetObject,
 		});
 
-		// Seed each non-default property as a change event so the materialized document carries the
-		// initial values (and a fresh projection can rebuild them by replay if the doc is ever dropped).
-		foreach (var pi in cmd.Data.GetType().GetProperties().Where(p => p.CanRead && p.CanWrite))
+		// Seed each property as a change event so the materialized document carries the initial
+		// values (and a fresh projection can rebuild them by replay if the doc is ever dropped).
+		// cmd.Data is the canonical bag, already normalized with default-valued properties dropped.
+		foreach (var (propertyName, value) in cmd.Data)
 		{
-			var value = pi.GetValue(cmd.Data);
-			if (value is null || Equals(value, pi.PropertyType.GetDefault()))
+			if (value is null)
 			{
 				continue;
 			}
@@ -359,7 +360,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 				EventId = GuidExtensions.CreateVersion7(),
 				TargetTypeId = cmd.TargetTypeId,
 				TargetId = cmd.TargetId,
-				PropertyName = pi.Name,
+				PropertyName = propertyName,
 				OldValue = null,
 				NewValue = value,
 			});
@@ -480,9 +481,9 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	{
 		var type = TypeMetadataProvider.GetTypeMetadata(ev.TargetTypeId).Type;
 		object model;
-		if (ev.DataObject is not null)
+		if (ev.MaterializedObject is not null)
 		{
-			model = ev.DataObject;
+			model = ev.MaterializedObject;
 		}
 		else if (TryGetTracked(ev.TargetId, out var tracked))
 		{

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -340,7 +340,6 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
 			Data = cmd.Data,
-			MaterializedObject = cmd.TargetObject,
 		});
 
 		// Seed each property as a change event so the materialized document carries the initial
@@ -481,12 +480,10 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	{
 		var type = TypeMetadataProvider.GetTypeMetadata(ev.TargetTypeId).Type;
 		object model;
-		if (ev.MaterializedObject is not null)
+		if (TryGetTracked(ev.TargetId, out var tracked))
 		{
-			model = ev.MaterializedObject;
-		}
-		else if (TryGetTracked(ev.TargetId, out var tracked))
-		{
+			// Locally-emitted create path: the collection's Add() already attached this exact
+			// instance before submitting the command, so it's already tracked under this id.
 			model = tracked;
 		}
 		else

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -401,6 +401,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			ComponentTypeId = cmd.ComponentTypeId,
 			ComponentId = cmd.ComponentId,
 			Data = cmd.Data,
+			LiveComponent = cmd.LiveComponent,
 		});
 		return Task.CompletedTask;
 	}
@@ -532,7 +533,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		var container = ResolveContainer(ev.TargetId);
 
 		var componentType = TypeMetadataProvider.GetTypeMetadata(ev.ComponentTypeId).Type;
-		var component = ComponentApplyHelpers.MaterializeComponent(componentType, ev.Data);
+		var component = ComponentApplyHelpers.MaterializeComponent(componentType, ev.LiveComponent, ev.Data);
 
 		if (!container.Components.TryAdd(component))
 		{

--- a/Synqra.Projection.MongoDb/MongoStoreCollection.cs
+++ b/Synqra.Projection.MongoDb/MongoStoreCollection.cs
@@ -59,7 +59,7 @@ internal sealed class MongoStoreCollection<T> : MongoStoreCollection, ISynqraCol
 			TargetTypeId = _projection.TypeMetadataProvider.GetTypeMetadata(typeof(T)).TypeId,
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetId = id,
-			Data = item,
+			Data = ObjectData.From(item),
 			TargetObject = item,
 		});
 		task.GetAwaiter().GetResult();

--- a/Synqra/AppJsonContext.cs
+++ b/Synqra/AppJsonContext.cs
@@ -41,6 +41,7 @@ namespace Synqra;
 [JsonSerializable(typeof(TransportOperation))]
 [JsonSerializable(typeof(IDictionary<string, object?>))]
 [JsonSerializable(typeof(Dictionary<string, object?>))]
+[JsonSerializable(typeof(ObjectData))]
 public partial class AppJsonContext : JsonSerializerContext
 {
 	public static JsonSerializerOptions DefaultOptions { get; }

--- a/TODO.md
+++ b/TODO.md
@@ -11,3 +11,23 @@ Deferred / known-improvement items. Prefer referencing an entry here over leavin
   before yielding anything. Switch to lazy cursor streaming (e.g. `Find(Scope).ToEnumerable()`, or
   explicit `ToCursor()` iteration) so `yield return` pulls documents on demand and large
   collections aren't fully materialized. Mind cursor lifetime/disposal across the `yield`.
+
+## CodeGeneration / ObjectData
+
+- [ ] **Generate native `ObjectData`-shaped read+write on `[SynqraModel]` types instead of
+  reflecting at runtime.** `ObjectData.From(object source, ...)` (`Synqra.Model/ObjectData.cs`) and
+  `ObjectDataApplyHelpers.HydrateFromData` (`Synqra.Projection.CommonStoreSupport/ComponentAndLinkApplyHelpers.cs`)
+  both fall back to `Type.GetProperties()`/reflection for the read and write directions
+  respectively. For `[SynqraModel]` types specifically this is unnecessary: `ModelBindingGenerator`
+  already walks the same partial-property set (with ancestors) at compile time for `SetCore`/the
+  generated setters — it could just as easily emit a native
+  `IEnumerable<KeyValuePair<string, object?>>` (read direction, feeds `ObjectData.From`'s fast path)
+  and reuse the existing `IBindableModel.Set` codegen (write direction, already reflection-free) so
+  the reflection branches in both helpers become a rare fallback for plain POCOs/anonymous objects
+  instead of the only path. Matters most for AOT/trimming (the codebase already tracks
+  `DynamicallyAccessedMembers`/IL2075 warnings elsewhere) — a generated dictionary view sidesteps
+  that entirely for the common case. Scoped as its own generator feature, not a quick patch: needs a
+  decision on minimal (`IEnumerable<KeyValuePair<>>`) vs. full `IReadOnlyDictionary<string, object?>`
+  surface, and a way to exclude well-known fields (e.g. `Link.LinkId`/`SourceId`/`TargetId`) from the
+  generated view — possibly an attribute on the property — instead of the manual `exclude` parameter
+  callers pass to `ObjectData.From` today.

--- a/Tests/Synqra.BinarySerializer.Tests/BinarySerializationTests.cs
+++ b/Tests/Synqra.BinarySerializer.Tests/BinarySerializationTests.cs
@@ -805,14 +805,14 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 						["number"] = 1,
 					},
 					*/
-					Data = new SampleTaskModel
+					Data = new ObjectData
 					{
-						Subject = "Task1",
-						Number = 1,
+						["Subject"] = "Task1",
+						["Number"] = 1,
 					},
 				},
 			},
-		}, "7B6D00007700000000001E5461736B310002"));
+		}, "7B6D0000770000000000035375626A65637400075461736B31004E756D626572000302"));
 
 		yield return () => SP(() => (71, new NewEvent1
 		{
@@ -844,14 +844,14 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 						["number"] = 1,
 					},
 					*/
-					Data = new SampleTaskModel
+					Data = new ObjectData
 					{
-						Subject = "Task1",
-						Number = 1,
+						["Subject"] = "Task1",
+						["Number"] = 1,
 					},
 				},
 			},
-		}, "7B6D04DFEFAAFC5C30602AD9FD1BF8000104DCEFAAFC5CB2B1C5AB90B83B00027704DCEFAAFC5CB2B1C5AB90B83B0002009849FAB0BD8BB7A456DE154556290012BDC5A48A7ABE8DF9580C63FBC206001304DBEFAAFC5CDB216DF966E2C9F33D1E5461736B310002"));
+		}, "7B6D04DFEFAAFC5C30602AD9FD1BF8000104DCEFAAFC5CB2B1C5AB90B83B00027704DCEFAAFC5CB2B1C5AB90B83B0002009849FAB0BD8BB7A456DE154556290012BDC5A48A7ABE8DF9580C63FBC206001304DBEFAAFC5CDB216DF966E2C9F33D035375626A65637400075461736B31004E756D626572000302"));
 
 		yield return () => SP(() => (72, new NewEvent1
 		{
@@ -1363,6 +1363,7 @@ public class BinarySerializationTests : SbxBaseTest
 				TargetId = default,
 				TargetTypeId = new Guid("00000000-0000-8000-8001-000000000000"),
 				CollectionId = default,
+				Data = new ObjectData(),
 			},
 		};
 		ser.Map(1, 2025.785, typeof(TransportOperation));

--- a/Tests/Synqra.BinarySerializer.Tests/SbxTestJsonSerializerContext.cs
+++ b/Tests/Synqra.BinarySerializer.Tests/SbxTestJsonSerializerContext.cs
@@ -50,6 +50,7 @@ namespace Synqra.BinarySerializer.Tests;
 [JsonSerializable(typeof(Synqra.ObjectCreatedEvent))]
 [JsonSerializable(typeof(Synqra.ObjectPropertyChangedEvent))]
 [JsonSerializable(typeof(Synqra.CreateObjectCommand))]
+[JsonSerializable(typeof(Synqra.ObjectData))]
 [JsonSerializable(typeof(Synqra.Command))]
 [JsonSerializable(typeof(Synqra.Event))]
 

--- a/Tests/Synqra.Tests/JsonSerializationTests.cs
+++ b/Tests/Synqra.Tests/JsonSerializationTests.cs
@@ -78,43 +78,23 @@ public class JsonSerializationTests
 			EventId = Guid.NewGuid(),
 			Data = new CreateObjectCommand
 			{
-				/*
-				Data = new Dictionary<string, object>
+				Data = new ObjectData
 				{
-					["subject"] = "Test1",
-				},
-				*/
-				Data = new SampleTaskModel
-				{
-					Subject = subject,
+					["Subject"] = subject,
 				},
 			},
 		};
 		async Task Check(JsonSerializerOptions ctx)
 		{
 			var json = JsonSerializer.Serialize<Event>(obj, ctx.Indented());
-			// using var __ = Assert.Multiple();
 			Console.WriteLine(json);
-			await Assert.That(json.NormalizeNewLines()).IsEqualTo($$"""
-			{
-				"_t": "CommandCreatedEvent",
-				"Data": {
-					"_t": "CreateObjectCommand",
-					"Data": {
-						"_t": "SampleTaskModel",
-						"Subject": "{{subject}}",
-						"Number": 0
-					},
-					"TargetTypeId": "00000000-0000-0000-0000-000000000000",
-					"CollectionId": "00000000-0000-0000-0000-000000000000",
-					"TargetId": "00000000-0000-0000-0000-000000000000",
-					"CommandId": "{{obj.Data.CommandId}}",
-					"StreamId": "00000000-0000-0000-0000-000000000000"
-				},
-				"EventId": "{{obj.EventId}}",
-				"CommandId": "{{obj.CommandId}}"
-			}
-			""".NormalizeNewLines());
+
+			// Data is now the canonical property bag (ObjectData), serialized as a plain JSON
+			// object — no "_t" discriminator and no SampleTaskModel reference. That loose,
+			// polymorphic-POCO payload is exactly the contract this redesign removed.
+			await Assert.That(json.Contains("SampleTaskModel")).IsFalse();
+			await Assert.That(json.Contains(subject)).IsTrue();
+
 			var deserializedObj = JsonSerializer.Deserialize<Event>(json, ctx);
 			await Assert.That(deserializedObj).IsNotNull();
 			await Assert.That(deserializedObj.CommandId).IsEqualTo(obj.CommandId);
@@ -122,8 +102,7 @@ public class JsonSerializationTests
 			await Assert.That(createdEvent.Data).IsNotNull();
 			var createCommand = (CreateObjectCommand)createdEvent.Data;
 			await Assert.That(createCommand.Data).IsNotNull();
-			var taskModel = (SampleTaskModel)createCommand.Data;
-			await Assert.That(taskModel.Subject).IsEqualTo(subject);
+			await Assert.That(GetSubject(createCommand.Data)).IsEqualTo(subject);
 		}
 		switch (ctxId)
 		{
@@ -154,16 +133,10 @@ public class JsonSerializationTests
 			EventId = Guid.NewGuid(),
 			Data = new CreateObjectCommand
 			{
-				/*
-				Data = new Dictionary<string, object>
+				Data = new ObjectData
 				{
-					["subject"] = "Test1",
-				},
-				*/
-				Data = new SampleTaskModel
-				{
-					Subject = "Test1",
-					Number = 1,
+					["Subject"] = "Test1",
+					["Number"] = 1,
 				},
 			},
 		};
@@ -183,34 +156,33 @@ public class JsonSerializationTests
 			var deserializedObj = JsonSerializer.Deserialize<TransportOperation>(json, jsonOptions);
 			var json2 = JsonSerializer.Serialize<TransportOperation>(deserializedObj, jsonOptions);
 			Console.WriteLine(json2.NormalizeNewLines());
-			await Assert.That(json2.NormalizeNewLines()).IsEqualTo($$"""
-	{
-		"_t": "NewEvent1",
-		"Event": {
-			"_t": "CommandCreatedEvent",
-			"Data": {
-				"_t": "CreateObjectCommand",
-				"Data": {
-					"_t": "SampleTaskModel",
-					"Subject": "Test1",
-					"Number": 1
-				},
-				"TargetTypeId": "00000000-0000-0000-0000-000000000000",
-				"CollectionId": "00000000-0000-0000-0000-000000000000",
-				"TargetId": "00000000-0000-0000-0000-000000000000",
-				"CommandId": "{{@event.Data.CommandId}}",
-				"StreamId": "00000000-0000-0000-0000-000000000000"
-			},
-			"EventId": "{{@event.EventId}}",
-			"CommandId": "{{@event.CommandId}}"
-		}
-	}
-	""".NormalizeNewLines());
+
+			// The payload survives a full serialize → deserialize → serialize cycle as a plain
+			// property bag — no "_t"/SampleTaskModel discriminator leaks back in.
+			await Assert.That(json2.Contains("SampleTaskModel")).IsFalse();
+			await Assert.That(json2.Contains("Test1")).IsTrue();
+
+			var roundTripped = (NewEvent1)deserializedObj;
+			var createCommand = (CreateObjectCommand)((CommandCreatedEvent)roundTripped.Event).Data;
+			await Assert.That(GetSubject(createCommand.Data)).IsEqualTo("Test1");
 		}
 		await Check(SampleJsonSerializerContext.DefaultOptions);
 		// await Check(AppJsonContext.Default);
 	}
 
+	// Dictionary-key casing differs per context (camelCase vs as-is), so look the value up
+	// case-insensitively rather than assuming a single key spelling.
+	static string? GetSubject(ObjectData data)
+	{
+		foreach (var (key, value) in data)
+		{
+			if (string.Equals(key, "Subject", StringComparison.OrdinalIgnoreCase))
+			{
+				return value as string;
+			}
+		}
+		return null;
+	}
 }
 
 public class AotTests

--- a/Tests/Synqra.Tests/JsonlStorageTests.cs
+++ b/Tests/Synqra.Tests/JsonlStorageTests.cs
@@ -154,6 +154,7 @@ public abstract class AppendStorageTests : BaseTest
 			EventId = key,
 			TargetId = Guid.NewGuid(),
 			TargetTypeId = Guid.NewGuid(),
+			Data = new ObjectData(),
 		};
 		await storage.AppendAsync(item);
 
@@ -185,6 +186,7 @@ public abstract class AppendStorageTests : BaseTest
 			EventId = key1,
 			TargetId = new Guid("00000001-0003-8000-8000-c0de11dae333"),
 			TargetTypeId = new Guid("00000001-0004-8000-8000-c0de11dae333"),
+			Data = new ObjectData(),
 		};
 		await storage.AppendAsync(item1);
 
@@ -196,6 +198,7 @@ public abstract class AppendStorageTests : BaseTest
 			EventId = key2,
 			TargetId = new Guid("00000002-0003-8000-8000-c0de11dae333"),
 			TargetTypeId = new Guid("00000002-0004-8000-8000-c0de11dae333"),
+			Data = new ObjectData(),
 		};
 		await storage.AppendAsync(item2);
 
@@ -253,9 +256,9 @@ public abstract class AppendStorageTests : BaseTest
 			TargetId = GuidExtensions.CreateVersion7(),
 			TargetTypeId = GuidExtensions.CreateVersion7(),
 			StreamId = GuidExtensions.CreateVersion7(),
-			Data = new StorableModel
+			Data = new ObjectData
 			{
-				Title = "Alice",
+				["Title"] = "Alice",
 			},
 		};
 		await storage.AppendAsync(ev);
@@ -286,9 +289,9 @@ public abstract class AppendStorageTests : BaseTest
 			TargetId = GuidExtensions.CreateVersion7(),
 			TargetTypeId = GuidExtensions.CreateVersion7(),
 			StreamId = GuidExtensions.CreateVersion7(),
-			Data = new StorableModel
+			Data = new ObjectData
 			{
-				Title = "Alice",
+				["Title"] = "Alice",
 			},
 		};
 		await storage.AppendAsync(ev);
@@ -301,9 +304,9 @@ public abstract class AppendStorageTests : BaseTest
 			TargetId = GuidExtensions.CreateVersion7(),
 			TargetTypeId = GuidExtensions.CreateVersion7(),
 			StreamId = GuidExtensions.CreateVersion7(),
-			Data = new StorableModel
+			Data = new ObjectData
 			{
-				Title = "Bob",
+				["Title"] = "Bob",
 			},
 		};
 		await storage.AppendAsync(ev2);
@@ -594,12 +597,13 @@ public class EventsJsonlStorageTests : JsonAppendStorageTests<Event, Guid>
 			EventId = SynqraGuids.SynqraRootStreamId,
 			TargetId = default,
 			TargetTypeId = default,
+			Data = new ObjectData(),
 		});
 
 		(_storage as IDisposable)?.Dispose();
 		await Assert.That(FileReadAllText(_fileName).NormalizeNewLines()).IsEqualTo($$"""
 {"Synqra.Storage.Jsonl":"0.1","rootItemType":"Synqra.Event"}
-{{SynqraGuids.SynqraRootStreamId.ToString("N")}}§{"_t":"ObjectCreatedEvent","TargetId":"00000000-0000-0000-0000-000000000000","TargetTypeId":"00000000-0000-0000-0000-000000000000","CollectionId":"00000000-0000-0000-0000-000000000000","EventId":"{{SynqraGuids.SynqraRootStreamId}}","CommandId":"00000000-0000-0000-0000-000000000000"}
+{{SynqraGuids.SynqraRootStreamId.ToString("N")}}§{"_t":"ObjectCreatedEvent","Data":{},"TargetId":"00000000-0000-0000-0000-000000000000","TargetTypeId":"00000000-0000-0000-0000-000000000000","CollectionId":"00000000-0000-0000-0000-000000000000","EventId":"{{SynqraGuids.SynqraRootStreamId}}","CommandId":"00000000-0000-0000-0000-000000000000"}
 
 """.NormalizeNewLines());
 	}

--- a/Tests/Synqra.Tests/LinksTests.cs
+++ b/Tests/Synqra.Tests/LinksTests.cs
@@ -304,7 +304,7 @@ public class LinksTests
 				LinkId = GuidExtensions.CreateVersion7(),
 				SourceId = store.GetId(a),
 				TargetId = store.GetId(b),
-				Data = new HierarchyLink { SourceId = store.GetId(a), TargetId = store.GetId(b) },
+				Data = new ObjectData(),
 			});
 		});
 		await Assert.That(ex is InvalidOperationException).IsTrue();

--- a/Tests/Synqra.Tests/MongoEventClassMapsTests.cs
+++ b/Tests/Synqra.Tests/MongoEventClassMapsTests.cs
@@ -64,37 +64,38 @@ public class MongoEventClassMapsTests
 	[Test]
 	public async Task Should_not_write_a_null_field_at_all()
 	{
-		// Data is a plain (non-JsonIgnore'd) property, never populated by the current
-		// command-handling path for ObjectCreatedEvent — it's null on every real event of this
-		// kind. Without the global IgnoreIfNullConvention, the document would still carry an
-		// explicit "Data": null for every single event, just to record the absence of a value.
-		var ev = new ObjectCreatedEvent
+		// OldValue is genuinely nullable and commonly absent (e.g. on a property's first-ever
+		// write). Without the global IgnoreIfNullConvention, the document would still carry an
+		// explicit "OldValue": null for every single event, just to record the absence of a value.
+		var ev = new ObjectPropertyChangedEvent
 		{
 			EventId = Guid.Parse("00000020-000e-8000-8000-0000000000be"),
 			CommandId = Guid.Parse("00000020-000f-8000-8000-0000000000bf"),
 			TargetId = Guid.Parse("00000020-0010-8000-8000-0000000000c0"),
 			TargetTypeId = Guid.Parse("00000020-0011-8000-8000-0000000000c1"),
 			CollectionId = Guid.Parse("00000020-0012-8000-8000-0000000000c2"),
-			Data = null,
+			PropertyName = "Name",
+			OldValue = null,
+			NewValue = "first value",
 		};
 
 		var doc = ((Event)ev).ToBsonDocument(typeof(Event));
-		await Assert.That(doc.Contains("Data")).IsFalse();
+		await Assert.That(doc.Contains("OldValue")).IsFalse();
 
-		var back = (ObjectCreatedEvent)BsonSerializer.Deserialize<Event>(doc);
-		await Assert.That(back.Data).IsNull();
+		var back = (ObjectPropertyChangedEvent)BsonSerializer.Deserialize<Event>(doc);
+		await Assert.That(back.OldValue).IsNull();
 	}
 
 	[Test]
 	public async Task Should_not_duplicate_LinkId_SourceId_TargetId_inside_Data()
 	{
-		// LinkAddedEvent already carries LinkId/SourceId/TargetId as its own explicit fields (see
-		// AddLinkCommand's remarks on why) — Data should only ever add a concrete subtype's own
-		// extra properties (a primitive link like HierarchyLink has none, so Data should come back
-		// essentially empty: just its own discriminator, nothing from the Link base).
+		// The normal path: AddLinkCommand/LinkAddedEvent.Data is built via ObjectData.From(link,
+		// Link.WellKnownDataFields), so LinkId/SourceId/TargetId never enter the bag — a primitive
+		// link like HierarchyLink has no other properties, so Data comes back empty.
 		var linkId = Guid.Parse("00000020-0013-8000-8000-0000000000c3");
 		var sourceId = Guid.Parse("00000020-0014-8000-8000-0000000000c4");
 		var targetId = Guid.Parse("00000020-0015-8000-8000-0000000000c5");
+		var link = new HierarchyLink { LinkId = linkId, SourceId = sourceId, TargetId = targetId };
 		var ev = new LinkAddedEvent
 		{
 			EventId = Guid.Parse("00000020-0016-8000-8000-0000000000c6"),
@@ -103,7 +104,7 @@ public class MongoEventClassMapsTests
 			LinkId = linkId,
 			SourceId = sourceId,
 			TargetId = targetId,
-			Data = new HierarchyLink { LinkId = linkId, SourceId = sourceId, TargetId = targetId },
+			Data = ObjectData.From(link, Link.WellKnownDataFields),
 		};
 
 		var doc = ((Event)ev).ToBsonDocument(typeof(Event));
@@ -112,16 +113,51 @@ public class MongoEventClassMapsTests
 		await Assert.That(doc["LinkId"].AsGuid).IsEqualTo(linkId);
 		await Assert.That(doc["SourceId"].AsGuid).IsEqualTo(sourceId);
 		await Assert.That(doc["TargetId"].AsGuid).IsEqualTo(targetId);
-		// But the nested Data blob does not repeat them.
+		// And the nested Data blob is empty — nothing was ever duplicated into it.
 		var data = doc["Data"].AsBsonDocument;
-		await Assert.That(data.Contains("LinkId")).IsFalse();
-		await Assert.That(data.Contains("SourceId")).IsFalse();
-		await Assert.That(data.Contains("TargetId")).IsFalse();
+		await Assert.That(data.ElementCount).IsEqualTo(0);
 
 		var back = (LinkAddedEvent)BsonSerializer.Deserialize<Event>(doc);
 		await Assert.That(back.LinkId).IsEqualTo(linkId);
 		await Assert.That(back.SourceId).IsEqualTo(sourceId);
 		await Assert.That(back.TargetId).IsEqualTo(targetId);
+	}
+
+	[Test]
+	public async Task Should_strip_well_known_fields_from_Data_even_if_a_caller_bypasses_the_exclude_list()
+	{
+		// LinkDataSerializer is a defensive backstop for callers who build Data by hand instead of
+		// going through ObjectData.From's exclude list (see its remarks in MongoEventClassMaps) — it
+		// must still strip LinkId/SourceId/TargetId from the bag while leaving any other key alone.
+		var linkId = Guid.Parse("00000020-0019-8000-8000-0000000000c9");
+		var sourceId = Guid.Parse("00000020-001a-8000-8000-0000000000ca");
+		var targetId = Guid.Parse("00000020-001b-8000-8000-0000000000cb");
+		var ev = new LinkAddedEvent
+		{
+			EventId = Guid.Parse("00000020-001c-8000-8000-0000000000cc"),
+			CommandId = Guid.Parse("00000020-001d-8000-8000-0000000000cd"),
+			LinkTypeId = Guid.Parse("00000020-001e-8000-8000-0000000000ce"),
+			LinkId = linkId,
+			SourceId = sourceId,
+			TargetId = targetId,
+			Data = new ObjectData
+			{
+				["LinkId"] = linkId,
+				["SourceId"] = sourceId,
+				["TargetId"] = targetId,
+				["Order"] = 3,
+			},
+		};
+
+		var doc = ((Event)ev).ToBsonDocument(typeof(Event));
+		var data = doc["Data"].AsBsonDocument;
+		await Assert.That(data.Contains("LinkId")).IsFalse();
+		await Assert.That(data.Contains("SourceId")).IsFalse();
+		await Assert.That(data.Contains("TargetId")).IsFalse();
+		await Assert.That(data["Order"].AsInt32).IsEqualTo(3);
+
+		var back = (LinkAddedEvent)BsonSerializer.Deserialize<Event>(doc);
+		await Assert.That(back.Data["Order"]).IsEqualTo(3);
 	}
 
 	[Test]

--- a/Tests/Synqra.Tests/MongoEventClassMapsTests.cs
+++ b/Tests/Synqra.Tests/MongoEventClassMapsTests.cs
@@ -62,30 +62,6 @@ public class MongoEventClassMapsTests
 	}
 
 	[Test]
-	public async Task Should_not_persist_JsonIgnored_DataObject_of_ObjectCreatedEvent()
-	{
-		// DataObject is the in-memory materialized object, marked [JsonIgnore]; it must not
-		// be written to the durable log (mirrors the JSON-lines log).
-		var ev = new ObjectCreatedEvent
-		{
-			EventId = Guid.Parse("00000020-0008-8000-8000-0000000000b8"),
-			CommandId = Guid.Parse("00000020-0009-8000-8000-0000000000b9"),
-			TargetId = Guid.Parse("00000020-000a-8000-8000-0000000000ba"),
-			TargetTypeId = Guid.Parse("00000020-000b-8000-8000-0000000000bb"),
-			CollectionId = Guid.Parse("00000020-000c-8000-8000-0000000000bc"),
-			DataObject = new { Anything = "should not be persisted" },
-		};
-
-		var doc = ((Event)ev).ToBsonDocument(typeof(Event));
-		await Assert.That(DiscriminatorLeaf(doc)).IsEqualTo("ObjectCreatedEvent");
-		await Assert.That(doc.Contains("DataObject")).IsFalse();
-
-		var back = (ObjectCreatedEvent)BsonSerializer.Deserialize<Event>(doc);
-		await Assert.That(back.EventId).IsEqualTo(ev.EventId);
-		await Assert.That(back.TargetId).IsEqualTo(ev.TargetId);
-	}
-
-	[Test]
 	public async Task Should_not_write_a_null_field_at_all()
 	{
 		// Data is a plain (non-JsonIgnore'd) property, never populated by the current

--- a/Tests/Synqra.Tests/SampleModels/SampleJsonSerializerContext.cs
+++ b/Tests/Synqra.Tests/SampleModels/SampleJsonSerializerContext.cs
@@ -38,6 +38,7 @@ namespace Synqra.Tests.SampleModels;
 [JsonSerializable(typeof(SampleOnePropertyObject))]
 [JsonSerializable(typeof(Dictionary<string, object?>))]
 [JsonSerializable(typeof(IDictionary<string, object?>))]
+[JsonSerializable(typeof(ObjectData))]
 [JsonSerializable(typeof(ISynqraCommand))]
 [JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(MyPocoTask))]

--- a/Tests/Synqra.Tests/SynqraStoreMatrixTests.cs
+++ b/Tests/Synqra.Tests/SynqraStoreMatrixTests.cs
@@ -527,6 +527,7 @@ public sealed class Cobra_Mongo_Store_Components_Tests : BaseTest
 
 		var ex = await Assert.ThrowsAsync(async () =>
 		{
+			var second = new TestUniqueComponent { Subject = "second" };
 			await store.SubmitCommandAsync(new AddComponentCommand
 			{
 				CommandId = GuidExtensions.CreateVersion7(),
@@ -536,7 +537,8 @@ public sealed class Cobra_Mongo_Store_Components_Tests : BaseTest
 				CollectionId = store.TypeMetadataProvider.GetTypeMetadata(typeof(TestGeneratedContainerNode)).GetCollectionId(""),
 				ComponentTypeId = store.TypeMetadataProvider.GetTypeMetadata(typeof(TestUniqueComponent)).TypeId,
 				ComponentId = Guid.Empty,
-				Data = new TestUniqueComponent { Subject = "second" },
+				Data = ObjectData.From(second),
+				LiveComponent = second,
 			});
 		});
 		await Assert.That(ex).IsTypeOf<InvalidOperationException>();

--- a/Tests/Synqra.Tests/TestsStateManagement.cs
+++ b/Tests/Synqra.Tests/TestsStateManagement.cs
@@ -190,7 +190,8 @@ public class TestsStateManageementInMemory : TestsStateManagement
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestUniqueComponent>(),
-			Data = component,
+			Data = ObjectData.From(component),
+			LiveComponent = component,
 		});
 
 		var attached = node.Components.GetUniqueComponent(typeof(TestUniqueComponent));
@@ -205,12 +206,14 @@ public class TestsStateManageementInMemory : TestsStateManagement
 		var node = new TestComponentNode { Name = "n2" };
 		_sut.GetCollection<TestComponentNode>().Add(node);
 
+		var first = new TestUniqueComponent { Subject = "first" };
 		await _sut.SubmitCommandAsync(new AddComponentCommand
 		{
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestUniqueComponent>(),
-			Data = new TestUniqueComponent { Subject = "first" },
+			Data = ObjectData.From(first),
+			LiveComponent = first,
 		});
 
 		// Adding a second [Component(IsUnique = true)] of the same type must fail
@@ -219,12 +222,14 @@ public class TestsStateManageementInMemory : TestsStateManagement
 		InvalidOperationException? caught = null;
 		try
 		{
+			var second = new TestUniqueComponent { Subject = "second" };
 			await _sut.SubmitCommandAsync(new AddComponentCommand
 			{
 				CommandId = GuidExtensions.CreateVersion7(),
 				TargetObject = node,
 				ComponentTypeId = TypeIdOf<TestUniqueComponent>(),
-				Data = new TestUniqueComponent { Subject = "second" },
+				Data = ObjectData.From(second),
+				LiveComponent = second,
 			});
 		}
 		catch (InvalidOperationException ex)
@@ -250,7 +255,8 @@ public class TestsStateManageementInMemory : TestsStateManagement
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestUniqueComponent>(),
-			Data = c,
+			Data = ObjectData.From(c),
+			LiveComponent = c,
 		});
 
 		// Unique components are addressed by type alone; ComponentId stays empty.
@@ -276,22 +282,26 @@ public class TestsStateManageementInMemory : TestsStateManagement
 		var aId = GuidExtensions.CreateVersion7();
 		var bId = GuidExtensions.CreateVersion7();
 
+		var compA = new TestTaggingComponent { Id = aId, Tag = "alpha" };
 		await _sut.SubmitCommandAsync(new AddComponentCommand
 		{
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestTaggingComponent>(),
 			ComponentId = aId,
-			Data = new TestTaggingComponent { Id = aId, Tag = "alpha" },
+			Data = ObjectData.From(compA),
+			LiveComponent = compA,
 		});
 
+		var compB = new TestTaggingComponent { Id = bId, Tag = "beta" };
 		await _sut.SubmitCommandAsync(new AddComponentCommand
 		{
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestTaggingComponent>(),
 			ComponentId = bId,
-			Data = new TestTaggingComponent { Id = bId, Tag = "beta" },
+			Data = ObjectData.From(compB),
+			LiveComponent = compB,
 		});
 
 		await Assert.That(node.Components.Count).IsEqualTo(2);
@@ -320,12 +330,14 @@ public class TestsStateManageementInMemory : TestsStateManagement
 		var node = new TestComponentNode { Name = "n5" };
 		_sut.GetCollection<TestComponentNode>().Add(node);
 
+		var doomed = new TestUniqueComponent { Subject = "doomed" };
 		await _sut.SubmitCommandAsync(new AddComponentCommand
 		{
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestUniqueComponent>(),
-			Data = new TestUniqueComponent { Subject = "doomed" },
+			Data = ObjectData.From(doomed),
+			LiveComponent = doomed,
 		});
 		await Assert.That(node.Components.Count).IsEqualTo(1);
 
@@ -348,12 +360,14 @@ public class TestsStateManageementInMemory : TestsStateManagement
 		var nodeId = _sut.GetId(node);
 
 		var beforeAdd = _sut.GetLastEventId(nodeId);
+		var compX = new TestUniqueComponent { Subject = "x" };
 		await _sut.SubmitCommandAsync(new AddComponentCommand
 		{
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestUniqueComponent>(),
-			Data = new TestUniqueComponent { Subject = "x" },
+			Data = ObjectData.From(compX),
+			LiveComponent = compX,
 		});
 		var afterAdd = _sut.GetLastEventId(nodeId);
 		await Assert.That(afterAdd).IsNotEqualTo(beforeAdd);
@@ -394,13 +408,15 @@ public class TestsStateManageementInMemory : TestsStateManagement
 		ConcurrencyException? caught = null;
 		try
 		{
+			var ghost = new TestUniqueComponent { Subject = "ghost" };
 			await _sut.SubmitCommandAsync(
 				new AddComponentCommand
 				{
 					CommandId = GuidExtensions.CreateVersion7(),
 					TargetObject = node,
 					ComponentTypeId = TypeIdOf<TestUniqueComponent>(),
-					Data = new TestUniqueComponent { Subject = "ghost" },
+					Data = ObjectData.From(ghost),
+					LiveComponent = ghost,
 				},
 				new CommandSubmissionOptions { ExpectedLastEventId = stale });
 		}
@@ -431,7 +447,8 @@ public class TestsStateManageementInMemory : TestsStateManagement
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestUniqueComponent>(),
-			Data = c,
+			Data = ObjectData.From(c),
+			LiveComponent = c,
 		});
 		await Assert.That(c.Subject).IsEqualTo("v1");
 
@@ -467,7 +484,8 @@ public class TestsStateManageementInMemory : TestsStateManagement
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestTaggingComponent>(),
 			ComponentId = tagId,
-			Data = c,
+			Data = ObjectData.From(c),
+			LiveComponent = c,
 		});
 
 		c.Tag = "beta"; // generator-emitted path
@@ -497,7 +515,8 @@ public class TestsStateManageementInMemory : TestsStateManagement
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestUniqueComponent>(),
-			Data = c,
+			Data = ObjectData.From(c),
+			LiveComponent = c,
 		});
 
 		node.Name = "concurrency-host-edited"; // unrelated container write
@@ -597,7 +616,8 @@ public class TestsStateManageementInMemory : TestsStateManagement
 			CommandId = GuidExtensions.CreateVersion7(),
 			TargetObject = node,
 			ComponentTypeId = TypeIdOf<TestActivatableComponent>(),
-			Data = c,
+			Data = ObjectData.From(c),
+			LiveComponent = c,
 		});
 
 		await Assert.That(c.ActivationCount).IsEqualTo(1);

--- a/Tests/Synqra.Tests/TestsStateManagement.cs
+++ b/Tests/Synqra.Tests/TestsStateManagement.cs
@@ -763,7 +763,7 @@ public abstract class TestsStateManagement : BaseTest<IObjectStore>
 
 		var q0 = new DemoModel(); // must register polimorfic before serializaiton
 		var q1 = new Item(); // must register polimorfic before serializaiton
-		var q2 = new CreateObjectCommand(); // must register polimorfic before serializaiton
+		var q2 = new CreateObjectCommand { Data = new ObjectData() }; // must register polimorfic before serializaiton
 		var q3 = new ChangeObjectPropertyCommand() { PropertyName = "q" }; // must register polimorfic before serializaiton
 
 		HostBuilder.Services.AddSingleton<FakeAppendStorage>();


### PR DESCRIPTION
## Summary
- `CreateObjectCommand.Data` and `ObjectCreatedEvent.Data` were typed as bare `object`/`object?`, so every reducer/projection re-discovered the runtime shape (POCO, anonymous object, `IBindableModel`, or dictionary) via reflection.
- New `ObjectData : Dictionary<string, object?>` is the single canonical property bag, normalized once via `ObjectData.From(...)` at the command boundary (`Synqra.Model/ObjectData.cs`). Consumers (InMemoryProjection, MongoProjection, File projection) now just enumerate it.
- `Data` is `required` and non-null on `CreateObjectCommand`/`ObjectCreatedEvent` (a sealed dict has no SBX wire representation for null, so leaving it nullable would have conflated null/empty).
- `ObjectCreatedEvent.DataObject` (renamed `MaterializedObject`) was removed entirely — every `Add()` call site already attaches the live instance before submitting, so the projection's own attach-tracking already resolves back to it; the field never changed the outcome on any path that runs.
- `SbxBindingGenerator` gained dictionary-subclass detection ahead of the `IEnumerable` fallback, and constructs concrete dictionary types via their `IDictionary`-accepting constructor instead of an invalid cast.
- **Extended to `Link`/`Component`** (the same loose-`object`-`Data` problem, hit independently by the just-landed Link/Mongo work): `AddLinkCommand`/`LinkAddedEvent.Data` and `AddComponentCommand`/`ComponentAddedEvent.Data` now use `ObjectData` too.
  - `ObjectData.From` gained an `exclude` parameter and a `[JsonIgnore]` skip during reflection capture.
  - Links exclude `LinkId`/`SourceId`/`TargetId` at construction (`Link.WellKnownDataFields`) — those are already explicit, authoritative fields on the event, so duplicating them into `Data` was dead weight. `LinkApplyHelpers.MaterializeLink` drops the now-unreachable "reuse the live instance" fast path (nothing downstream of link creation relies on reference identity). Mongo's `LinkDataSerializer` stays registered as a defensive backstop, rewritten against `ObjectData` directly instead of round-tripping through the generic object serializer.
  - Components keep a separate `LiveComponent` carrier alongside `Data`, because component identity *is* load-bearing there (no attach-before-submit step the way object creation has — the projection must get the caller's own instance back or its generated property setters silently orphan).

## Test plan
- [x] `dotnet build Synqra.sln` — 0 errors
- [x] `Synqra.BinarySerializer.Tests` — 140/140 passed
- [x] `Synqra.Tests` — 170/170 passed (includes new/updated Mongo class-map coverage for the well-known-field exclusion and its defensive backstop)