### PR TITLE
Throw clearly instead of silently empty for GetCollection<TLink>()

### DIFF
--- a/Synqra.Projection.CommonStoreSupport/ComponentAndLinkApplyHelpers.cs
+++ b/Synqra.Projection.CommonStoreSupport/ComponentAndLinkApplyHelpers.cs
@@ -113,6 +113,24 @@ public static class ComponentApplyHelpers
 /// <summary>Pure materialization logic shared by every projection's link event-apply path.</summary>
 public static class LinkApplyHelpers
 {
+	/// <summary>
+	/// Guards every projection's <c>GetCollection</c>/<c>GetCollection&lt;T&gt;</c> against
+	/// <see cref="Link"/>-derived types. Links never live in the generic per-type collection those
+	/// methods build — they have their own dedicated index (<see cref="ILinkIndex"/>) maintained from
+	/// <see cref="LinkAddedEvent"/>/<see cref="LinkRemovedEvent"/> (see plans/links.md). Without this
+	/// guard, <c>GetCollection&lt;TLink&gt;()</c> compiles fine and silently returns an always-empty
+	/// collection, since nothing ever populates it for a link type.
+	/// </summary>
+	public static void GuardNotLinkType(Type type)
+	{
+		if (typeof(Link).IsAssignableFrom(type))
+		{
+			throw new NotSupportedException(
+				$"GetCollection<{type.Name}>() cannot be used for '{type.Name}' — it derives from Link, and links are not stored in the generic object collection. " +
+				$"Use ILinkIndex instead (cast the store to ILinkIndex and read Links / LinksAt / LinksBetween), or the generated [To]/[From]/[Related] navigation properties.");
+		}
+	}
+
 	/// <summary>Same three-case materialization <see cref="ComponentApplyHelpers.MaterializeComponent"/> uses: live instance, json-shaped dict, or fresh instance with no payload.</summary>
 	public static Link MaterializeLink(Type linkType, object? data)
 	{

--- a/Synqra.Projection.File/_DI.cs
+++ b/Synqra.Projection.File/_DI.cs
@@ -146,6 +146,7 @@ public static class FileSynqraExtensions
 
 		internal FileObjectCollection GetCollection(Type type, string collectionName = "")
 		{
+			Synqra.Projection.LinkApplyHelpers.GuardNotLinkType(type);
 			var metadata = TypeMetadataProvider.GetTypeMetadata(type);
 			var collectionId = metadata.GetCollectionId(collectionName ?? throw new ArgumentNullException(nameof(collectionName)));
 
@@ -159,6 +160,7 @@ public static class FileSynqraExtensions
 
 		internal FileObjectCollection<T> GetCollection<T>(string collectionName = "") where T : class
 		{
+			Synqra.Projection.LinkApplyHelpers.GuardNotLinkType(typeof(T));
 			var metadata = TypeMetadataProvider.GetTypeMetadata(typeof(T));
 			var collectionId = metadata.GetCollectionId(collectionName);
 			return GetCollection<T>(collectionId);

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -376,6 +376,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 
 	internal InMemoryStoreCollection GetCollection(Type type, string collectionName)
 	{
+		LinkApplyHelpers.GuardNotLinkType(type);
 		var collectionId = GetCollectionId(type, collectionName ?? throw new ArgumentNullException(nameof(collectionName)));
 #if NET7_0_OR_GREATER
 		ref var slot = ref CollectionsMarshal.GetValueRefOrAddDefault(_collections, collectionId, out var exists);
@@ -405,6 +406,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 
 	internal InMemoryStoreCollection<T> GetCollectionInternal<T>(string? collectionName = null) where T : class
 	{
+		LinkApplyHelpers.GuardNotLinkType(typeof(T));
 		var collectionId = GetCollectionId(typeof(T), collectionName ?? "");
 #if NET7_0_OR_GREATER
 		ref var slot = ref CollectionsMarshal.GetValueRefOrAddDefault(_collections, collectionId, out var exists);

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -120,6 +120,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 
 	internal MongoStoreCollection GetCollection(Type type, string collectionName)
 	{
+		LinkApplyHelpers.GuardNotLinkType(type);
 		var collectionId = TypeMetadataProvider.GetTypeMetadata(type).GetCollectionId(collectionName ?? "");
 		lock (_collectionsGate)
 		{

--- a/Synqra.Projection.Sqlite/SqliteProjection.cs
+++ b/Synqra.Projection.Sqlite/SqliteProjection.cs
@@ -247,6 +247,7 @@ public class SqliteStore : IObjectStore
 
 	internal StoreCollection GetCollection(Type type, string collectionName)
 	{
+		Synqra.Projection.LinkApplyHelpers.GuardNotLinkType(type);
 		var collectionId = GetCollectionId(type, collectionName ?? throw new ArgumentNullException(nameof(collectionName)));
 #if NET7_0_OR_GREATER
 		ref var slot = ref CollectionsMarshal.GetValueRefOrAddDefault(_collections, collectionId, out var exists);
@@ -272,6 +273,7 @@ public class SqliteStore : IObjectStore
 	internal SqliteStoreCollection<T> GetCollection<T>(string collectionName)
 		where T : class
 	{
+		Synqra.Projection.LinkApplyHelpers.GuardNotLinkType(typeof(T));
 		var collectionId = GetCollectionId(typeof(T), collectionName ?? throw new ArgumentNullException(nameof(collectionName)));
 #if NET7_0_OR_GREATER
 		ref var slot = ref CollectionsMarshal.GetValueRefOrAddDefault(_collections, collectionId, out var exists);

--- a/Tests/Synqra.Tests/LinksTests.cs
+++ b/Tests/Synqra.Tests/LinksTests.cs
@@ -584,4 +584,44 @@ public class LinksTests
 		await Assert.That(aChanged).Contains(nameof(TestGraphNode.RelatedNodes));
 		await Assert.That(bChanged).Contains(nameof(TestGraphNode.RelatedNodes));
 	}
+
+	// ---- GetCollection<TLink>() footgun: links never ride the generic object collection, so
+	// calling GetCollection<T>() for a Link-derived type used to silently come back empty instead
+	// of surfacing the mistake — must throw a clear error pointing at ILinkIndex instead. ----
+
+	[Test]
+	public async Task Should_throw_a_clear_error_when_GetCollection_is_called_for_a_link_type()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+
+		var a = AddNode(store, "a");
+		var b = AddNode(store, "b");
+		a.Children.Add(b); // a real HierarchyLink now exists — proves the throw isn't masking an empty-anyway case
+
+		var ex = await Assert.ThrowsAsync(async () =>
+		{
+			store.GetCollection<HierarchyLink>();
+			await Task.CompletedTask;
+		});
+
+		await Assert.That(ex is NotSupportedException).IsTrue();
+		await Assert.That(ex!.Message).Contains("ILinkIndex");
+	}
+
+	[Test]
+	public async Task Should_throw_a_clear_error_when_the_non_generic_GetCollection_is_called_for_a_link_type()
+	{
+		var sp = BuildServices();
+		var store = sp.GetRequiredService<IObjectStore>();
+
+		var ex = await Assert.ThrowsAsync(async () =>
+		{
+			store.GetCollection(typeof(HierarchyLink), null);
+			await Task.CompletedTask;
+		});
+
+		await Assert.That(ex is NotSupportedException).IsTrue();
+		await Assert.That(ex!.Message).Contains("ILinkIndex");
+	}
 }


### PR DESCRIPTION
## Summary
- `GetCollection<T>()`/`GetCollection(Type, string)` compiled fine for `Link`-derived types but silently returned an always-empty collection — links live in `ILinkIndex`, not the generic per-type collection. This shipped as a real bug in a consumer (wires never rendered in two UI views) before being tracked down.
- Added `LinkApplyHelpers.GuardNotLinkType(Type)` and wired it into every projection's `GetCollection`/`GetCollection<T>` (InMemory, Mongo, Sqlite, File) — now throws `NotSupportedException` pointing the caller at `ILinkIndex` instead of returning empty.

## Test plan
- [x] Added regression tests in `LinksTests.cs` covering both the generic and non-generic `GetCollection` overloads against a real (non-empty) link type, asserting `NotSupportedException` mentioning `ILinkIndex`.
- [x] `dotnet test Tests/Synqra.Tests/Synqra.Tests.csproj -f net10.0` — 172/172 passing.