### PR TITLE
Native BSON for Mongo read-model; fix Link.LinkId/_id duplication

### DIFF
--- a/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
@@ -74,6 +74,24 @@ public static class MongoEventClassMaps
 				});
 			}
 
+			// Link.LinkId IS the document's own identity wherever a Link is stored natively as its
+			// own document — MongoProjection's "Links" read-model collection. Mapping it to _id (here,
+			// once, on the shared base class map every concrete Link subtype's AutoMap extends) avoids
+			// a redundant duplicate field (_id and LinkId carrying the exact same value). Not done via
+			// a [BsonId] attribute on the model itself: Synqra.Model has no MongoDB dependency, and
+			// every other storage backend (in-memory, SBX files) addresses a link by this same LinkId
+			// property without needing it singled out as "the" id — that's a Mongo-only document
+			// convention. LinkDataSerializer's own well-known-field strip (LinkAddedEvent.Data) accounts
+			// for this rename too — see its WellKnown list.
+			if (!BsonClassMap.IsClassMapRegistered(typeof(Link)))
+			{
+				BsonClassMap.RegisterClassMap<Link>(cm =>
+				{
+					cm.AutoMap();
+					cm.MapIdProperty(x => x.LinkId);
+				});
+			}
+
 			RegisterDerived<ObjectCreatedEvent>("ObjectCreatedEvent");
 			RegisterDerived<ObjectPropertyChangedEvent>("ObjectPropertyChangedEvent");
 			RegisterDerived<ObjectDeletedEvent>("ObjectDeletedEvent");
@@ -84,9 +102,10 @@ public static class MongoEventClassMaps
 			RegisterDerived<LinkRemovedEvent>("LinkRemovedEvent");
 
 			// LinkAddedEvent gets a member-scoped serializer on Data so the embedded link drops the
-			// three well-known fields it would otherwise duplicate (see LinkDataSerializer). This keeps
-			// the Link class map itself untouched — unlike a global convention, so MongoProjection's
-			// native link collection can still persist LinkId/SourceId/TargetId for querying.
+			// three well-known fields (_id/LinkId, SourceId, TargetId) it would otherwise duplicate
+			// (see LinkDataSerializer). This keeps the Link class map's own field SET untouched —
+			// unlike a global convention, so MongoProjection's native link collection can still persist
+			// _id/SourceId/TargetId for querying.
 			RegisterDerived<LinkAddedEvent>("LinkAddedEvent", cm =>
 				cm.GetMemberMap(e => e.Data).SetSerializer(new LinkDataSerializer()));
 
@@ -151,17 +170,19 @@ public static class MongoEventClassMaps
 	/// Member-scoped BSON serializer for <see cref="LinkAddedEvent.Data"/> (the link instance).
 	/// Serializes the link natively through the normal <c>object</c> serializer — so a consumer's
 	/// concrete <c>Link</c> subtype keeps its own extra fields and its <c>_t</c> discriminator — then
-	/// drops the three well-known fields (<see cref="Link.LinkId"/>/<see cref="Link.SourceId"/>/
-	/// <see cref="Link.TargetId"/>) from the resulting sub-document, because the event already carries
-	/// them as explicit top-level fields. Because it's attached to this one member rather than the
-	/// <c>Link</c> class map, it never affects how a <c>Link</c> is serialized anywhere else — notably
-	/// <c>MongoProjection</c>'s native "Links" collection, which must keep those very fields to query by
-	/// endpoint. On replay the materialized link re-stamps LinkId/SourceId/TargetId from the event's own
-	/// explicit fields, so the stripped fields are never read back from Data.
+	/// drops the three well-known fields (<see cref="Link.LinkId"/> — written as <c>_id</c>, since the
+	/// shared <c>Link</c> class map maps it as the id member, see <see cref="Register"/> —
+	/// <see cref="Link.SourceId"/>/<see cref="Link.TargetId"/>) from the resulting sub-document,
+	/// because the event already carries them as explicit top-level fields. Because it's attached to
+	/// this one member rather than the <c>Link</c> class map, it never affects how a <c>Link</c> is
+	/// serialized anywhere else — notably <c>MongoProjection</c>'s native "Links" collection, which
+	/// must keep those very fields to query by endpoint. On replay the materialized link re-stamps
+	/// LinkId/SourceId/TargetId from the event's own explicit fields, so the stripped fields are never
+	/// read back from Data.
 	/// </summary>
 	sealed class LinkDataSerializer : SerializerBase<object>
 	{
-		static readonly string[] WellKnown = [nameof(Link.LinkId), nameof(Link.SourceId), nameof(Link.TargetId)];
+		static readonly string[] WellKnown = ["_id", nameof(Link.SourceId), nameof(Link.TargetId)];
 
 		// Looked up lazily so it resolves the patched, fully-open object serializer (see
 		// PatchObjectSerializerDefaults) rather than whatever might exist at type-init time.

--- a/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text.Json.Serialization;
 using MongoDB.Bson;
+using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Bson.Serialization.Serializers;
@@ -80,6 +81,14 @@ public static class MongoEventClassMaps
 			RegisterDerived<ComponentAddedEvent>("ComponentAddedEvent");
 			RegisterDerived<ComponentPropertyChangedEvent>("ComponentPropertyChangedEvent");
 			RegisterDerived<ComponentDeletedEvent>("ComponentDeletedEvent");
+			RegisterDerived<LinkRemovedEvent>("LinkRemovedEvent");
+
+			// LinkAddedEvent gets a member-scoped serializer on Data so the embedded link drops the
+			// three well-known fields it would otherwise duplicate (see LinkDataSerializer). This keeps
+			// the Link class map itself untouched — unlike a global convention, so MongoProjection's
+			// native link collection can still persist LinkId/SourceId/TargetId for querying.
+			RegisterDerived<LinkAddedEvent>("LinkAddedEvent", cm =>
+				cm.GetMemberMap(e => e.Data).SetSerializer(new LinkDataSerializer()));
 
 			_registered = true;
 		}
@@ -107,25 +116,18 @@ public static class MongoEventClassMaps
 	/// command-handling path) are nullable reference types, so without this every document carries
 	/// an explicit <c>"Field": null</c> for each one that happens not to apply.
 	/// </item>
-	/// <item>
-	/// Strips <see cref="Link.LinkId"/>/<see cref="Link.SourceId"/>/<see cref="Link.TargetId"/> from
-	/// the <see cref="Link"/> base's own class map — which is what every concrete link subtype's
-	/// auto-mapped chain shares (BSON builds one class map per level of the inheritance chain, and
-	/// caches/reuses <c>typeof(Link)</c>'s). Without this, <see cref="LinkAddedEvent.Data"/> (a
-	/// concrete <c>Link</c> instance, e.g. <c>HierarchyLink</c>) would duplicate the exact three
-	/// fields <see cref="LinkAddedEvent"/> itself already carries explicitly, persisted twice in the
-	/// same document. Safe to strip universally: nothing else round-trips a <c>Link</c> through this
-	/// native-BSON path — <c>MongoProjection</c>'s own "Links" collection storage goes through
-	/// <c>System.Text.Json</c> instead, an entirely separate serializer this convention never touches.
-	/// On replay, the materialized link's <c>LinkId</c>/<c>SourceId</c>/<c>TargetId</c> are always
-	/// re-stamped from the event's own explicit fields anyway (see <c>VisitLinkAddedCore</c>), so the
-	/// stripped fields were never read back even before this fix — purely dead weight on disk.
-	/// </item>
 	/// </list>
+	/// <para>
+	/// Note: the redundancy where <see cref="LinkAddedEvent.Data"/> (a concrete <c>Link</c>) would
+	/// duplicate the three well-known fields the event already carries explicitly is handled NOT here
+	/// (a global Link-class-map strip would also clobber <c>MongoProjection</c>'s native link storage,
+	/// which needs those fields to query) but by a member-scoped <see cref="LinkDataSerializer"/> on the
+	/// <c>Data</c> member alone — see its registration in <see cref="Register"/>.
+	/// </para>
 	/// </summary>
 	static void RegisterJsonIgnoreConvention()
 	{
-		var pack = new ConventionPack { new JsonIgnoreConvention(), new IgnoreIfNullConvention(true), new LinkWellKnownFieldsConvention() };
+		var pack = new ConventionPack { new JsonIgnoreConvention(), new IgnoreIfNullConvention(true) };
 		ConventionRegistry.Register("Synqra.JsonIgnoreAndSkipNulls", pack, _ => true);
 	}
 
@@ -145,24 +147,54 @@ public static class MongoEventClassMaps
 		}
 	}
 
-	sealed class LinkWellKnownFieldsConvention : IClassMapConvention
+	/// <summary>
+	/// Member-scoped BSON serializer for <see cref="LinkAddedEvent.Data"/> (the link instance).
+	/// Serializes the link natively through the normal <c>object</c> serializer — so a consumer's
+	/// concrete <c>Link</c> subtype keeps its own extra fields and its <c>_t</c> discriminator — then
+	/// drops the three well-known fields (<see cref="Link.LinkId"/>/<see cref="Link.SourceId"/>/
+	/// <see cref="Link.TargetId"/>) from the resulting sub-document, because the event already carries
+	/// them as explicit top-level fields. Because it's attached to this one member rather than the
+	/// <c>Link</c> class map, it never affects how a <c>Link</c> is serialized anywhere else — notably
+	/// <c>MongoProjection</c>'s native "Links" collection, which must keep those very fields to query by
+	/// endpoint. On replay the materialized link re-stamps LinkId/SourceId/TargetId from the event's own
+	/// explicit fields, so the stripped fields are never read back from Data.
+	/// </summary>
+	sealed class LinkDataSerializer : SerializerBase<object>
 	{
-		public string Name => "Synqra.LinkWellKnownFields";
+		static readonly string[] WellKnown = [nameof(Link.LinkId), nameof(Link.SourceId), nameof(Link.TargetId)];
 
-		public void Apply(BsonClassMap classMap)
+		// Looked up lazily so it resolves the patched, fully-open object serializer (see
+		// PatchObjectSerializerDefaults) rather than whatever might exist at type-init time.
+		IBsonSerializer? _objectSerializer;
+		IBsonSerializer ObjectSerializer => _objectSerializer ??= BsonSerializer.LookupSerializer(typeof(object));
+
+		public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value)
 		{
-			if (classMap.ClassType != typeof(Link))
+			if (value is null)
 			{
+				context.Writer.WriteNull();
 				return;
 			}
-			foreach (var memberMap in classMap.DeclaredMemberMaps.ToArray())
+
+			// Serialize the link to a throwaway document (carries _t + every mapped field), then strip
+			// the three the event already owns and write what's left to the real output.
+			var doc = new BsonDocument();
+			using (var docWriter = new BsonDocumentWriter(doc))
 			{
-				classMap.UnmapMember(memberMap.MemberInfo);
+				ObjectSerializer.Serialize(BsonSerializationContext.CreateRoot(docWriter), args, value);
 			}
+			foreach (var name in WellKnown)
+			{
+				doc.Remove(name);
+			}
+			BsonDocumentSerializer.Instance.Serialize(context, args, doc);
 		}
+
+		public override object Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+			=> ObjectSerializer.Deserialize(context, args);
 	}
 
-	static void RegisterDerived<T>(string discriminator)
+	static void RegisterDerived<T>(string discriminator, Action<BsonClassMap<T>>? configure = null)
 		where T : Event
 	{
 		if (BsonClassMap.IsClassMapRegistered(typeof(T)))
@@ -176,6 +208,7 @@ public static class MongoEventClassMaps
 			// e.g. ObjectCreatedEvent.DataObject is the in-memory materialized object,
 			// marked [JsonIgnore] — it must not be persisted into the durable log.
 			UnmapJsonIgnored(cm);
+			configure?.Invoke(cm);
 		});
 	}
 

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -265,8 +265,11 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	/// type load, independent of Mongo ever having been touched.
 	/// <paramref name="addressingFields"/> names the projection's own non-model bookkeeping columns
 	/// (e.g. a component's <c>ContainerId</c>) to drop before deserializing, alongside the always-
-	/// dropped <c>_id</c> and <c>_t</c> (resolving the type is the only thing <c>_t</c> is for; the
-	/// concrete type's own class map has no member for it).
+	/// dropped <c>_t</c> (resolving the type is the only thing <c>_t</c> is for; the concrete type's
+	/// own class map has no member for it). <c>_id</c> is dropped too — UNLESS the resolved type is a
+	/// <see cref="Link"/>, whose own class map maps <c>_id</c> to the real <c>LinkId</c> member (see
+	/// <see cref="MongoEventClassMaps.Register"/>): stripping it there would leave <c>LinkId</c>
+	/// un-set on the deserialized instance.
 	/// </summary>
 	internal object FromDocument(BsonDocument doc, params string[] addressingFields)
 	{
@@ -275,7 +278,10 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			?? throw new InvalidOperationException($"Unknown discriminator '{discriminator}' — no model is registered under that name.");
 
 		var clone = (BsonDocument)doc.DeepClone();
-		clone.Remove("_id");
+		if (!typeof(Link).IsAssignableFrom(type))
+		{
+			clone.Remove("_id");
+		}
 		clone.Remove("_t");
 		foreach (var field in addressingFields)
 		{
@@ -294,11 +300,19 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	/// declared base/interface's). The globally-registered conventions (see
 	/// <see cref="MongoEventClassMaps.Register"/>, called from this class's static constructor) drop
 	/// any <c>[JsonIgnore]</c> member from that class map, matching the JSON side's persisted shape.
+	/// A type whose own class map already designates an id member (<see cref="Link"/>'s <c>LinkId</c>,
+	/// mapped onto <c>_id</c> — see <see cref="MongoEventClassMaps.Register"/>) gets <c>_id</c> written
+	/// natively as part of that serialization, so it's left alone here; a plain model with no such
+	/// member gets <paramref name="id"/> written as the document's <c>_id</c>, as a native Guid (not a
+	/// string) so every id is represented identically across the whole document.
 	/// </summary>
 	BsonDocument ToDocument(object model, Guid id)
 	{
 		var doc = model.ToBsonDocument(typeof(object));
-		doc["_id"] = id.ToString();
+		if (!doc.Contains("_id"))
+		{
+			doc["_id"] = new BsonBinaryData(id, GuidRepresentation.Standard);
+		}
 		return doc;
 	}
 
@@ -307,7 +321,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		var type = TypeMetadataProvider.GetTypeMetadata(targetTypeId).Type;
 		var collection = _database.GetCollection<BsonDocument>(type.Name);
 		var doc = ToDocument(model, id);
-		collection.ReplaceOne(Builders<BsonDocument>.Filter.Eq("_id", id.ToString()), doc, new ReplaceOptions { IsUpsert = true });
+		collection.ReplaceOne(Builders<BsonDocument>.Filter.Eq("_id", id), doc, new ReplaceOptions { IsUpsert = true });
 	}
 
 	// ---------------------------------------------------------------- ICommandVisitor
@@ -622,7 +636,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		// ToDocument already stamps the "_t" discriminator (= link type name) the per-type queries
 		// filter on, so no separate type column is written here.
 		var doc = ToDocument(link, link.LinkId);
-		linksMongo.ReplaceOne(Builders<BsonDocument>.Filter.Eq("_id", link.LinkId.ToString()), doc, new ReplaceOptions { IsUpsert = true });
+		linksMongo.ReplaceOne(Builders<BsonDocument>.Filter.Eq("_id", link.LinkId), doc, new ReplaceOptions { IsUpsert = true });
 
 		if (link is IBindableModel bindable && bindable.Store is null)
 		{
@@ -634,7 +648,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	public Task VisitAsync(LinkRemovedEvent ev, EventVisitorContext ctx)
 	{
 		var linksMongo = _database.GetCollection<BsonDocument>(LinksMongoCollectionName);
-		linksMongo.DeleteOne(Builders<BsonDocument>.Filter.Eq("_id", ev.LinkId.ToString())); // no-op (idempotent) if already gone
+		linksMongo.DeleteOne(Builders<BsonDocument>.Filter.Eq("_id", ev.LinkId)); // no-op (idempotent) if already gone
 		return Task.CompletedTask;
 	}
 
@@ -661,7 +675,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 
 		foreach (var doc in linksMongo.Find(Builders<BsonDocument>.Filter.And(typeIdFilter, endpointFilter)).ToList())
 		{
-			var candidateId = Guid.Parse(doc["_id"].AsString);
+			var candidateId = doc["_id"].AsGuid;
 			if (candidateId == excludeId)
 			{
 				continue;
@@ -704,17 +718,17 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	/// </summary>
 	static FilterDefinition<BsonDocument> ComponentFilter(Guid containerId, Type componentType, Guid componentId) =>
 		Builders<BsonDocument>.Filter.And(
-			Builders<BsonDocument>.Filter.Eq("ContainerId", containerId.ToString()),
+			Builders<BsonDocument>.Filter.Eq("ContainerId", containerId),
 			Builders<BsonDocument>.Filter.Eq(DiscriminatorField, componentType.Name),
-			Builders<BsonDocument>.Filter.Eq("ComponentId", componentId.ToString()));
+			Builders<BsonDocument>.Filter.Eq("ComponentId", componentId));
 
 	void UpsertComponent(Guid containerId, Guid componentTypeId, Guid componentId, IComponent component)
 	{
 		var componentsMongo = _database.GetCollection<BsonDocument>(ComponentsMongoCollectionName);
 		// Native driver serialization through nominal type object -> always writes "_t" (see ToDocument).
 		var doc = component.ToBsonDocument(typeof(object));
-		doc["ContainerId"] = containerId.ToString();
-		doc["ComponentId"] = componentId.ToString();
+		doc["ContainerId"] = new BsonBinaryData(containerId, GuidRepresentation.Standard);
+		doc["ComponentId"] = new BsonBinaryData(componentId, GuidRepresentation.Standard);
 		componentsMongo.ReplaceOne(ComponentFilter(containerId, component.GetType(), componentId), doc, new ReplaceOptions { IsUpsert = true });
 	}
 
@@ -735,7 +749,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	void LoadComponentsInto(IComponentContainer container, Guid containerId, Guid containerCollectionId)
 	{
 		var componentsMongo = _database.GetCollection<BsonDocument>(ComponentsMongoCollectionName);
-		foreach (var doc in componentsMongo.Find(Builders<BsonDocument>.Filter.Eq("ContainerId", containerId.ToString())).ToList())
+		foreach (var doc in componentsMongo.Find(Builders<BsonDocument>.Filter.Eq("ContainerId", containerId)).ToList())
 		{
 			// Concrete type comes from the "_t" discriminator inside the document (see UpsertComponent) —
 			// no type-id column to read; FromDocument strips the addressing columns and resolves it.
@@ -836,7 +850,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	bool ILinkIndex.TryGetById(Guid linkId, out Link? link)
 	{
 		var linksMongo = _database.GetCollection<BsonDocument>(LinksMongoCollectionName);
-		var doc = linksMongo.Find(Builders<BsonDocument>.Filter.Eq("_id", linkId.ToString())).FirstOrDefault();
+		var doc = linksMongo.Find(Builders<BsonDocument>.Filter.Eq("_id", linkId)).FirstOrDefault();
 		if (doc is null)
 		{
 			link = null;

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -4,8 +4,10 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using Synqra.AppendStorage;
+using Synqra.AppendStorage.MongoDb;
 using Synqra.BinarySerializer;
 
 namespace Synqra.Projection.MongoDb;
@@ -41,6 +43,11 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	static MongoProjection()
 	{
 		AppContext.SetSwitch("Synqra.GuidExtensions.ValidateNamespaceIdHashChain", false);
+		// Native BSON (de)serialization below needs the same global conventions the event log
+		// registers (drop [JsonIgnore] members, skip nulls) and the same patched Guid/object
+		// serializer defaults — register them here too, since a host that wires up MongoDb only for
+		// the projection (not the event log) would otherwise never call this. Idempotent/guarded.
+		MongoEventClassMaps.Register();
 	}
 
 	const string LinksMongoCollectionName = "Links";
@@ -245,38 +252,52 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		=> _database.GetCollection<BsonDocument>(MongoCollectionName(type, collectionName));
 
 	/// <summary>
-	/// Rehydrates a stored document into its concrete model. The concrete type is read from the
-	/// <c>_t</c> discriminator the document carries (written by <see cref="ToDocument"/> via the
-	/// polymorphic <see cref="ObjectConverter"/>) — the same discriminator convention Synqra's models
-	/// and the Mongo event log already use — so the caller never has to pre-resolve the type, and no
-	/// separate type-id side field is needed. <paramref name="addressingFields"/> names the projection's
-	/// own non-model bookkeeping columns (e.g. a component's <c>ContainerId</c>) to drop before
-	/// deserializing; <c>_id</c> is always dropped. Both are appended after <c>_t</c> on write, so
-	/// stripping them leaves <c>_t</c> first, where polymorphic deserialization requires it.
+	/// Rehydrates a stored document into its concrete model via the native MongoDB driver
+	/// serializer — no JSON round-trip. The concrete type is read from the document's own <c>_t</c>
+	/// discriminator (written by <see cref="ToDocument"/>) and resolved through
+	/// <see cref="SynqraJsonTypeInfoResolver.GetByDiscriminator"/> — the very same discriminator
+	/// registry <see cref="ObjectConverter"/> (the JSON side) uses, so both serializers agree on what
+	/// <c>_t</c> values mean without the driver's own (class-map-based) polymorphism machinery ever
+	/// getting involved. That sidesteps a real cold-start gap: BSON's built-in discriminator
+	/// resolution only knows about a type once the driver has auto-mapped it at least once in this
+	/// process, which a freshly-started process reading pre-existing documents can't guarantee —
+	/// whereas Synqra's own registry is populated by each model's generated static registration, at
+	/// type load, independent of Mongo ever having been touched.
+	/// <paramref name="addressingFields"/> names the projection's own non-model bookkeeping columns
+	/// (e.g. a component's <c>ContainerId</c>) to drop before deserializing, alongside the always-
+	/// dropped <c>_id</c> and <c>_t</c> (resolving the type is the only thing <c>_t</c> is for; the
+	/// concrete type's own class map has no member for it).
 	/// </summary>
 	internal object FromDocument(BsonDocument doc, params string[] addressingFields)
 	{
+		var discriminator = doc["_t"].AsString;
+		var type = SynqraJsonTypeInfoResolver.GetByDiscriminator(discriminator)
+			?? throw new InvalidOperationException($"Unknown discriminator '{discriminator}' — no model is registered under that name.");
+
 		var clone = (BsonDocument)doc.DeepClone();
 		clone.Remove("_id");
+		clone.Remove("_t");
 		foreach (var field in addressingFields)
 		{
 			clone.Remove(field);
 		}
-		return JsonSerializer.Deserialize(clone.ToJson(), typeof(object), _jsonSerializerOptions)
-			?? throw new InvalidOperationException("Failed to deserialize a stored document.");
+		return BsonSerializer.Deserialize(clone, type);
 	}
 
 	/// <summary>
-	/// Serializes a model to a stored document through the polymorphic <see cref="ObjectConverter"/>
-	/// (inputType <c>object</c>), so STJ stamps a <c>_t</c> discriminator and every concrete field —
-	/// even when the value is held behind an interface/base (a component behind <c>IComponent</c>, a
-	/// link behind <c>Link</c>). <c>_t</c> is written first; <c>_id</c> and any addressing columns are
-	/// appended after, so a read can strip them and still find <c>_t</c> in the leading position.
+	/// Serializes a model to a stored document via the native MongoDB driver serializer — no JSON
+	/// round-trip. Going through nominal type <c>object</c> (rather than <c>model.GetType()</c>) means
+	/// the driver always sees nominal != actual type, so it always writes the <c>_t</c> discriminator
+	/// — even when the value is held behind an interface/base (a component behind <c>IComponent</c>,
+	/// a link behind <c>Link</c>) where nominal and actual would otherwise coincide. Every concrete
+	/// field is included by construction (this serializes the *actual* type's own class map, not a
+	/// declared base/interface's). The globally-registered conventions (see
+	/// <see cref="MongoEventClassMaps.Register"/>, called from this class's static constructor) drop
+	/// any <c>[JsonIgnore]</c> member from that class map, matching the JSON side's persisted shape.
 	/// </summary>
 	BsonDocument ToDocument(object model, Guid id)
 	{
-		var json = JsonSerializer.Serialize(model, typeof(object), _jsonSerializerOptions);
-		var doc = BsonDocument.Parse(json);
+		var doc = model.ToBsonDocument(typeof(object));
 		doc["_id"] = id.ToString();
 		return doc;
 	}
@@ -627,16 +648,16 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	Guid? FindStructuralDuplicate(IMongoCollection<BsonDocument> linksMongo, Link link, Guid excludeId)
 	{
 		var typeIdFilter = LinkTypeFilter(link.GetType());
-		// SourceId/TargetId are stored as strings — ToDocument round-trips the model through
-		// JsonSerializer, which renders a Guid as a string, not the BSON Binary subtype the driver's
-		// own GuidSerializer would produce for a typed Guid filter value. Compare as strings to match.
+		// SourceId/TargetId are native Link fields, serialized through Link's own class map (the
+		// patched standard GuidSerializer) — filter with a raw Guid so the driver encodes it the same
+		// way (BSON Binary subtype), not a string.
 		var endpointFilter = Builders<BsonDocument>.Filter.Or(
 			Builders<BsonDocument>.Filter.And(
-				Builders<BsonDocument>.Filter.Eq("SourceId", link.SourceId.ToString()),
-				Builders<BsonDocument>.Filter.Eq("TargetId", link.TargetId.ToString())),
+				Builders<BsonDocument>.Filter.Eq("SourceId", link.SourceId),
+				Builders<BsonDocument>.Filter.Eq("TargetId", link.TargetId)),
 			Builders<BsonDocument>.Filter.And(
-				Builders<BsonDocument>.Filter.Eq("SourceId", link.TargetId.ToString()),
-				Builders<BsonDocument>.Filter.Eq("TargetId", link.SourceId.ToString())));
+				Builders<BsonDocument>.Filter.Eq("SourceId", link.TargetId),
+				Builders<BsonDocument>.Filter.Eq("TargetId", link.SourceId)));
 
 		foreach (var doc in linksMongo.Find(Builders<BsonDocument>.Filter.And(typeIdFilter, endpointFilter)).ToList())
 		{
@@ -669,12 +690,13 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	/// <summary>
 	/// Components are persisted in their own shared Mongo collection — NOT embedded in their
 	/// container's own document the way the container's plain properties are. <see cref="IComponentsCollection"/>'s
-	/// element type is the marker interface <see cref="IComponent"/>; serialized naively through that
-	/// declared element type, <c>System.Text.Json</c> would drop every concrete field. The fix is the
-	/// polymorphic <see cref="ObjectConverter"/> (see <see cref="ToDocument"/>): serializing through
-	/// <c>object</c> stamps a <c>_t</c> discriminator and all concrete fields, and reading back through
-	/// <c>object</c> resolves the concrete type from <c>_t</c> alone. So the stored document needs no
-	/// separate type-id column — the <c>_t</c> discriminator doubles as the type filter, mirroring how
+	/// element type is the marker interface <see cref="IComponent"/>; serialized through that
+	/// declared element type, the driver would build a class map for the interface itself (which has
+	/// no members) and drop every concrete field. Going through nominal type <c>object</c> (see
+	/// <see cref="ToDocument"/>) sidesteps that — the driver serializes the *actual* type's own class
+	/// map and always stamps a <c>_t</c> discriminator, and reading back resolves the concrete type
+	/// from <c>_t</c> alone via <see cref="FromDocument"/>. So the stored document needs no separate
+	/// type-id column — the <c>_t</c> discriminator doubles as the type filter, mirroring how
 	/// links are stored. The remaining (container, type, id) addressing matches how
 	/// <see cref="ComponentApplyHelpers.ResolveComponent"/> addresses a component on the live, in-memory
 	/// side of this same apply path — with the type filtered via <c>_t</c> so a unique component
@@ -689,10 +711,8 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	void UpsertComponent(Guid containerId, Guid componentTypeId, Guid componentId, IComponent component)
 	{
 		var componentsMongo = _database.GetCollection<BsonDocument>(ComponentsMongoCollectionName);
-		// Through object -> ObjectConverter stamps "_t" first plus every concrete field; ContainerId /
-		// ComponentId are appended after, so a read strips them and still finds "_t" leading.
-		var json = JsonSerializer.Serialize(component, typeof(object), _jsonSerializerOptions);
-		var doc = BsonDocument.Parse(json);
+		// Native driver serialization through nominal type object -> always writes "_t" (see ToDocument).
+		var doc = component.ToBsonDocument(typeof(object));
 		doc["ContainerId"] = containerId.ToString();
 		doc["ComponentId"] = componentId.ToString();
 		componentsMongo.ReplaceOne(ComponentFilter(containerId, component.GetType(), componentId), doc, new ReplaceOptions { IsUpsert = true });
@@ -763,16 +783,15 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	IReadOnlyList<Link> ILinkIndex.LinksAt(Guid nodeId, LinkEnd end, Type linkType)
 	{
 		var linksMongo = _database.GetCollection<BsonDocument>(LinksMongoCollectionName);
-		// Compared as strings — see FindStructuralDuplicate's remark on why.
-		var nodeIdString = nodeId.ToString();
+		// Native Guid filter — see FindStructuralDuplicate's remark on why.
 		var endpointFilter = end switch
 		{
 			LinkEnd.None => throw new ArgumentException("LinkEnd.None is not a valid link end.", nameof(end)),
-			LinkEnd.Source => Builders<BsonDocument>.Filter.Eq("SourceId", nodeIdString),
-			LinkEnd.Target => Builders<BsonDocument>.Filter.Eq("TargetId", nodeIdString),
+			LinkEnd.Source => Builders<BsonDocument>.Filter.Eq("SourceId", nodeId),
+			LinkEnd.Target => Builders<BsonDocument>.Filter.Eq("TargetId", nodeId),
 			_ => Builders<BsonDocument>.Filter.Or(
-				Builders<BsonDocument>.Filter.Eq("SourceId", nodeIdString),
-				Builders<BsonDocument>.Filter.Eq("TargetId", nodeIdString)),
+				Builders<BsonDocument>.Filter.Eq("SourceId", nodeId),
+				Builders<BsonDocument>.Filter.Eq("TargetId", nodeId)),
 		};
 		return linksMongo.Find(Builders<BsonDocument>.Filter.And(LinkTypeFilter(linkType), endpointFilter)).ToList()
 			.Select(LoadLink)
@@ -782,11 +801,9 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	IReadOnlyList<Link> ILinkIndex.LinksBetween(Guid a, Guid b, Type linkType)
 	{
 		var linksMongo = _database.GetCollection<BsonDocument>(LinksMongoCollectionName);
-		var aString = a.ToString();
-		var bString = b.ToString();
 		var endpointFilter = Builders<BsonDocument>.Filter.Or(
-			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", aString), Builders<BsonDocument>.Filter.Eq("TargetId", bString)),
-			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", bString), Builders<BsonDocument>.Filter.Eq("TargetId", aString)));
+			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", a), Builders<BsonDocument>.Filter.Eq("TargetId", b)),
+			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", b), Builders<BsonDocument>.Filter.Eq("TargetId", a)));
 		return linksMongo.Find(Builders<BsonDocument>.Filter.And(LinkTypeFilter(linkType), endpointFilter)).ToList()
 			.Select(LoadLink)
 			.ToArray();
@@ -796,11 +813,9 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	{
 		var linkType = key.LinkType;
 		var linksMongo = _database.GetCollection<BsonDocument>(LinksMongoCollectionName);
-		var xString = key.X.ToString();
-		var yString = key.Y.ToString();
 		var endpointFilter = Builders<BsonDocument>.Filter.Or(
-			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", xString), Builders<BsonDocument>.Filter.Eq("TargetId", yString)),
-			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", yString), Builders<BsonDocument>.Filter.Eq("TargetId", xString)));
+			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", key.X), Builders<BsonDocument>.Filter.Eq("TargetId", key.Y)),
+			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", key.Y), Builders<BsonDocument>.Filter.Eq("TargetId", key.X)));
 
 		foreach (var doc in linksMongo.Find(Builders<BsonDocument>.Filter.And(LinkTypeFilter(linkType), endpointFilter)).ToList())
 		{

--- a/Synqra.Projection.MongoDb/MongoStoreCollection.cs
+++ b/Synqra.Projection.MongoDb/MongoStoreCollection.cs
@@ -69,7 +69,7 @@ internal sealed class MongoStoreCollection<T> : MongoStoreCollection, ISynqraCol
 	{
 		foreach (var doc in _mongo.Find(FilterDefinition<BsonDocument>.Empty).ToList())
 		{
-			var id = Guid.Parse(doc["_id"].AsString);
+			var id = doc["_id"].AsGuid;
 			if (_projection.TryGetTracked(id, out var existing))
 			{
 				yield return (T)existing;

--- a/Synqra.Projection.MongoDb/Synqra.Projection.MongoDb.csproj
+++ b/Synqra.Projection.MongoDb/Synqra.Projection.MongoDb.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Synqra.AppendStorage.Abstractions\Synqra.AppendStorage.Abstractions.csproj" />
+    <ProjectReference Include="..\Synqra.AppendStorage.MongoDb\Synqra.AppendStorage.MongoDb.csproj" />
     <ProjectReference Include="..\Synqra.BinarySerializer\Synqra.BinarySerializer.csproj" />
     <ProjectReference Include="..\Synqra.Model\Synqra.Model.csproj" />
     <ProjectReference Include="..\Synqra.Projection.CommonStoreSupport\Synqra.Projection.CommonStoreSupport.csproj" />


### PR DESCRIPTION
## Context

PR #94 landed with only its first commit (a801edf -> rebased as bb9c187 on master-quotaly): replace the `_linkTypeId`/`ComponentTypeId` side columns with the `_t` discriminator, still serializing through a JSON-string bridge (`JsonSerializer` + `BsonDocument.Parse`/`.ToJson()`). The PR was merged before its two follow-up commits landed on the branch — they're orphaned on the now-closed `feat/mongo-polymorphic-storage` branch. This PR re-proposes them, rebased onto the current `master-quotaly`.

## What this carries

1. **Member-scoped serializer for `LinkAddedEvent.Data`** — replaces the global `LinkWellKnownFieldsConvention` (which unmapped `LinkId`/`SourceId`/`TargetId` from `Link`'s own BSON class map, globally) with `LinkDataSerializer`, attached only to the `Data` member. The global strip would have clobbered any future native-BSON link storage; the member-scoped version doesn't touch the `Link` class map at all.

2. **Native BSON for MongoProjection's read-model** — `ToDocument`/`FromDocument`/`UpsertComponent` go through the MongoDB driver directly (`model.ToBsonDocument(typeof(object))` / `BsonSerializer.Deserialize`), not a JSON round-trip. `_t` resolution reuses `SynqraJsonTypeInfoResolver.GetByDiscriminator` (same registry the JSON side already uses) rather than the driver's own class-map-based polymorphism, sidestepping a cold-start gap.

3. **Consistent native Guid representation + `Link.LinkId` → `_id`** — `_id`/`ContainerId`/`ComponentId` were still plain BSON strings while everything else (event log, `SourceId`/`TargetId`) was native `Binary`. Fixed to native Guid throughout. `Link.LinkId` is now mapped onto `_id` via `cm.MapIdProperty(x => x.LinkId)` (not a `[BsonId]` attribute — `Synqra.Model` has no MongoDB dependency), eliminating a redundant duplicate field a Links document previously carried (`_id` and `LinkId` with the identical value).

## Verification

Full suite **170/170** against a real mongod, after each commit. Stored shape confirmed by hand via mongosh:
```
Links:      { _id, _t, SourceId, TargetId }              -- no separate LinkId, all native UUID
Components: { _id (ObjectId), _t, ...fields, ContainerId, ComponentId } -- Container/ComponentId native UUID
Nodes:      { _id, _t, ...fields }                        -- _id native UUID
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)