### PR TITLE
Add TODO.md tracking the MongoStoreCollection streaming gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,12 @@ minimal, auto-merge-safe diffs.
 - Be careful with replay ordering. A number of tests assume event order is preserved across append storage and projection replay.
 - Generated files, schema attributes, migration scripts, and compiled EF artifacts should only be updated when the change actually requires them.
 
+## Deferred Work / TODO
+
+Known improvements and deferred items live in [`TODO.md`](TODO.md). Check it before working in an
+area (it may already describe the cleanup you're about to do), and add an entry there rather than
+leaving a silent `// TODO` in code.
+
 ## Good First Read Before Editing
 
 - `readme.md`

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# Synqra TODO
+
+Deferred / known-improvement items. Prefer referencing an entry here over leaving a silent
+`// TODO` in code, so the work is discoverable and tracked.
+
+## Projection.MongoDb
+
+- [ ] **`MongoStoreCollection<T>` enumerator should stream, not materialize.**
+  `Synqra.Projection.MongoDb/MongoStoreCollection.cs` → `IEnumerable<T>.GetEnumerator()` calls
+  `_mongo.Find(Scope).ToList()`, which eagerly loads the entire (scoped) collection into memory
+  before yielding anything. Switch to lazy cursor streaming (e.g. `Find(Scope).ToEnumerable()`, or
+  explicit `ToCursor()` iteration) so `yield return` pulls documents on demand and large
+  collections aren't fully materialized. Mind cursor lifetime/disposal across the `yield`.


### PR DESCRIPTION
Small housekeeping PR: adds `TODO.md` (deferred-work tracker) and references it from `AGENTS.md`.

Records the one item still open from the earlier Mongo-projection work (superseded by the Link/Edge framework + native BSON serialization already on `master-quotaly`): `MongoStoreCollection<T>.GetEnumerator()` calls `.Find(Scope).ToList()`, eagerly materializing the whole scoped collection instead of streaming the cursor lazily.

No code behavior changes.