### PR TITLE
fix: configurable WebSocket endpoint for EventReplicationService

### DIFF
--- a/Synqra/EventReplicationConfig.cs
+++ b/Synqra/EventReplicationConfig.cs
@@ -6,6 +6,16 @@ namespace Synqra;
 public class EventReplicationConfig
 {
 	public virtual ushort Port { get; set; }
+
+	/// <summary>
+	/// Full WebSocket endpoint URI for the replication master. When set, overrides the default
+	/// <c>ws://localhost:{Port}/api/synqra/ws</c> construction so the WASM client can connect to
+	/// the correct remote host in deployed environments.
+	/// </summary>
+	public virtual string? Endpoint { get; set; }
+
+	internal Uri ResolveEndpointUri() =>
+		Endpoint is not null ? new Uri(Endpoint) : new Uri($"ws://localhost:{Port}/api/synqra/ws");
 }
 
 public class DelegatedEventReplicationConfig : EventReplicationConfig

--- a/Synqra/EventReplicationService.cs
+++ b/Synqra/EventReplicationService.cs
@@ -137,7 +137,7 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 			try
 			{
 				wsConnection = new ClientWebSocket();
-				await wsConnection.ConnectAsync(new Uri($"ws://localhost:{_config.Port}/api/synqra/ws"), _cts.Token);
+				await wsConnection.ConnectAsync(_config.ResolveEndpointUri(), _cts.Token);
 				_networkSerializationService.Reinitialize();
 				// Not online yet — that is declared only after the HELLO handshake completes,
 				// when the master is guaranteed to have registered this node for broadcasts.


### PR DESCRIPTION
## Summary
- `EventReplicationConfig` gains an optional `Endpoint` (string) property
- `EventReplicationService` calls `_config.ResolveEndpointUri()` instead of hardcoding `ws://localhost:{Port}/api/synqra/ws`
- When `Endpoint` is null, `ResolveEndpointUri()` falls back to the existing localhost pattern — no behavior change for local dev

## Why
In deployed environments (PR previews, production) the WASM client ran in the visitor's browser and tried to connect to `ws://localhost:5116`, hitting the visitor's own machine instead of the server. The page hung for 10 seconds (10 retries × 1s) then crashed the replication service.

## Test plan
- [ ] Local dev: existing behavior preserved (no Endpoint set → falls back to `ws://localhost:{Port}/api/synqra/ws`)
- [ ] Deployed PR preview: Quotaly's `PlaygroundHostModule` sets `Endpoint` derived from `NavigationManager.BaseUri`; scene page loads without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)