### PR TITLE
Mongo2Go removal support + reflection-free Guid/object serializer scoping

### DIFF
--- a/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.Json.Serialization;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
@@ -51,8 +50,16 @@ public static class MongoEventClassMaps
 				return;
 			}
 
-			PatchObjectSerializerDefaults();
-			RegisterJsonIgnoreConvention();
+			// LINQ filters/projections (e.g. a raw Guid key in Builders<T>.Filter.Eq) resolve their
+			// Guid serializer from this global registry, not from any class map's member serializer
+			// — a member-scoped fix (the convention below) can't reach query-time serialization at
+			// all. TryRegisterSerializer (not RegisterSerializer) so this is a no-op, not a throw,
+			// if Security/Jobs/SimpleV1 already claimed the slot first — every feature in this
+			// process wants the exact same GuidRepresentation.Standard, so whichever asks first
+			// "winning" is fine, unlike RegisterSerializer which throws on a second caller
+			// regardless of whether the value would've matched.
+			BsonSerializer.TryRegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
+			RegisterSynqraConventions();
 
 			if (!BsonClassMap.IsClassMapRegistered(typeof(Event)))
 			{
@@ -114,8 +121,8 @@ public static class MongoEventClassMaps
 	}
 
 	/// <summary>
-	/// Registers two global conventions applied to <em>any</em> class map BSON builds — including
-	/// ones never explicitly registered here:
+	/// Registers conventions applied to <em>any</em> class map BSON builds for Synqra's own
+	/// model ecosystem — including ones never explicitly registered here:
 	/// <list type="bullet">
 	/// <item>
 	/// Strips every <see cref="JsonIgnoreAttribute"/>-marked member. Without this, a dynamic
@@ -135,18 +142,39 @@ public static class MongoEventClassMaps
 	/// command-handling path) are nullable reference types, so without this every document carries
 	/// an explicit <c>"Field": null</c> for each one that happens not to apply.
 	/// </item>
+	/// <item>
+	/// Attaches an explicit, member-scoped <see cref="GuidSerializer"/>/<see cref="ObjectSerializer"/>
+	/// to every <see cref="Guid"/>- and <c>object</c>-typed member (<see cref="GuidAndObjectSerializerConvention"/>).
+	/// The MongoDB driver's process-wide defaults require an explicit GUID representation and refuse
+	/// to (de)serialize an <c>object</c>-typed member holding a type it doesn't recognize as "safe" —
+	/// both confirmed still true on the current driver version, not legacy baggage — but neither needs
+	/// a process-wide fix: scoping both choices to Synqra's own member maps via this convention (the
+	/// same filter as the other conventions in this pack) gets exactly the same outcome with zero
+	/// blast radius outside Synqra's own types. This replaces an earlier approach that reached into
+	/// <see cref="BsonSerializer"/>/<see cref="ObjectSerializer"/> internals via reflection and
+	/// overwrote them process-wide — confirmed unnecessary by direct experiment: a member-scoped
+	/// serializer fully resolves both errors, and an unrelated class map elsewhere in the same process
+	/// is unaffected and still gets the driver's strict defaults.
+	/// </item>
 	/// </list>
 	/// <para>
 	/// Note: the redundancy where <see cref="LinkAddedEvent.Data"/> (a concrete <c>Link</c>) would
 	/// duplicate the three well-known fields the event already carries explicitly is handled NOT here
 	/// (a global Link-class-map strip would also clobber <c>MongoProjection</c>'s native link storage,
 	/// which needs those fields to query) but by a member-scoped <see cref="LinkDataSerializer"/> on the
-	/// <c>Data</c> member alone — see its registration in <see cref="Register"/>.
+	/// <c>Data</c> member alone — see its registration in <see cref="Register"/>. That serializer reuses
+	/// this same scoped, wide-open <see cref="ObjectSerializer"/> instance (<see cref="ScopedOpenObjectSerializer"/>)
+	/// rather than looking one up ambiently.
 	/// </para>
 	/// </summary>
-	static void RegisterJsonIgnoreConvention()
+	static void RegisterSynqraConventions()
 	{
-		var pack = new ConventionPack { new JsonIgnoreConvention(), new IgnoreIfNullConvention(true) };
+		var pack = new ConventionPack
+		{
+			new JsonIgnoreConvention(),
+			new IgnoreIfNullConvention(true),
+			new GuidAndObjectSerializerConvention(),
+		};
 		// Scoped to Synqra's own model ecosystem — NOT a blanket `_ => true`. That filter
 		// previously applied this pack to every class map in the process, including
 		// completely unrelated host application types that have nothing to do with Synqra
@@ -160,10 +188,45 @@ public static class MongoEventClassMaps
 		// model or Link subclass without needing per-type registration — the original
 		// reason `_ => true` was used — while excluding everything that isn't Synqra's.
 		ConventionRegistry.Register(
-			"Synqra.JsonIgnoreAndSkipNulls"
+			"Synqra.MemberConventions"
 			, pack
 			, t => typeof(Event).IsAssignableFrom(t) || typeof(Link).IsAssignableFrom(t) || typeof(IBindableModel).IsAssignableFrom(t)
 		);
+	}
+
+	/// <summary>
+	/// Shared, wide-open object serializer — see <see cref="RegisterSynqraConventions"/>. Also used
+	/// directly (not via ambient <c>BsonSerializer.LookupSerializer</c>) wherever a model is serialized
+	/// with nominal type <c>object</c> to force the <c>_t</c> discriminator — e.g.
+	/// <c>MongoProjection.ToDocument</c> — since that path has no class-map member to scope a
+	/// convention to, and the driver's own ambient default rejects any type it doesn't recognize.
+	/// </summary>
+	public static readonly IBsonSerializer ScopedOpenObjectSerializer = new ObjectSerializer(static _ => true);
+
+	/// <summary>Shared, member-scoped <see cref="GuidRepresentation.Standard"/> serializer — see <see cref="RegisterSynqraConventions"/>.</summary>
+	static readonly IBsonSerializer ScopedStandardGuidSerializer = new GuidSerializer(GuidRepresentation.Standard);
+
+	/// <summary>
+	/// Attaches <see cref="ScopedStandardGuidSerializer"/> to every <see cref="Guid"/>/<c>Guid?</c> member
+	/// and <see cref="ScopedOpenObjectSerializer"/> to every <c>object</c>-typed member it sees — scoped to
+	/// whichever types the enclosing <see cref="ConventionPack"/> is registered against (Synqra's own
+	/// ecosystem), never touching the driver's process-wide defaults. See <see cref="RegisterSynqraConventions"/>.
+	/// </summary>
+	sealed class GuidAndObjectSerializerConvention : IMemberMapConvention
+	{
+		public string Name => "Synqra.GuidAndObjectSerializer";
+
+		public void Apply(BsonMemberMap memberMap)
+		{
+			if (memberMap.MemberType == typeof(Guid) || memberMap.MemberType == typeof(Guid?))
+			{
+				memberMap.SetSerializer(ScopedStandardGuidSerializer);
+			}
+			else if (memberMap.MemberType == typeof(object))
+			{
+				memberMap.SetSerializer(ScopedOpenObjectSerializer);
+			}
+		}
 	}
 
 	sealed class JsonIgnoreConvention : IClassMapConvention
@@ -200,10 +263,9 @@ public static class MongoEventClassMaps
 	{
 		static readonly string[] WellKnown = ["_id", nameof(Link.SourceId), nameof(Link.TargetId)];
 
-		// Looked up lazily so it resolves the patched, fully-open object serializer (see
-		// PatchObjectSerializerDefaults) rather than whatever might exist at type-init time.
-		IBsonSerializer? _objectSerializer;
-		IBsonSerializer ObjectSerializer => _objectSerializer ??= BsonSerializer.LookupSerializer(typeof(object));
+		// Reuses the same scoped, wide-open instance the GuidAndObjectSerializerConvention attaches
+		// elsewhere — never the driver's restrictive process-wide default.
+		static IBsonSerializer ObjectSerializer => ScopedOpenObjectSerializer;
 
 		public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value)
 		{
@@ -266,111 +328,4 @@ public static class MongoEventClassMaps
 		}
 	}
 
-	/// <summary>
-	/// Forces two ambient MongoDB defaults that the public API cannot reliably change once the
-	/// process has started, by reaching into <see cref="BsonSerializer"/>/<see cref="ObjectSerializer"/>
-	/// internals and overwriting them directly rather than asking nicely. Both fixes are needed for
-	/// any <c>object</c>-typed event member that carries a live, concrete payload — e.g.
-	/// <see cref="LinkAddedEvent.Data"/> (the link instance itself, mirroring
-	/// <see cref="ComponentAddedEvent.Data"/>'s contract) or a boxed <see cref="Guid"/> like
-	/// <see cref="ObjectPropertyChangedEvent.NewValue"/>:
-	/// <list type="number">
-	/// <item>
-	/// <b>GUID representation.</b> MongoDB driver 3.x requires an explicit one; the obvious approach
-	/// — <c>BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard))</c> —
-	/// does not work reliably. The global registry lazily self-registers a default
-	/// <c>GuidSerializer(Unspecified)</c> the moment ANYTHING in the process first asks for one
-	/// (observed in practice: a driver-internal admin command from test infrastructure spinning up
-	/// a database, well before this method ever runs), and the public API refuses to register a
-	/// different one over an existing registration — first ask wins, permanently. Overwriting the
-	/// registry's backing dictionary entry directly sidesteps that race: it doesn't matter who got
-	/// there first, because this replaces whatever is there.
-	/// </item>
-	/// <item>
-	/// <b>Type allowlist.</b> The default <see cref="ObjectSerializer"/> refuses to (de)serialize any
-	/// type it doesn't recognize as "safe" — a deliberate anti-gadget-attack default aimed at
-	/// untrusted input, which an event-sourcing log's own application-defined payload types are not.
-	/// Constructing a replacement with both allowed-type predicates open and patching it in the same
-	/// way covers this.
-	/// </item>
-	/// </list>
-	/// <para>
-	/// Each <c>ObjectSerializer</c> instance carries its own copies of both — a private
-	/// <c>_guidSerializer</c> field and the allowed-type predicates — fixed at construction, never
-	/// re-read from the registry afterward. And there can be multiple instances already cached
-	/// (confirmed empirically: <c>ObjectSerializer.Instance</c> and whatever the registry separately
-	/// resolved for <c>typeof(object)</c> are NOT the same object), so a single freshly-constructed,
-	/// fully-open replacement is force-installed everywhere an instance could come from: the
-	/// registry's <c>typeof(object)</c> slot, the <c>ObjectSerializer.Instance</c> static field
-	/// itself, and any other <c>ObjectSerializer</c> already sitting in the registry cache.
-	/// </para>
-	/// <para>
-	/// Reflects into <see cref="BsonSerializer"/>/<see cref="BsonSerializerRegistry"/>/
-	/// <see cref="ObjectSerializer"/> internals — all private and unsupported, so a driver upgrade
-	/// could rename or restructure them. If that happens this degrades to a no-op (caught and
-	/// ignored) rather than a crash; the symptom would be the same "GuidRepresentation is
-	/// Unspecified" / "is not configured as a type that is allowed to be serialized" exceptions this
-	/// method exists to prevent, at which point the field names below need updating for the new
-	/// driver version.
-	/// </para>
-	/// </summary>
-	static void PatchObjectSerializerDefaults()
-	{
-		try
-		{
-			var standardGuid = new GuidSerializer(GuidRepresentation.Standard);
-			var openPredicate = (Func<Type, bool>)(static _ => true);
-
-			var guidSerializerField = typeof(ObjectSerializer).GetField("_guidSerializer", BindingFlags.NonPublic | BindingFlags.Instance);
-			var allowedSerializeField = typeof(ObjectSerializer).GetField("_allowedSerializationTypes", BindingFlags.NonPublic | BindingFlags.Instance);
-			var allowedDeserializeField = typeof(ObjectSerializer).GetField("_allowedDeserializationTypes", BindingFlags.NonPublic | BindingFlags.Instance);
-
-			// Mutate fields on the EXISTING instance(s) in place — instance fields stay mutable via
-			// reflection even when readonly, unlike a `static readonly` field (see below). This is
-			// the only thing that actually works: replacing ObjectSerializer's `static readonly
-			// __instance` field throws FieldAccessException ("Cannot set initonly static field
-			// ... after type is initialized") under this runtime, so swapping in a freshly
-			// constructed instance is not an option — every already-existing ObjectSerializer has
-			// to be patched where it stands.
-			void PatchInstance(ObjectSerializer instance)
-			{
-				guidSerializerField?.SetValue(instance, standardGuid);
-				allowedSerializeField?.SetValue(instance, openPredicate);
-				allowedDeserializeField?.SetValue(instance, openPredicate);
-			}
-
-			PatchInstance(ObjectSerializer.Instance);
-
-			var registry = typeof(BsonSerializer)
-				.GetField("__serializerRegistry", BindingFlags.NonPublic | BindingFlags.Static)?
-				.GetValue(null);
-			var cache = registry?.GetType()
-				.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-				.GetValue(registry) as System.Collections.Concurrent.ConcurrentDictionary<Type, IBsonSerializer>;
-			if (cache is not null)
-			{
-				cache[typeof(Guid)] = standardGuid;
-				// Patch whatever ObjectSerializer instance(s) are already cached under some other
-				// type key (e.g. a closed-over instance from before this method ran), and make sure
-				// the registry's own typeof(object) slot holds a patched instance too — calling
-				// GetOrAdd-style LookupSerializer for the first time would otherwise construct (and
-				// cache) a fresh, restricted instance this method never gets to touch.
-				if (!cache.TryGetValue(typeof(object), out var existingObjectSerializer) || existingObjectSerializer is not ObjectSerializer)
-				{
-					cache[typeof(object)] = ObjectSerializer.Instance;
-				}
-				foreach (var cached in cache.Values)
-				{
-					if (cached is ObjectSerializer os)
-					{
-						PatchInstance(os);
-					}
-				}
-			}
-		}
-		catch
-		{
-			// Best-effort: see the "unsupported reflection" remarks above.
-		}
-	}
 }

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -309,7 +309,11 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	/// </summary>
 	BsonDocument ToDocument(object model, Guid id)
 	{
-		var doc = model.ToBsonDocument(typeof(object));
+		// Explicit serializer, not ambient BsonSerializer.LookupSerializer(typeof(object)) — the
+		// driver's own default ObjectSerializer rejects any concrete type it doesn't recognize as
+		// "safe", and a consumer's model type (e.g. a Quotaly feature's Node) is never one ahead of
+		// time. See MongoEventClassMaps.ScopedOpenObjectSerializer's own remarks.
+		var doc = model.ToBsonDocument(typeof(object), MongoEventClassMaps.ScopedOpenObjectSerializer);
 		if (!doc.Contains("_id"))
 		{
 			doc["_id"] = new BsonBinaryData(id, GuidRepresentation.Standard);
@@ -727,7 +731,8 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	{
 		var componentsMongo = _database.GetCollection<BsonDocument>(ComponentsMongoCollectionName);
 		// Native driver serialization through nominal type object -> always writes "_t" (see ToDocument).
-		var doc = component.ToBsonDocument(typeof(object));
+		// Explicit serializer, not ambient lookup — see ToDocument's own remarks.
+		var doc = component.ToBsonDocument(typeof(object), MongoEventClassMaps.ScopedOpenObjectSerializer);
 		doc["ContainerId"] = new BsonBinaryData(containerId, GuidRepresentation.Standard);
 		doc["ComponentId"] = new BsonBinaryData(componentId, GuidRepresentation.Standard);
 		componentsMongo.ReplaceOne(ComponentFilter(containerId, component.GetType(), componentId), doc, new ReplaceOptions { IsUpsert = true });

--- a/Synqra.Projection.MongoDb/_DI.cs
+++ b/Synqra.Projection.MongoDb/_DI.cs
@@ -85,7 +85,16 @@ public static class MongoSynqraStoreExtensions
 				? options.DatabaseName!
 				: string.IsNullOrWhiteSpace(url.DatabaseName) ? "synqra" : url.DatabaseName;
 			var database = new MongoClient(options.ConnectionString).GetDatabase(databaseName);
-			return ActivatorUtilities.CreateInstance<MongoProjection>(sp, database);
+			// MongoProjection's IAppendStorage<Event,Guid> constructor parameter is optional, so
+			// ActivatorUtilities would otherwise silently resolve it UNKEYED (or null if nothing
+			// unkeyed is registered) — confirmed losing every event silently in a keyed setup with
+			// no error anywhere. Pass the keyed instance explicitly, same as `database` already is.
+			// (Can't pass a null reference as an explicit ActivatorUtilities parameter — it matches
+			// explicit params by their runtime type, which throws on null — so branch instead.)
+			var eventStorage = sp.GetKeyedService<IAppendStorage<Event, Guid>>(key);
+			return eventStorage is null
+				? ActivatorUtilities.CreateInstance<MongoProjection>(sp, database)
+				: ActivatorUtilities.CreateInstance<MongoProjection>(sp, database, eventStorage);
 		});
 		services.AddKeyedSingleton<IObjectStore>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<MongoProjection>(key));
 		services.AddKeyedSingleton<IProjection>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<MongoProjection>(key));

--- a/Tests/Synqra.Tests.TestHelpers/EphemeralMongo.cs
+++ b/Tests/Synqra.Tests.TestHelpers/EphemeralMongo.cs
@@ -21,7 +21,7 @@ namespace Synqra.Tests.TestHelpers;
 /// starts; standalone is faster and more reliable.
 /// </para>
 /// </summary>
-static class EphemeralMongo
+public static class EphemeralMongo
 {
 	static readonly object _sync = new();
 	static string? _engineConnectionString;
@@ -48,19 +48,6 @@ static class EphemeralMongo
 						_engineConnectionString = app.Configuration.GetConnectionString("mongodb");
 						if (string.IsNullOrWhiteSpace(_engineConnectionString))
 						{
-							/*
-							try
-							{
-								SweepStaleMongodOnWindows();
-								_runner = MongoDbRunner.Start(singleNodeReplSet: false);
-								_engineConnectionString = _runner.ConnectionString;
-							}
-							catch (Exception ex)
-							{
-								EmergencyLog.Default.LogError(ex, $"MongoDbRunner");
-								throw;
-							}
-							*/
 							throw new Exception("ConnectionString 'mongodb' is required for test to run. Make sure spawning mongod and setting env var is part of test execution command");
 						}
 
@@ -88,35 +75,10 @@ static class EphemeralMongo
 
 			var builder = new MongoUrlBuilder(_engineConnectionString)
 			{
-				DatabaseName = prefix + GuidExtensions.CreateVersion7().ToString().Replace('-', '_').ToLowerInvariant(),
+				// DatabaseName = prefix + GuidExtensions.CreateVersion7().ToString().Replace('-', '_').ToLowerInvariant(),
+				DatabaseName = prefix + Guid.NewGuid().ToString("N"),
 			};
 			return builder.ToString();
-		}
-	}
-
-	[Conditional("DEBUG")]
-	static void SweepStaleMongodOnWindows()
-	{
-		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-		{
-			return;
-		}
-		// A never-disposed shared runner can leave a mongod behind across runs on dev
-		// machines; sweep ones older than a minute (never elevated, so other users'
-		// processes are left alone).
-		foreach (var p in Process.GetProcessesByName("mongod").Concat(Process.GetProcessesByName("mongod.exe")))
-		{
-			try
-			{
-				if (DateTime.UtcNow - p.StartTime.ToUniversalTime() > TimeSpan.FromMinutes(1))
-				{
-					p.Kill();
-				}
-			}
-			catch (System.ComponentModel.Win32Exception)
-			{
-				// Owned by another user — skip, let Mongo2Go work around it.
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Make `EphemeralMongo` public so Quotaly can reuse it directly as the single shared test-Mongo helper across both repos (replacing Mongo2Go entirely).
- Replace `MongoEventClassMaps.PatchObjectSerializerDefaults()` (reflection into `BsonSerializer`/`ObjectSerializer` private fields, mutating process-wide state) with `GuidAndObjectSerializerConvention` — a convention scoped to Synqra's own type filter, same mechanism already used for `JsonIgnoreConvention`/`IgnoreIfNullConvention`. Confirmed via a standalone PoC that the underlying driver requirements (explicit GUID representation, `ObjectSerializer`'s type allow-list) are real on the current driver version, but member-scoping resolves both with zero footprint outside Synqra's own types.
- Query-time Guid serialization (LINQ filters) can't be member-scoped — register it via the public, safe `BsonSerializer.TryRegisterSerializer`, the same pattern Quotaly's own Jobs/SimpleV1 Mongo serialization already uses, instead of reflection.
- `MongoProjection.ToDocument`/`UpsertComponent` now pass the scoped serializer explicitly instead of relying on ambient `BsonSerializer.LookupSerializer(typeof(object))`.
- Fixed a real bug found while testing this: the keyed `AddMongoDbSynqraStoreCore` constructed `MongoProjection` via `ActivatorUtilities` with only `database` passed explicitly, so its optional `IAppendStorage<Event,Guid>` parameter resolved **unkeyed** — in an all-keyed setup this silently dropped every event with no error.

## Test plan
- [x] All 172 Synqra tests pass (`dotnet run --project Tests/Synqra.Tests`)
- [x] Quotaly's Security IntegrationTests (17) and Jobs IntegrationTests (25) pass against real Mongo
- [x] Quotaly's previously-`[Explicit]` `SceneMongoSnapshotTests` now runs and passes, confirming events are actually persisted end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)