### PR TITLE
fix: make AsyncInvoker.InvokeAsync awaitable

### DIFF
--- a/Synqra.BlobStorage.IndexedDb/IndexedDbBlobStorage.cs
+++ b/Synqra.BlobStorage.IndexedDb/IndexedDbBlobStorage.cs
@@ -12,6 +12,7 @@ internal class IndexedDbBlobStorage<TKey> : IBlobStorage<TKey>, IJsonMirrorBlobS
 	private readonly Func<TKey, string> _getKeyFromItem;
 	private readonly Func<string, TKey> _getKeyFromText;
 	private readonly bool _wantsJsonMirror;
+	private readonly Task _initTask;
 
 	public bool WantsJsonMirror => _wantsJsonMirror;
 
@@ -28,11 +29,12 @@ internal class IndexedDbBlobStorage<TKey> : IBlobStorage<TKey>, IJsonMirrorBlobS
 		_getKeyFromItem = getKeyFromItem;
 		_getKeyFromText = getKeyFromText;
 		_wantsJsonMirror = wantsJsonMirror;
-		AsyncInvoker.InvokeAsync(_indexedDbInterop.InitializeAsync());
+		_initTask = AsyncInvoker.InvokeAsync(_indexedDbInterop.InitializeAsync());
 	}
 
 	public async ValueTask<byte[]> ReadBlobAsync(TKey key, CancellationToken cancellationToken = default)
 	{
+		await _initTask;
 		var blob = await _indexedDbInterop.GetBlobAsync(_storeName, _getKeyFromItem(key));
 		if (blob is null)
 		{
@@ -44,21 +46,25 @@ internal class IndexedDbBlobStorage<TKey> : IBlobStorage<TKey>, IJsonMirrorBlobS
 
 	public async ValueTask WriteBlobAsync(TKey key, ReadOnlyMemory<byte> blob, CancellationToken cancellationToken = default)
 	{
+		await _initTask;
 		await _indexedDbInterop.AddBlobAsync(_storeName, _getKeyFromItem(key), blob, json: null);
 	}
 
 	public async ValueTask WriteBlobAsync(TKey key, ReadOnlyMemory<byte> blob, string json, CancellationToken cancellationToken = default)
 	{
+		await _initTask;
 		await _indexedDbInterop.AddBlobAsync(_storeName, _getKeyFromItem(key), blob, json);
 	}
 
 	public async ValueTask DeleteBlobAsync(TKey key, CancellationToken cancellationToken = default)
 	{
+		await _initTask;
 		await _indexedDbInterop.DeleteAsync(_storeName, _getKeyFromItem(key));
 	}
 
 	public async IAsyncEnumerable<TKey> EnumerateKeysAsync(TKey? from = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 	{
+		await _initTask;
 		var currentFrom = from is null || Equals(from, default(TKey))
 			? null
 			: _getKeyFromItem(from);

--- a/Synqra.Projection.InMemory/_SharedUtils.cs
+++ b/Synqra.Projection.InMemory/_SharedUtils.cs
@@ -2,7 +2,7 @@
 
 static class AsyncInvoker
 {
-	public static async void InvokeAsync(Task task)
+	public static async Task InvokeAsync(Task task)
 	{
 		try
 		{
@@ -10,10 +10,8 @@ static class AsyncInvoker
 		}
 		catch (Exception ex)
 		{
-			_ = Task.Run(async () =>
-			{
-				Console.Error.WriteLine($"AsyncInvoker: {ex}");
-			});
+			_ = Task.Run(() => Console.Error.WriteLine($"AsyncInvoker: {ex}"));
+			throw;
 		}
 	}
 }

--- a/Synqra.Utils/_SharedUtils.cs
+++ b/Synqra.Utils/_SharedUtils.cs
@@ -2,7 +2,7 @@
 
 static class AsyncInvoker
 {
-	public static async void InvokeAsync(Task task)
+	public static async Task InvokeAsync(Task task)
 	{
 		try
 		{
@@ -10,10 +10,8 @@ static class AsyncInvoker
 		}
 		catch (Exception ex)
 		{
-			_ = Task.Run(async () =>
-			{
-				Console.Error.WriteLine($"AsyncInvoker: {ex}");
-			});
+			_ = Task.Run(() => Console.Error.WriteLine($"AsyncInvoker: {ex}"));
+			throw;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `AsyncInvoker.InvokeAsync` returns `Task` instead of `async void`, and rethrows after logging instead of swallowing.
- `IndexedDbBlobStorage` stores the constructor-started init `Task` and awaits it at the top of every public member, so reads/writes no longer race the IndexedDB initialization kicked off in the constructor.

## Why
`async void` made the fire-and-forget init unobservable — no way for a caller to know when (or whether) IndexedDB finished initializing before doing real work. Returning `Task` lets the consumer choose to await it.

## Test plan
- [x] `dotnet build Synqra.sln -c Release` — 0 errors