### PR TITLE
Replay full backlog to (re)connecting clients + safe client resync

### DIFF
--- a/Synqra.AppendStorage.Abstractions/IAppendStorage.cs
+++ b/Synqra.AppendStorage.Abstractions/IAppendStorage.cs
@@ -37,3 +37,17 @@ public interface IAppendStorage<T, TKey> : IDisposable, IAsyncDisposable
 #endif
 		;
 }
+
+/// <summary>
+/// Optional capability — implemented only where "wipe everything and resync fresh from the
+/// server" is a meaningful, safe recovery action (currently just a client's local IndexedDb
+/// cache; see <see cref="Synqra.BlobStorage.IClearableBlobStorage"/>). Not part of
+/// <see cref="IAppendStorage{T, TKey}"/> itself — File/Sqlite/Mongo-backed storage is the
+/// durable source of truth, not a disposable cache, so most implementations shouldn't have to
+/// implement this at all; check with an `is` pattern match instead (see
+/// EventReplicationService's own use of this).
+/// </summary>
+public interface IClearableAppendStorage
+{
+	Task ClearAllAsync(CancellationToken cancellationToken = default);
+}

--- a/Synqra.AppendStorage.BlobStorage/BlobAppendStorage.cs
+++ b/Synqra.AppendStorage.BlobStorage/BlobAppendStorage.cs
@@ -8,7 +8,7 @@ using Synqra.BlobStorage;
 
 namespace Synqra.AppendStorage.BlobStorage;
 
-public class BlobAppendStorage<T, TKey> : IAppendStorage<T, TKey>
+public class BlobAppendStorage<T, TKey> : IAppendStorage<T, TKey>, IClearableAppendStorage
 	where T : class
 	where TKey : notnull, IComparable<TKey>
 {
@@ -92,6 +92,18 @@ public class BlobAppendStorage<T, TKey> : IAppendStorage<T, TKey>
 	public Task FlushAsync(CancellationToken cancellationToken = default)
 	{
 		return Task.CompletedTask;
+	}
+
+	public async Task ClearAllAsync(CancellationToken cancellationToken = default)
+	{
+		if (_blobStorage is not IClearableBlobStorage clearable)
+		{
+			throw new NotSupportedException($"{_blobStorage.GetType().Name} does not support clearing — only implementations of IClearableBlobStorage do.");
+		}
+		await clearable.ClearAllAsync(cancellationToken);
+		// The attached-objects cache would otherwise keep serving these same in-memory
+		// instances back out of GetAllAsync/GetAsync even though the backing store is empty.
+		_attachedObjectsById.Clear();
 	}
 
 	public void Dispose()

--- a/Synqra.BlobStorage.Abstractions/IBlobStorage.cs
+++ b/Synqra.BlobStorage.Abstractions/IBlobStorage.cs
@@ -31,3 +31,15 @@ public interface IBlobStorage<TKey> : IDisposable, IAsyncDisposable
 #endif
 		;
 }
+
+/// <summary>
+/// Optional capability — implemented only by backends where "wipe everything and resync
+/// fresh from the server" is a meaningful, safe recovery action (currently just IndexedDb,
+/// a disposable client-local cache). File/Sqlite/Mongo backends are the durable source of
+/// truth themselves, so they don't implement this; check with an `is` pattern match rather
+/// than adding it to <see cref="IBlobStorage{TKey}"/> itself.
+/// </summary>
+public interface IClearableBlobStorage
+{
+	Task ClearAllAsync(CancellationToken cancellationToken = default);
+}

--- a/Synqra.BlobStorage.IndexedDb/IndexedDbBlobStorage.cs
+++ b/Synqra.BlobStorage.IndexedDb/IndexedDbBlobStorage.cs
@@ -4,7 +4,7 @@ using Synqra.BlobStorage;
 
 namespace Synqra.BlobStorage.IndexedDb;
 
-internal class IndexedDbBlobStorage<TKey> : IBlobStorage<TKey>, IJsonMirrorBlobStorage<TKey>
+internal class IndexedDbBlobStorage<TKey> : IBlobStorage<TKey>, IJsonMirrorBlobStorage<TKey>, IClearableBlobStorage
 	where TKey : notnull, IComparable<TKey>
 {
 	private readonly IndexedDbJsInterop _indexedDbInterop;
@@ -92,6 +92,12 @@ internal class IndexedDbBlobStorage<TKey> : IBlobStorage<TKey>, IJsonMirrorBlobS
 			currentFrom = page[^1];
 			fromExclusive = true;
 		}
+	}
+
+	public async Task ClearAllAsync(CancellationToken cancellationToken = default)
+	{
+		await _initTask;
+		await _indexedDbInterop.ClearStoreAsync(_storeName);
 	}
 
 	public void Dispose()

--- a/Synqra.BlobStorage.IndexedDb/IndexedDbJsInterop.cs
+++ b/Synqra.BlobStorage.IndexedDb/IndexedDbJsInterop.cs
@@ -52,6 +52,13 @@ public class IndexedDbJsInterop : IAsyncDisposable
 		await module.InvokeVoidAsync("deleteByKey", storeName, keyText);
 	}
 
+	/// <summary>Wipes every record for this storeName only — used by resync recovery.</summary>
+	public async Task ClearStoreAsync(string storeName)
+	{
+		var module = await _moduleTask.Value;
+		await module.InvokeVoidAsync("clearStore", storeName);
+	}
+
 	public async ValueTask DisposeAsync()
 	{
 		if (_moduleTask.IsValueCreated)

--- a/Synqra.BlobStorage.IndexedDb/wwwroot/indexedDbJsInterop.js
+++ b/Synqra.BlobStorage.IndexedDb/wwwroot/indexedDbJsInterop.js
@@ -117,4 +117,33 @@ export async function deleteByKey(storeName, keyText) {
     const collection = transaction.objectStore(collectionName);
     collection.delete(getCompoundKey(storeName, keyText));
 }
+// Used by resync recovery — wipes every record for this storeName only, not the whole
+// database (a single IndexedDB database can hold records for more than one storeName,
+// see getCompoundKey), by cursor-deleting every key under this storeName's prefix.
+export async function clearStore(storeName) {
+    await initialize();
+    return await new Promise((resolve, reject) => {
+        const transaction = synqraDbResult.transaction(collectionName, "readwrite");
+        const collection = transaction.objectStore(collectionName);
+        const prefix = `${storeName}${separator}`;
+        const request = collection.openKeyCursor(IDBKeyRange.lowerBound(prefix));
+        request.onsuccess = function (event) {
+            const cursor = event.target.result;
+            if (!cursor) {
+                resolve();
+                return;
+            }
+            const compoundKey = String(cursor.primaryKey);
+            if (!compoundKey.startsWith(prefix)) {
+                resolve();
+                return;
+            }
+            collection.delete(compoundKey);
+            cursor.continue();
+        };
+        request.onerror = function () {
+            reject(request.error);
+        };
+    });
+}
 //# sourceMappingURL=indexedDbJsInterop.js.map

--- a/Synqra.Model/IEventReplicationService.cs
+++ b/Synqra.Model/IEventReplicationService.cs
@@ -6,4 +6,13 @@ public interface IEventReplicationService
 	bool IsOnline { get; }
 
 	void Trigger(Command command, IReadOnlyList<Event> events);
+
+	/// <summary>
+	/// Wipes this client's local durable event log, if the underlying storage supports it
+	/// (see <see cref="Synqra.AppendStorage.IClearableAppendStorage"/>) — a no-op otherwise.
+	/// Does not itself reconnect or reload anything: this is Synqra core and has no Blazor
+	/// dependency, so a caller (e.g. a "Force Resync" button) is responsible for reloading
+	/// the app afterward to actually rebuild state from the server's fully-synced backlog.
+	/// </summary>
+	Task ClearLocalStorageAsync();
 }

--- a/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
+++ b/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
@@ -52,33 +52,58 @@ public static class SynqraReplicationEndpointExtensions
 			using var socket = await ctx.WebSockets.AcceptWebSocketAsync();
 
 			#region HELLO — from client
+			// 8 bytes magic + 16 bytes the client's own "last event id it already received
+			// from a server" cursor (Guid.Empty means "never synced, send me everything") —
+			// see EventReplicationState.LastEventIdFromServer's own remarks.
 			var helloBytes = await ReceiveFullMessageAsync(socket, ctx.RequestAborted);
 			if (helloBytes is null)
 			{
 				return;
 			}
-			if (helloBytes.Length != 8)
+			if (helloBytes.Length != 24)
 			{
-				throw new InvalidOperationException($"Protocol negotiation failed: received {helloBytes.Length} bytes instead of 8.");
+				throw new InvalidOperationException($"Protocol negotiation failed: received {helloBytes.Length} bytes instead of 24.");
 			}
-			var magic = BitConverter.ToUInt64(helloBytes);
+			var magic = BitConverter.ToUInt64(helloBytes, 0);
 			if (magic != networkSerializationService.Magic)
 			{
 				throw new InvalidOperationException($"Protocol negotiation failed: received magic {magic:X16} instead of {networkSerializationService.Magic:X16}.");
 			}
+			var clientCursor = new Guid(helloBytes.AsSpan(8, 16));
 			#endregion
 
-			#region HELLO — to client
-			// Register for broadcasts BEFORE answering HELLO, and do both under the same
-			// gate as every broadcast SendAsync on this socket: the moment the client
-			// observes this reply, every later broadcast is guaranteed to reach it, and
-			// this reply can never interleave with a concurrent broadcast write.
+			#region HELLO — to client, then replay this stream's backlog since clientCursor
+			// Register for broadcasts BEFORE answering HELLO, and do both — plus the backlog
+			// replay below — under the same gate as every broadcast SendAsync on this socket:
+			// the moment the client observes the HELLO reply, every later broadcast is
+			// guaranteed to reach it, and none of this can interleave with a concurrent
+			// broadcast write. Holding the gate for the whole backlog replay blocks other
+			// clients' broadcasts briefly — acceptable, this runs once per connection, and
+			// the file already accepts a single global semaphore over throughput elsewhere.
 			var magicBytes = BitConverter.GetBytes(networkSerializationService.Magic);
 			await broadcastGate.WaitAsync(ctx.RequestAborted);
 			try
 			{
 				sockets.Add(socket);
 				await socket.SendAsync(magicBytes, WebSocketMessageType.Binary, endOfMessage: true, ctx.RequestAborted);
+
+				var storage = serviceKey is null
+					? ctx.RequestServices.GetRequiredService<IAppendStorage<Event, Guid>>()
+					: ctx.RequestServices.GetRequiredKeyedService<IAppendStorage<Event, Guid>>(serviceKey);
+				var backlogBuffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
+				try
+				{
+					await foreach (var ev in storage.GetAllAsync(from: clientCursor, ctx.RequestAborted))
+					{
+						knownEvents.TryAdd(ev.EventId, null);
+						var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, backlogBuffer);
+						await socket.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
+					}
+				}
+				finally
+				{
+					ArrayPool<byte>.Shared.Return(backlogBuffer);
+				}
 			}
 			finally
 			{

--- a/Synqra/EventReplicationService.cs
+++ b/Synqra/EventReplicationService.cs
@@ -111,24 +111,56 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 	protected async override Task ExecuteAsync(CancellationToken stoppingToken)
 	{
 		var ctx = _synqraStoreContext.Value ?? throw new ArgumentException();
-		if (ctx is ISelfLoadingProjection selfLoading)
-		{
-			// This projection (e.g. InMemoryProjection, when constructed with the same
-			// IAppendStorage this service reads) already replayed its own durable log on
-			// construction — fire-and-forget, started before this method ever runs. Doing
-			// our own replay loop here too would apply every persisted event a second time;
-			// any unique component rejects that on the second application
-			// ("ComponentAddedEvent ... uniqueness ... rejected during replay"), which is
-			// exactly the crash users hit on every page reload. Await the SAME load instead
-			// of repeating it.
-			await selfLoading.LoadStateAsync();
-		}
-		else
+
+		// Seed the by-EventId dedup (_skipSet/_skipList, otherwise only populated by
+		// ProcessEvent for events received live) from whatever's already durably stored
+		// locally — a separate pass from the actual replay below, regardless of which
+		// replay path runs. Without this, the server's backlog replay (see
+		// SynqraReplicationEndpointExtensions.cs) would resend every event this client
+		// already has on every reconnect, and ProcessEvent would re-apply them since it had
+		// never seen their ids before — the exact "unique component rejected on second
+		// application" crash the comment below was written to avoid, just via a new path.
+		// Wrapped together with the actual replay in one try/catch: a corrupt/undeserializable
+		// local record here means this client's local durable log can no longer be trusted at
+		// all — clear it and continue with an empty skip-set and a cold LastEventIdFromServer,
+		// which is now a correct and safe "send me everything" signal (see #2/#3), not a bug.
+		try
 		{
 			await foreach (var ev in _storage.GetAllAsync(from: default))
 			{
-				await ev.AcceptAsync(ctx, null);
+				lock (_skipSet)
+				{
+					if (_skipSet.Add(ev.EventId))
+					{
+						_skipList.AddLast(ev.EventId);
+					}
+				}
 			}
+
+			if (ctx is ISelfLoadingProjection selfLoading)
+			{
+				// This projection (e.g. InMemoryProjection, when constructed with the same
+				// IAppendStorage this service reads) already replayed its own durable log on
+				// construction — fire-and-forget, started before this method ever runs. Doing
+				// our own replay loop here too would apply every persisted event a second time;
+				// any unique component rejects that on the second application
+				// ("ComponentAddedEvent ... uniqueness ... rejected during replay"), which is
+				// exactly the crash users hit on every page reload. Await the SAME load instead
+				// of repeating it.
+				await selfLoading.LoadStateAsync();
+			}
+			else
+			{
+				await foreach (var ev in _storage.GetAllAsync(from: default))
+				{
+					await ev.AcceptAsync(ctx, null);
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			EmergencyLog.Default.LogWarning(ex, "EventReplicationService: local durable log failed to replay — clearing it and resyncing fresh from the server.");
+			await ClearLocalStorageAsync();
 		}
 
 		ClientWebSocket wsConnection;
@@ -187,6 +219,11 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 						await _storage.AppendAsync(ne1.Event);
 						EmergencyLog.Default.LogInformation($"{GetHashCode():X4} <<< {ne1.Event}");
 						await ProcessEvent(ne1.Event);
+						// Tracks how far this client's backlog catch-up has progressed —
+						// applies to both a genuine live event and one the server resent as
+						// backlog (see the HELLO region above); mirrors LastEventIdFromMe's
+						// own bookkeeping for outgoing events.
+						_eventReplicationState.LastEventIdFromServer = ne1.Event.EventId;
 						break;
 					default:
 						throw new NotSupportedException();
@@ -197,11 +234,16 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 
 		#region HELLO
 		{
-			var buffer = ArrayPool<byte>.Shared.Rent(8);
+			// 8 bytes magic + 16 bytes LastEventIdFromServer — tells the server exactly
+			// where this client's backlog catch-up should resume from (Guid.Empty means
+			// "never synced, send me everything"). See SynqraReplicationEndpointExtensions.cs's
+			// own remarks on the server side of this handshake.
+			var buffer = ArrayPool<byte>.Shared.Rent(24);
 			try
 			{
 				BitConverter.TryWriteBytes(buffer, _networkSerializationService.Magic);
-				await wsConnection.SendAsync(new ArraySegment<byte>(buffer, 0, 8), WebSocketMessageType.Binary, endOfMessage: true, _cts.Token);
+				_eventReplicationState.LastEventIdFromServer.TryWriteBytes(buffer.AsSpan(8, 16));
+				await wsConnection.SendAsync(new ArraySegment<byte>(buffer, 0, 24), WebSocketMessageType.Binary, endOfMessage: true, _cts.Token);
 			}
 			finally
 			{
@@ -290,6 +332,21 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 		catch (SemaphoreFullException)
 		{
 			// already signaled - concurrent triggers coalesce into one loop iteration
+		}
+	}
+
+	/// <inheritdoc />
+	public async Task ClearLocalStorageAsync()
+	{
+		lock (_skipSet)
+		{
+			_skipSet.Clear();
+			_skipList.Clear();
+		}
+		_eventReplicationState.LastEventIdFromServer = default;
+		if (_storage is IClearableAppendStorage clearable)
+		{
+			await clearable.ClearAllAsync();
 		}
 	}
 }

--- a/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
+++ b/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
@@ -296,49 +296,59 @@ internal class SynqraTestNode
 				if (!ctx.WebSockets.IsWebSocketRequest) { ctx.Response.StatusCode = 400; return; }
 				using var socket = await ctx.WebSockets.AcceptWebSocketAsync();
 
-				// Simple command registry (no reflection)
-				/*
-				var handlers = new Dictionary<string, Func<JsonElement, ValueTask<JsonElement>>>
-				{
-					["sum"] = async args =>
-					{
-						// args is a JSON array: [a, b]
-						var a = args[0].GetInt32();
-						var b = args[1].GetInt32();
-						// SerializeToElement avoids intermediate strings and is AOT-friendly for primitives/known types
-						return JsonSerializer.SerializeToElement(a + b);
-					},
-				};
-				*/
+				// Hand-rolled duplicate of SynqraReplicationEndpointExtensions.cs's HELLO/
+				// broadcast protocol, kept in sync by hand — Synqra.Replication.AspNetCore
+				// (the real production endpoint) is net10.0-only, but this test project also
+				// builds for net8.0/net9.0, so it can't just call the real thing on every TFM.
 
 				#region HELLO - from client
+				// 8 bytes magic + 16 bytes the client's own "last event id it already
+				// received from a server" cursor — see EventReplicationService's HELLO send
+				// and EventReplicationState.LastEventIdFromServer's own remarks.
 				var helloBytes = await ReceiveFullMessageAsync(socket, ctx.RequestAborted);
 				if (helloBytes is null)
 				{
 					return;
 				}
-				if (helloBytes.Length != 8)
+				if (helloBytes.Length != 24)
 				{
-					throw new Exception($"Protocol Negotiation Failed! Received {helloBytes.Length} bytes instead of 8.");
+					throw new Exception($"Protocol Negotiation Failed! Received {helloBytes.Length} bytes instead of 24.");
 				}
-				var magic = BitConverter.ToUInt64(helloBytes);
+				var magic = BitConverter.ToUInt64(helloBytes, 0);
 				if (magic != networkSerializationService.Magic)
 				{
 					throw new Exception($"Protocol Negotiation Failed! Received Magic {magic:X16} instead of {networkSerializationService.Magic:X16}.");
 				}
+				var clientCursor = new Guid(helloBytes.AsSpan(8, 16));
 				#endregion
-				#region HELLO - to client
-				// Register for broadcasts BEFORE answering HELLO, and do both under the
-				// broadcast semaphore: the moment a client observes the HELLO reply (and
-				// reports IsOnline), every subsequent broadcast is guaranteed to reach it,
-				// and the reply cannot interleave with a concurrent broadcast SendAsync on
-				// the same socket.
+				#region HELLO - to client, then replay this stream's backlog since clientCursor
+				// Register for broadcasts BEFORE answering HELLO, and do both — plus the
+				// backlog replay below — under the broadcast semaphore: the moment a client
+				// observes the HELLO reply (and reports IsOnline), every subsequent broadcast
+				// is guaranteed to reach it, and none of this can interleave with a concurrent
+				// broadcast SendAsync on the same socket.
 				var magicBytes = BitConverter.GetBytes(networkSerializationService.Magic);
 				await _semaphoreSlim.WaitAsync(ctx.RequestAborted);
 				try
 				{
 					_sockets.Add(socket);
 					await socket.SendAsync(magicBytes, WebSocketMessageType.Binary, endOfMessage: true, ctx.RequestAborted);
+
+					var backlogStorage = app.Services.GetRequiredService<IAppendStorage<Event, Guid>>();
+					var backlogBuffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
+					try
+					{
+						await foreach (var ev in backlogStorage.GetAllAsync(from: clientCursor, ctx.RequestAborted))
+						{
+							knownEvents.TryAdd(ev.EventId, null);
+							var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, backlogBuffer);
+							await socket.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
+						}
+					}
+					finally
+					{
+						ArrayPool<byte>.Shared.Return(backlogBuffer);
+					}
 				}
 				finally
 				{
@@ -355,8 +365,6 @@ internal class SynqraTestNode
 						{
 							break;
 						}
-						// var json = Encoding.UTF8.GetString(messageBytes);
-						// var operation = JsonSerializer.Deserialize<TransportOperation>(json, AppJsonContext.Default.Options);
 						var operation = networkSerializationService.Deserialize<TransportOperation>(messageBytes);
 
 						var storeCtx = app.Services.GetRequiredService<IProjection>();
@@ -409,38 +417,6 @@ internal class SynqraTestNode
 						{
 							throw new NotSupportedException();
 						}
-						/*
-						try
-						{
-							var invoke = JsonSerializer.Deserialize(messageBytes.Value, AppJsonContext.Default);
-							if (invoke?.Kind != "invoke") continue;
-
-							JsonElement resultEl;
-							string? error = null;
-
-							if (handlers.TryGetValue(invoke.Data.Method, out var handler))
-							{
-								resultEl = await handler(invoke.Data.Args);
-							}
-							else
-							{
-								error = $"Unknown method '{invoke.Data.Method}'";
-								resultEl = default;
-							}
-						// var result = new Envelope<ResultMessage>("result", new ResultMessage(invoke.Data.Id, error is null ? resultEl : null, error));
-
-
-						var payload = JsonSerializer.SerializeToUtf8Bytes(result, AppJsonContext.Default);
-							await socket.SendAsync(payload, WebSocketMessageType.Text, true, ctx.RequestAborted);
-						}
-						catch (Exception ex)
-						{
-							// best-effort error reply with id=-1 when deserialization fails
-							var err = new Envelope<ResultMessage>("result", new ResultMessage(-1, null, ex.GetType().Name));
-							var payload = JsonSerializer.SerializeToUtf8Bytes(err, WsJson.Default.EnvelopeResultMessage);
-							await socket.SendAsync(payload, WebSocketMessageType.Text, true, ctx.RequestAborted);
-						}
-						*/
 					}
 				}
 				catch (Exception ex)

--- a/Tests/Synqra.Tests/Syncronization/BacklogReplaySyncronizationTests.cs
+++ b/Tests/Synqra.Tests/Syncronization/BacklogReplaySyncronizationTests.cs
@@ -1,0 +1,86 @@
+using Synqra.Tests.SampleModels.Syncronization;
+using Synqra.Tests.Simulator;
+using Synqra.Tests.TestHelpers;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Synqra.Tests.Syncronization;
+
+/// <summary>
+/// A connecting client used to get nothing but future events (see
+/// SynqraReplicationEndpointExtensions.cs's own remarks) — a brand-new device, a cleared
+/// browser, or a second browser for the same account saw none of a stream's existing history.
+/// These pin the fix: the master now replays a stream's full backlog (via the client's HELLO
+/// cursor) to any (re)connecting client, keyed by what that specific client has already seen.
+/// </summary>
+[NotInParallel]
+internal class BacklogReplaySyncronizationTests : BaseTest
+{
+	const int PropagationTimeoutMs = 10_000;
+
+	[Test]
+	public async Task Should_replay_existing_history_to_a_client_that_connects_after_the_data_already_exists()
+	{
+		var nodeMaster = new SynqraTestNode(builder => { }, masterHost: true);
+		await nodeMaster.Started;
+
+		// Node A writes data and syncs it to the master BEFORE node C ever exists — the
+		// scenario the old protocol silently failed: a client's history predates the
+		// connecting client by definition, since it never even existed yet.
+		var nodeA = new SynqraTestNode(builder => { }) { Port = nodeMaster.Port };
+		await nodeA.Started;
+		await WaitForOnlineAsync(nodeA);
+
+		var collectionA = nodeA.StoreContext.GetCollection<SampleTaskModel>();
+		var task = new SampleTaskModel { Subject = "Pre-existing task" };
+		collectionA.Add(task);
+
+		// Confirm it actually reached the master's own durable store before node C connects —
+		// otherwise this test would pass by accident (a live-broadcast race, not a real
+		// backlog replay).
+		var sw = Stopwatch.StartNew();
+		while (!await MasterHasEventForAsync(nodeMaster) && (sw.ElapsedMilliseconds < PropagationTimeoutMs || Debugger.IsAttached))
+		{
+			await Task.Delay(100);
+		}
+		await Assert.That(await MasterHasEventForAsync(nodeMaster)).IsTrue();
+
+		// Node C has never connected before — a cold LastEventIdFromServer cursor, exactly
+		// like a brand-new device or a cleared browser.
+		var nodeC = new SynqraTestNode(builder => { }) { Port = nodeMaster.Port };
+		await nodeC.Started;
+		await WaitForOnlineAsync(nodeC);
+
+		var collectionC = nodeC.StoreContext.GetCollection<SampleTaskModel>();
+		sw = Stopwatch.StartNew();
+		while (collectionC.Count < 1 && (sw.ElapsedMilliseconds < PropagationTimeoutMs || Debugger.IsAttached))
+		{
+			await Task.Delay(100);
+		}
+		await Assert.That(collectionC).HasCount(1);
+		await Assert.That(collectionC.First().Subject).IsEqualTo("Pre-existing task");
+	}
+
+	static async Task<bool> MasterHasEventForAsync(SynqraTestNode master)
+	{
+		await foreach (var _ in master.Events.GetAllAsync())
+		{
+			return true;
+		}
+		return false;
+	}
+
+	static async Task WaitForOnlineAsync(SynqraTestNode node)
+	{
+		var sw = Stopwatch.StartNew();
+		while (!node.StoreContext.IsOnline())
+		{
+			if (sw.ElapsedMilliseconds > 30_000 && !Debugger.IsAttached)
+			{
+				throw new TimeoutException("Node did not come online within 30s");
+			}
+			await Task.Delay(100);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
A connecting client only ever got new events going forward — no code path read a stream's persisted history back to it. A genuinely new device, a cleared browser, or a second browser for the same account saw none of that stream's existing content. Not a corruption edge case, a missing capability (confirmed by reading `SynqraReplicationEndpointExtensions.cs` directly, not assuming).

Extends the client→server HELLO from 8 bytes (magic only) to 24 (+ the client's own `EventReplicationState.LastEventIdFromServer` cursor, `Guid.Empty` meaning "never synced"). The server now reads `storage.GetAllAsync(from: cursor)` and replays it to just that socket via the same `NewEvent1` message shape already used for live broadcast — no new client message type needed.

`EventReplicationService` now also seeds its by-EventId dedup (`_skipSet`) from local storage at startup (previously only `ProcessEvent` did) — otherwise, once the server resends backlog, a client that already has some of it locally would re-apply it and hit the same "unique component rejected on second application" crash a prior fix already worked around for a different path.

Also lands the client resync half this was bundled with:
- A corrupt/undeserializable local record during startup replay is now caught and cleared (`IClearableAppendStorage`, implemented by `IndexedDbBlobStorage`/`BlobAppendStorage`) instead of crashing the whole app.
- `IEventReplicationService.ClearLocalStorageAsync()` is exposed for a manual "Force Resync" action.
- Both are now safe specifically *because* reconnecting after a clear is guaranteed to reconstruct full state again.

**Deferred, not lost**: schema-upgrade lifters (the other half of the original backlog item). Synqra's SBX wire format has no per-record version tag by design — the low-level serializer only knows the raw smallest content of an object; version/dictionary negotiation is meant to happen at a coarser layer (a stream header, a reconfiguration message), not per record, to keep compression efficient. Building real lifters means designing that layer first — not blocking on it now, especially since Synqra has already been shifting toward JSON in practice.

## Test plan
- [x] Updated the test-only replication simulator (`SynqraTestNode.cs`) to the same 24-byte protocol so it can't silently drift from production again
- [x] Added a dedicated test: a client that connects *after* another client's data already exists on the master receives it via backlog replay
- [x] All 175 existing Synqra tests pass on net8.0, net9.0, and net10.0
- [x] Full Quotaly docker-compose acceptance suite (real Mongo, real WS boot) — 19/19 passing, no regressions