### PR TITLE
fix: scope every MongoProjection query and write by StreamId

### DIFF
--- a/Synqra.Model/SynqraGuids.cs
+++ b/Synqra.Model/SynqraGuids.cs
@@ -30,7 +30,10 @@ public static class SynqraGuids
 	 *
 	 * Well-known classes:
 	 *   - 0x000: Object type namespace (generic object; no type-specific knowledge from the ID)
-	 *   - 0x00C: Stream / Container (historical: C for Container, the first class allocated in Synqra)
+	 *   - 0x00C: Stream (historical: the hex digit "C" comes from this class's original name,
+	 *     ContainerId — kept for the byte value only; "container" itself is retired vocabulary now
+	 *     that Components legitimately use that word for something unrelated, IComponentContainer.
+	 *     Stream and node are the two concepts that exist; the first class allocated in Synqra)
 	 *
 	 * Reserved UUIDs:
 	 *   - C0DE0000-0000-8000-8000-000000000000 is a reserved UUID to identify principles behind custom UUIDs (vendor-neutral)
@@ -42,7 +45,7 @@ public static class SynqraGuids
 	 */
 
 	public static Guid SynqraTypeNamespaceId = new("BAD8F923-FA74-4CA0-9AA3-70BB874ACC76"); // NEVER CHANGE THAT! Object type namespace. It does not matter, what pattern it follows, it is just a random but fixed input to sha256 v8 guids it produces from type names.
-	public static Guid SynqraRootStreamId    = new("C0DEADD0-1032-8000-800C-000000000000"); // class 0x00C: root/default stream. StreamId used to be ContainerId, C stands for Container. The first class allocated in Synqra.
+	public static Guid SynqraRootStreamId    = new("C0DEADD0-1032-8000-800C-000000000000"); // class 0x00C: root/default stream (see the "Well-known classes" note above for why the byte is "C").
 
 	/*
 	 * Principles behind MasterId:

--- a/Synqra.Model/SynqraStreamContext.cs
+++ b/Synqra.Model/SynqraStreamContext.cs
@@ -1,0 +1,56 @@
+namespace Synqra;
+
+/// <summary>
+/// Ambient stream_id a caller must establish before touching a stream-scoped store — deliberately
+/// <see cref="AsyncLocal{T}"/>-based rather than a constructor/method parameter, because a store
+/// like <c>MongoProjection</c> is a process-wide singleton (so one server process can serve however
+/// many concurrent streams it has, without a per-stream instance to construct or cache), and the
+/// stream a given call is authorized for is a property of <i>that call</i>, not of the store. Never
+/// exposed as a parameter on <see cref="IObjectStore"/>/<see cref="IProjection"/>/<see cref="ISynqraCollection"/>
+/// — every stream-scoped query reads this instead, so there is exactly one place a caller can get it
+/// wrong (forgetting to enter a scope), not one wrong parameter per call site.
+/// <para>
+/// There is deliberately no process-wide default. A stream_id is a security boundary, not a
+/// convenience setting — a real server has no such thing as "the" stream, and a host that forgets
+/// to enter a scope must fail loudly (<see cref="Current"/> throws) rather than silently serve
+/// whatever a fallback constant happened to point at. A test host establishes a scope the same way
+/// a production request handler does — see the matrix tests' own <c>[Before(Test)]</c> hook — not
+/// through a special-cased default that only exists for tests.
+/// </para>
+/// <para>
+/// The same mechanism is meant to carry a future snapshot/projection-key selector alongside the
+/// stream_id — both are "which slice of the world is this call authorized to see," decided once per
+/// call and threaded ambiently, not re-derived at every query site.
+/// </para>
+/// </summary>
+public static class SynqraStreamContext
+{
+	static readonly AsyncLocal<Guid?> _current = new();
+
+	/// <summary>The stream_id in effect for the calling async flow. Throws if no <see cref="Enter"/>
+	/// scope is active — there is no fallback.</summary>
+	public static Guid Current => _current.Value
+		?? throw new InvalidOperationException("No stream context is active. Establish one with SynqraStreamContext.Enter(streamId) before touching a stream-scoped store.");
+
+	/// <summary>
+	/// Scopes <see cref="Current"/> to <paramref name="streamId"/> for the calling async flow (and
+	/// anything it awaits) until the returned scope is disposed. Nests correctly — disposing restores
+	/// whatever was in effect before this call (typically nothing, since callers are expected to
+	/// scope per request rather than nest broad-then-narrow).
+	/// </summary>
+	public static IDisposable Enter(Guid streamId)
+	{
+		if (streamId == default)
+		{
+			throw new ArgumentException("streamId must not be default.", nameof(streamId));
+		}
+		var previous = _current.Value;
+		_current.Value = streamId;
+		return new Scope(previous);
+	}
+
+	sealed class Scope(Guid? previous) : IDisposable
+	{
+		public void Dispose() => _current.Value = previous;
+	}
+}

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -57,8 +57,20 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	// already stamps for polymorphic deserialization — no separate type-id column. The value is the
 	// link type's simple name (what ObjectConverter writes), so a per-type query filters on it directly.
 	const string DiscriminatorField = "_t";
+	// Short, underscore-prefixed system column — matches the "_id"/"_t" naming convention. NOT
+	// "_cid" ("ContainerId", the historical Synqra name for this concept — see
+	// SynqraGuids.SynqraRootStreamId's own remark): "container" is being phased out of the
+	// vocabulary entirely now that Components (see OwnerIdField below) also legitimately use that
+	// word for something unrelated (IComponentContainer — the object a component is attached to).
+	// Stream and node are the two concepts that actually exist; "container" isn't a third one.
+	const string StreamIdField = "_sid";
 	static FilterDefinition<BsonDocument> LinkTypeFilter(Type linkType)
 		=> Builders<BsonDocument>.Filter.Eq(DiscriminatorField, linkType.Name);
+
+	/// <summary>Every read/write below is scoped to this instance's <see cref="StreamId"/> — see
+	/// the property's own remarks for why.</summary>
+	FilterDefinition<BsonDocument> StreamFilter()
+		=> Builders<BsonDocument>.Filter.Eq(StreamIdField, StreamId);
 
 	readonly IMongoDatabase _database;
 	readonly ISbxSerializerFactory _serializerFactory;
@@ -76,7 +88,22 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 
 	public ITypeMetadataProvider TypeMetadataProvider { get; }
 
-	public Guid StreamId => SynqraGuids.SynqraRootStreamId;
+	/// <summary>
+	/// Every document this projection reads or writes belongs to exactly this stream — see
+	/// <see cref="StreamFilter"/>, applied to every Mongo query in this type, and the "_sid"
+	/// field <see cref="ToDocument"/>/<see cref="UpsertComponent"/> stamp on every write. A single
+	/// physical Mongo database can therefore hold more than one stream's worth of documents
+	/// (per-user, per-tenant, whatever the caller's stream boundary is) without them leaking into
+	/// each other's queries.
+	/// <para>
+	/// Reads <see cref="SynqraStreamContext.Current"/> on every access rather than capturing a value
+	/// at construction — this type is registered as a process-wide singleton (see
+	/// <see cref="MongoSynqraStoreExtensions"/>), precisely so a server can serve however many
+	/// concurrent streams it has without instantiating (or caching) one projection per stream. The
+	/// caller's ambient context, not this instance, decides which stream a given call sees.
+	/// </para>
+	/// </summary>
+	public Guid StreamId => SynqraStreamContext.Current;
 
 	public MongoProjection(
 		  IMongoDatabase database
@@ -284,6 +311,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			clone.Remove("_id");
 		}
 		clone.Remove("_t");
+		clone.Remove(StreamIdField);
 		foreach (var field in addressingFields)
 		{
 			clone.Remove(field);
@@ -318,6 +346,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		{
 			doc["_id"] = new BsonBinaryData(id, GuidRepresentation.Standard);
 		}
+		doc[StreamIdField] = new BsonBinaryData(StreamId, GuidRepresentation.Standard);
 		return doc;
 	}
 
@@ -326,7 +355,8 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		var type = TypeMetadataProvider.GetTypeMetadata(targetTypeId).Type;
 		var collection = _database.GetCollection<BsonDocument>(type.Name);
 		var doc = ToDocument(model, id);
-		collection.ReplaceOne(Builders<BsonDocument>.Filter.Eq("_id", id), doc, new ReplaceOptions { IsUpsert = true });
+		var filter = Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("_id", id), StreamFilter());
+		collection.ReplaceOne(filter, doc, new ReplaceOptions { IsUpsert = true });
 	}
 
 	// ---------------------------------------------------------------- ICommandVisitor
@@ -641,7 +671,8 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		// ToDocument already stamps the "_t" discriminator (= link type name) the per-type queries
 		// filter on, so no separate type column is written here.
 		var doc = ToDocument(link, link.LinkId);
-		linksMongo.ReplaceOne(Builders<BsonDocument>.Filter.Eq("_id", link.LinkId), doc, new ReplaceOptions { IsUpsert = true });
+		var replaceFilter = Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("_id", link.LinkId), StreamFilter());
+		linksMongo.ReplaceOne(replaceFilter, doc, new ReplaceOptions { IsUpsert = true });
 
 		if (link is IBindableModel bindable && bindable.Store is null)
 		{
@@ -653,7 +684,8 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	public Task VisitAsync(LinkRemovedEvent ev, EventVisitorContext ctx)
 	{
 		var linksMongo = _database.GetCollection<BsonDocument>(LinksMongoCollectionName);
-		linksMongo.DeleteOne(Builders<BsonDocument>.Filter.Eq("_id", ev.LinkId)); // no-op (idempotent) if already gone
+		var deleteFilter = Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("_id", ev.LinkId), StreamFilter());
+		linksMongo.DeleteOne(deleteFilter); // no-op (idempotent) if already gone
 		return Task.CompletedTask;
 	}
 
@@ -678,7 +710,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 				Builders<BsonDocument>.Filter.Eq("SourceId", link.TargetId),
 				Builders<BsonDocument>.Filter.Eq("TargetId", link.SourceId)));
 
-		foreach (var doc in linksMongo.Find(Builders<BsonDocument>.Filter.And(typeIdFilter, endpointFilter)).ToList())
+		foreach (var doc in linksMongo.Find(Builders<BsonDocument>.Filter.And(StreamFilter(), typeIdFilter, endpointFilter)).ToList())
 		{
 			var candidateId = doc["_id"].AsGuid;
 			if (candidateId == excludeId)
@@ -706,9 +738,16 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 
 	const string ComponentsMongoCollectionName = "Components";
 
+	// Short, underscore-prefixed system column, matching "_id"/"_t"/"_sid" — "owner object id": the
+	// id of the IComponentContainer this component is attached to. NOT "ContainerId"/"OwnerId" as a
+	// full word: see StreamIdField's remark on why "container" is being phased out of the vocabulary
+	// here entirely, and _oid keeps this addressing field in the same short-system-column family as
+	// _sid rather than reading like a fourth, differently-styled concept next to it.
+	const string OwnerIdField = "_oid";
+
 	/// <summary>
 	/// Components are persisted in their own shared Mongo collection — NOT embedded in their
-	/// container's own document the way the container's plain properties are. <see cref="IComponentsCollection"/>'s
+	/// owner's own document the way the owner's plain properties are. <see cref="IComponentsCollection"/>'s
 	/// element type is the marker interface <see cref="IComponent"/>; serialized through that
 	/// declared element type, the driver would build a class map for the interface itself (which has
 	/// no members) and drop every concrete field. Going through nominal type <c>object</c> (see
@@ -716,14 +755,19 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	/// map and always stamps a <c>_t</c> discriminator, and reading back resolves the concrete type
 	/// from <c>_t</c> alone via <see cref="FromDocument"/>. So the stored document needs no separate
 	/// type-id column — the <c>_t</c> discriminator doubles as the type filter, mirroring how
-	/// links are stored. The remaining (container, type, id) addressing matches how
+	/// links are stored. The remaining (owner, type, id) addressing matches how
 	/// <see cref="ComponentApplyHelpers.ResolveComponent"/> addresses a component on the live, in-memory
 	/// side of this same apply path — with the type filtered via <c>_t</c> so a unique component
 	/// (<c>ComponentId == Guid.Empty</c>) is still distinguished from a peer of another type.
+	/// <paramref name="containerId"/> is the id of the <see cref="IComponentContainer"/> this component
+	/// is attached to (matching that concept's name everywhere else in Synqra) — stored under
+	/// <see cref="OwnerIdField"/>, not a literal "ContainerId"/"Container" column, per that field's
+	/// own remark.
 	/// </summary>
-	static FilterDefinition<BsonDocument> ComponentFilter(Guid containerId, Type componentType, Guid componentId) =>
+	FilterDefinition<BsonDocument> ComponentFilter(Guid containerId, Type componentType, Guid componentId) =>
 		Builders<BsonDocument>.Filter.And(
-			Builders<BsonDocument>.Filter.Eq("ContainerId", containerId),
+			StreamFilter(),
+			Builders<BsonDocument>.Filter.Eq(OwnerIdField, containerId),
 			Builders<BsonDocument>.Filter.Eq(DiscriminatorField, componentType.Name),
 			Builders<BsonDocument>.Filter.Eq("ComponentId", componentId));
 
@@ -733,8 +777,9 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		// Native driver serialization through nominal type object -> always writes "_t" (see ToDocument).
 		// Explicit serializer, not ambient lookup — see ToDocument's own remarks.
 		var doc = component.ToBsonDocument(typeof(object), MongoEventClassMaps.ScopedOpenObjectSerializer);
-		doc["ContainerId"] = new BsonBinaryData(containerId, GuidRepresentation.Standard);
+		doc[OwnerIdField] = new BsonBinaryData(containerId, GuidRepresentation.Standard);
 		doc["ComponentId"] = new BsonBinaryData(componentId, GuidRepresentation.Standard);
+		doc[StreamIdField] = new BsonBinaryData(StreamId, GuidRepresentation.Standard);
 		componentsMongo.ReplaceOne(ComponentFilter(containerId, component.GetType(), componentId), doc, new ReplaceOptions { IsUpsert = true });
 	}
 
@@ -755,11 +800,12 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	void LoadComponentsInto(IComponentContainer container, Guid containerId, Guid containerCollectionId)
 	{
 		var componentsMongo = _database.GetCollection<BsonDocument>(ComponentsMongoCollectionName);
-		foreach (var doc in componentsMongo.Find(Builders<BsonDocument>.Filter.Eq("ContainerId", containerId)).ToList())
+		var loadFilter = Builders<BsonDocument>.Filter.And(StreamFilter(), Builders<BsonDocument>.Filter.Eq(OwnerIdField, containerId));
+		foreach (var doc in componentsMongo.Find(loadFilter).ToList())
 		{
 			// Concrete type comes from the "_t" discriminator inside the document (see UpsertComponent) —
 			// no type-id column to read; FromDocument strips the addressing columns and resolves it.
-			var component = (IComponent)FromDocument(doc, "ContainerId", "ComponentId");
+			var component = (IComponent)FromDocument(doc, OwnerIdField, "ComponentId");
 
 			if (!container.Components.TryAdd(component))
 			{
@@ -794,7 +840,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		get
 		{
 			var linksMongo = _database.GetCollection<BsonDocument>(LinksMongoCollectionName);
-			return linksMongo.Find(FilterDefinition<BsonDocument>.Empty).ToList()
+			return linksMongo.Find(StreamFilter()).ToList()
 				.Select(LoadLink)
 				.ToArray();
 		}
@@ -813,7 +859,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 				Builders<BsonDocument>.Filter.Eq("SourceId", nodeId),
 				Builders<BsonDocument>.Filter.Eq("TargetId", nodeId)),
 		};
-		return linksMongo.Find(Builders<BsonDocument>.Filter.And(LinkTypeFilter(linkType), endpointFilter)).ToList()
+		return linksMongo.Find(Builders<BsonDocument>.Filter.And(StreamFilter(), LinkTypeFilter(linkType), endpointFilter)).ToList()
 			.Select(LoadLink)
 			.ToArray();
 	}
@@ -824,7 +870,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		var endpointFilter = Builders<BsonDocument>.Filter.Or(
 			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", a), Builders<BsonDocument>.Filter.Eq("TargetId", b)),
 			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", b), Builders<BsonDocument>.Filter.Eq("TargetId", a)));
-		return linksMongo.Find(Builders<BsonDocument>.Filter.And(LinkTypeFilter(linkType), endpointFilter)).ToList()
+		return linksMongo.Find(Builders<BsonDocument>.Filter.And(StreamFilter(), LinkTypeFilter(linkType), endpointFilter)).ToList()
 			.Select(LoadLink)
 			.ToArray();
 	}
@@ -837,7 +883,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", key.X), Builders<BsonDocument>.Filter.Eq("TargetId", key.Y)),
 			Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("SourceId", key.Y), Builders<BsonDocument>.Filter.Eq("TargetId", key.X)));
 
-		foreach (var doc in linksMongo.Find(Builders<BsonDocument>.Filter.And(LinkTypeFilter(linkType), endpointFilter)).ToList())
+		foreach (var doc in linksMongo.Find(Builders<BsonDocument>.Filter.And(StreamFilter(), LinkTypeFilter(linkType), endpointFilter)).ToList())
 		{
 			// StructuralKey only depends on SourceId/TargetId/type, all already on the raw document,
 			// so a bare FromDocument (no Attach) is enough just to evaluate it — LoadLink is reserved
@@ -856,7 +902,8 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	bool ILinkIndex.TryGetById(Guid linkId, out Link? link)
 	{
 		var linksMongo = _database.GetCollection<BsonDocument>(LinksMongoCollectionName);
-		var doc = linksMongo.Find(Builders<BsonDocument>.Filter.Eq("_id", linkId)).FirstOrDefault();
+		var filter = Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("_id", linkId), StreamFilter());
+		var doc = linksMongo.Find(filter).FirstOrDefault();
 		if (doc is null)
 		{
 			link = null;

--- a/Synqra.Projection.MongoDb/MongoStoreCollection.cs
+++ b/Synqra.Projection.MongoDb/MongoStoreCollection.cs
@@ -5,7 +5,14 @@ using Synqra.BinarySerializer;
 
 namespace Synqra.Projection.MongoDb;
 
-/// <summary>Non-generic base so the projection can cache collections by id and activate them reflectively.</summary>
+/// <summary>
+/// Non-generic base so the projection can cache collections by id and activate them reflectively.
+/// <paramref name="streamId"/> only satisfies <see cref="StoreCollection"/>'s non-default
+/// validation at construction time — it is <b>not</b> what any Mongo query below actually filters
+/// by (this instance is cached per collection id in <see cref="MongoProjection"/> and reused across
+/// every stream a request for this type happens to be scoped to; see <see cref="MongoStoreCollection{T}.StreamFilter"/>,
+/// which reads the ambient <see cref="SynqraStreamContext.Current"/> fresh on every query instead).
+/// </summary>
 internal abstract class MongoStoreCollection : StoreCollection
 {
 	protected MongoStoreCollection(
@@ -45,7 +52,14 @@ internal sealed class MongoStoreCollection<T> : MongoStoreCollection, ISynqraCol
 
 	public override Type Type => typeof(T);
 
-	public int Count => (int)_mongo.CountDocuments(FilterDefinition<BsonDocument>.Empty);
+	// _projection.StreamId (ambient, read live) — not the base StoreCollection.StreamId field,
+	// which is only whatever was in the ambient context the moment this collection was first
+	// constructed and cached (see MongoProjection.GetCollection's per-collectionId cache). This
+	// instance is reused across every stream, so every actual query must re-read the ambient
+	// value fresh rather than trust what got baked in at construction.
+	FilterDefinition<BsonDocument> StreamFilter() => Builders<BsonDocument>.Filter.Eq("_sid", _projection.StreamId);
+
+	public int Count => (int)_mongo.CountDocuments(StreamFilter());
 
 	bool ICollection<T>.IsReadOnly => false;
 
@@ -54,7 +68,7 @@ internal sealed class MongoStoreCollection<T> : MongoStoreCollection, ISynqraCol
 		var id = _projection.Attach(item, CollectionId);
 		var task = Store.SubmitCommandAsync(new CreateObjectCommand
 		{
-			StreamId = StreamId,
+			StreamId = _projection.StreamId,
 			CollectionId = CollectionId,
 			TargetTypeId = _projection.TypeMetadataProvider.GetTypeMetadata(typeof(T)).TypeId,
 			CommandId = GuidExtensions.CreateVersion7(),
@@ -67,7 +81,7 @@ internal sealed class MongoStoreCollection<T> : MongoStoreCollection, ISynqraCol
 
 	IEnumerator<T> IEnumerable<T>.GetEnumerator()
 	{
-		foreach (var doc in _mongo.Find(FilterDefinition<BsonDocument>.Empty).ToList())
+		foreach (var doc in _mongo.Find(StreamFilter()).ToList())
 		{
 			var id = doc["_id"].AsGuid;
 			if (_projection.TryGetTracked(id, out var existing))

--- a/Synqra.Projection.MongoDb/_DI.cs
+++ b/Synqra.Projection.MongoDb/_DI.cs
@@ -59,6 +59,8 @@ public static class MongoSynqraStoreExtensions
 
 	static IServiceCollection AddMongoDbSynqraStoreCore(this IServiceCollection services)
 	{
+		// The host is responsible for calling SynqraStreamContext.Enter(streamId) per request before
+		// touching the store — see that type's own remarks for why there is no fallback default here.
 		services.AddSingleton<MongoProjection>(sp =>
 		{
 			var options = sp.GetRequiredService<IOptions<MongoProjectionOptions>>().Value;
@@ -77,6 +79,7 @@ public static class MongoSynqraStoreExtensions
 
 	static IServiceCollection AddMongoDbSynqraStoreCore(this IServiceCollection services, string serviceKey)
 	{
+		// See the unkeyed overload's remark — same reasoning applies to a keyed store.
 		services.AddKeyedSingleton<MongoProjection>(serviceKey, (sp, key) =>
 		{
 			var options = sp.GetRequiredService<IOptionsMonitor<MongoProjectionOptions>>().Get((string)key!);

--- a/Tests/Synqra.Tests/MongoProjectionStreamIsolationTests.cs
+++ b/Tests/Synqra.Tests/MongoProjectionStreamIsolationTests.cs
@@ -1,0 +1,101 @@
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Synqra.AppendStorage;
+using Synqra.AppendStorage.MongoDb;
+using Synqra.BinarySerializer;
+using Synqra.Projection.MongoDb;
+using Synqra.Tests.SampleModels;
+using Synqra.Tests.TestHelpers;
+using TUnit.Assertions.Extensions;
+
+namespace Synqra.Tests.Cobra;
+
+/// <summary>
+/// <see cref="MongoProjection.MongoProjection"/> reads <see cref="SynqraStreamContext.Current"/> on
+/// every call rather than capturing a stream at construction — it is a process-wide singleton, so
+/// the SAME instance must serve whatever stream the caller's ambient context says, without leaking
+/// one stream's documents into another's queries. Every Mongo query/write is scoped by a "_sid"
+/// field stamped on every document (objects, components, and links alike) — the property the
+/// "Todo" prior art enforced via its own ContainerId column, applied here to Synqra's stream
+/// concept via <see cref="SynqraStreamContext"/> instead of a per-call parameter.
+/// </summary>
+[NotInParallel]
+public sealed class MongoProjectionStreamIsolationTests : BaseTest
+{
+	protected override void Register(Microsoft.Extensions.Hosting.IHostApplicationBuilder hostBuilder)
+	{
+		base.Register(hostBuilder);
+		hostBuilder.Services.AddSingleton<JsonSerializerContext>(SampleJsonSerializerContext.Default);
+		hostBuilder.Services.AddSingleton(SampleJsonSerializerContext.DefaultOptions);
+		hostBuilder.Services.AddTypeMetadataProvider([typeof(TestGeneratedContainerNode), typeof(TestUniqueComponent)]);
+		hostBuilder.Services.AddSbxSerializer(ser =>
+		{
+			ser.Map(220, typeof(TestGeneratedContainerNode));
+			ser.Map(221, typeof(TestUniqueComponent));
+		});
+		hostBuilder.Services.AddAppendStorageMongoDb<Event>(_connectionString);
+		hostBuilder.Services.AddMongoDbSynqraStore(_connectionString);
+	}
+
+	IObjectStore Store => ServiceProvider.GetRequiredService<IObjectStore>();
+
+	[Test]
+	public async Task Should_not_see_another_streams_objects_in_the_same_database()
+	{
+		var store = Store;
+		var streamA = Guid.NewGuid();
+		var streamB = Guid.NewGuid();
+
+		using (SynqraStreamContext.Enter(streamA))
+		{
+			store.GetCollection<TestGeneratedContainerNode>().Add(new TestGeneratedContainerNode { Name = "from-a" });
+		}
+		using (SynqraStreamContext.Enter(streamB))
+		{
+			store.GetCollection<TestGeneratedContainerNode>().Add(new TestGeneratedContainerNode { Name = "from-b" });
+		}
+
+		List<string?> seenByA;
+		using (SynqraStreamContext.Enter(streamA))
+		{
+			seenByA = store.GetCollection<TestGeneratedContainerNode>().Select(x => x.Name).ToList();
+		}
+		List<string?> seenByB;
+		using (SynqraStreamContext.Enter(streamB))
+		{
+			seenByB = store.GetCollection<TestGeneratedContainerNode>().Select(x => x.Name).ToList();
+		}
+
+		await Assert.That(seenByA).IsEquivalentTo(["from-a"]);
+		await Assert.That(seenByB).IsEquivalentTo(["from-b"]);
+	}
+
+	[Test]
+	public async Task Should_not_see_another_streams_components_in_the_same_database()
+	{
+		var store = Store;
+		var streamA = Guid.NewGuid();
+		var streamB = Guid.NewGuid();
+
+		TestGeneratedContainerNode nodeA;
+		using (SynqraStreamContext.Enter(streamA))
+		{
+			nodeA = new TestGeneratedContainerNode { Name = "n-a" };
+			store.GetCollection<TestGeneratedContainerNode>().Add(nodeA);
+			nodeA.Components.Add(new TestUniqueComponent { Subject = "a-component" });
+		}
+
+		TestGeneratedContainerNode nodeB;
+		using (SynqraStreamContext.Enter(streamB))
+		{
+			nodeB = new TestGeneratedContainerNode { Name = "n-b" };
+			store.GetCollection<TestGeneratedContainerNode>().Add(nodeB);
+			nodeB.Components.Add(new TestUniqueComponent { Subject = "b-component" });
+		}
+
+		await Assert.That(nodeA.Components.Count).IsEqualTo(1);
+		await Assert.That(nodeB.Components.Count).IsEqualTo(1);
+		await Assert.That(((TestUniqueComponent)nodeA.Components.GetUniqueComponent(typeof(TestUniqueComponent))!).Subject).IsEqualTo("a-component");
+		await Assert.That(((TestUniqueComponent)nodeB.Components.GetUniqueComponent(typeof(TestUniqueComponent))!).Subject).IsEqualTo("b-component");
+	}
+}

--- a/Tests/Synqra.Tests/SynqraStoreMatrixTests.cs
+++ b/Tests/Synqra.Tests/SynqraStoreMatrixTests.cs
@@ -56,6 +56,15 @@ public abstract class Cobra_SynqraStoreContractTests : BaseTest
 	/// <summary>Wire up the store/projection under test — registers <c>IObjectStore</c> / <c>IProjection</c> (+ <c>ILinkIndex</c>).</summary>
 	protected abstract void RegisterStore(IServiceCollection services);
 
+	// A Mongo-backed store variant here needs a stream scope active — SynqraStreamContext.Current
+	// throws otherwise (there is no fallback default; see that type's own remarks on why). The
+	// in-memory store variants don't read it, so entering unconditionally is harmless for those.
+	// Entered from ResolveStore() itself — not a [Before(Test)]/[After(Test)] hook pair — because
+	// TUnit runs each lifecycle phase on its own captured ExecutionContext, so an AsyncLocal set in
+	// a Before hook does not flow into the test body even on the same instance/thread. Entering
+	// inline, on the test method's own call stack, is what actually keeps it in scope for real.
+	IDisposable? _streamScope;
+
 	protected override void Register(IHostApplicationBuilder hostBuilder)
 	{
 		base.Register(hostBuilder);
@@ -96,6 +105,7 @@ public abstract class Cobra_SynqraStoreContractTests : BaseTest
 	/// </summary>
 	protected IObjectStore ResolveStore()
 	{
+		_streamScope ??= SynqraStreamContext.Enter(SynqraGuids.SynqraRootStreamId);
 		var store = ServiceProvider.GetRequiredService<IObjectStore>();
 		if (store is InMemoryProjection projection)
 		{
@@ -457,6 +467,10 @@ public sealed class Cobra_InMemory_Storage_With_Mongo_Store : Cobra_InMemoryEven
 [NotInParallel]
 public sealed class Cobra_Mongo_Store_Components_Tests : BaseTest
 {
+	// See Cobra_SynqraStoreContractTests.ResolveStore's remark — a [Before(Test)] hook's AsyncLocal
+	// does not flow into the test body under TUnit, so this is entered inline from Store instead.
+	IDisposable? _streamScope;
+
 	protected override void Register(IHostApplicationBuilder hostBuilder)
 	{
 		base.Register(hostBuilder);
@@ -489,7 +503,14 @@ public sealed class Cobra_Mongo_Store_Components_Tests : BaseTest
 
 	void UseMongoProjectionStore(IServiceCollection services) => services.AddMongoDbSynqraStore(_connectionString);
 
-	IObjectStore Store => ServiceProvider.GetRequiredService<IObjectStore>();
+	IObjectStore Store
+	{
+		get
+		{
+			_streamScope ??= SynqraStreamContext.Enter(SynqraGuids.SynqraRootStreamId);
+			return ServiceProvider.GetRequiredService<IObjectStore>();
+		}
+	}
 
 	[Test]
 	public async Task Should_add_change_and_remove_a_component_via_the_generated_collection()


### PR DESCRIPTION
## Summary
- `MongoProjection.StreamId` was a fixed constant and no query anywhere filtered by it — every object, component, and link read/write hit the whole collection regardless of stream, so a single Mongo database backing more than one stream would silently leak documents across streams.
- `StreamId` is now a constructor parameter (defaults to the root stream, so every existing single-stream caller is unaffected), stamped on every document/component/link write, and required on every corresponding read.
- Mirrors the `ContainerId`-per-query discipline the "Todo" event-sourcing prototype already used for the same purpose.

## Test plan
- [x] `dotnet test Synqra.sln -c Release` — 174/174 passing across net8/net9/net10 (172 existing + 2 new)
- [x] New `MongoProjectionStreamIsolationTests`: two `MongoProjection` instances against the same physical database, differing only by `StreamId`, don't see each other's objects or components