### PR TITLE
Make stream id first-class; deprecate SynqraRootStreamId

### DIFF
--- a/Contoso/Contoso.Projection.InMemory/ContosoInMemoryProjection.cs
+++ b/Contoso/Contoso.Projection.InMemory/ContosoInMemoryProjection.cs
@@ -9,9 +9,10 @@ namespace Contoso.Projection.InMemory;
 
 public class LocalOnlyContosoInMemoryProjection : ContosoInMemoryProjection
 {
-	public LocalOnlyContosoInMemoryProjection(ISbxSerializerFactory serializerFactory, ITypeMetadataProvider typeMetadataProvider) : base(
+	public LocalOnlyContosoInMemoryProjection(ISbxSerializerFactory serializerFactory, ITypeMetadataProvider typeMetadataProvider, Guid streamId) : base(
 		  serializerFactory: serializerFactory
 		, typeMetadataProvider: typeMetadataProvider
+		, streamId: streamId
 		, eventStorage: null
 		, eventReplicationService: null
 		, jsonSerializerOptions: null
@@ -26,6 +27,7 @@ public class ContosoInMemoryProjection : InMemoryProjection, IContosoCommandVisi
 	public ContosoInMemoryProjection(
 		  ISbxSerializerFactory serializerFactory
 		, ITypeMetadataProvider typeMetadataProvider
+		, Guid streamId
 		, IAppendStorage<Event, Guid>? eventStorage = null
 		, IAppendStorage<ProjectionSnapshot, Guid>? snapshotStorage = null
 		, IEventReplicationService? eventReplicationService = null
@@ -34,6 +36,7 @@ public class ContosoInMemoryProjection : InMemoryProjection, IContosoCommandVisi
 		) : base(
 			  serializerFactory
 			, typeMetadataProvider
+			, streamId
 			, eventStorage
 			, eventReplicationService
 			, jsonSerializerOptions

--- a/Contoso/Contoso.Wasm/Pages/Home.razor
+++ b/Contoso/Contoso.Wasm/Pages/Home.razor
@@ -12,43 +12,58 @@
 
 <h1>This page tests Synqra on WASM</h1>
 
-<div>@projection.ProjectionStatus</div>
+@if (projection is null)
+{
+    <div>Loading projection…</div>
+}
+else
+{
+    <div>@projection.ProjectionStatus</div>
 
-<h2>Test 001 - Add element to collection</h2>
-<InputText @bind-Value="itemName" data-testid="itemName" />
-<button @onclick="AddElement" data-testid="btnAdd">Add element to collection</button>
-<button @onclick="TestBatch" data-testid="btnTest">Test Batch</button>
-<button @onclick="StressTest" data-testid="btnStress">Stress Test</button>
-<table>
-    <thead>
-        <tr>
-            <th>Id</th>
-            <th>Item Name</th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var item in projection.GetCollection<ContosoItem>())
-        {
+    <h2>Test 001 - Add element to collection</h2>
+    <InputText @bind-Value="itemName" data-testid="itemName" />
+    <button @onclick="AddElement" data-testid="btnAdd">Add element to collection</button>
+    <button @onclick="TestBatch" data-testid="btnTest">Test Batch</button>
+    <button @onclick="StressTest" data-testid="btnStress">Stress Test</button>
+    <table>
+        <thead>
             <tr>
-                <td><code>@projection.GetId(item)</code></td>
-                <td>@item.ItemName</td>
+                <th>Id</th>
+                <th>Item Name</th>
             </tr>
-        }
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+            @foreach (var item in projection.GetCollection<ContosoItem>())
+            {
+                <tr>
+                    <td><code>@projection.GetId(item)</code></td>
+                    <td>@item.ItemName</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
 @code {
+    // The Contoso demo's single feature stream. A stream id is mandatory and first-class; it is
+    // supplied here at the call site (never baked into a DI registration) when resolving the
+    // projection from the provider.
+    private static readonly Guid ContosoStreamId = new Guid("c04705a0-0000-4000-8000-c04705a00001");
 
     private string stressLabel = "Stress Test";
-    private readonly ContosoInMemoryProjection projection;
-    private readonly IAppendStorage<Event, Guid> appendStorage;
+    private ContosoInMemoryProjection? projection;
 
-    public Home(ContosoInMemoryProjection projection, IAppendStorage<Event, Guid> appendStorage)
+    [Inject]
+    private IProjectionProvider ProjectionProvider { get; set; } = default!;
+
+    [Inject]
+    private IAppendStorage<Event, Guid> appendStorage { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
     {
-        this.projection = projection;
-        this.appendStorage = appendStorage;
+        projection = (ContosoInMemoryProjection)await ProjectionProvider.GetAsync(ContosoStreamId);
         projection.CommandProcessed += (sender, args) =>
         {
-            StateHasChanged();
+            _ = InvokeAsync(StateHasChanged);
         };
     }
 
@@ -56,7 +71,7 @@
 
     private void AddElement(MouseEventArgs args)
     {
-        projection.GetCollection<ContosoItem>().Add(new ContosoItem
+        projection!.GetCollection<ContosoItem>().Add(new ContosoItem
         {
             ItemName = itemName,
         });
@@ -93,7 +108,7 @@
             {
                 ItemName = itemName,
             };
-            projection.GetCollection<ContosoItem>().Add(item);
+            projection!.GetCollection<ContosoItem>().Add(item);
             for (int j = 0; j < batch; j++)
             {
                 item.ItemName2 = Guid.NewGuid().ToString("N");

--- a/Contoso/Contoso.Wasm/Program.cs
+++ b/Contoso/Contoso.Wasm/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Synqra;
 using Synqra.AppendStorage.BlobStorage.IndexedDb;
 using Synqra.BinarySerializer;
+using Synqra.Projection.InMemory;
 using System.Text.Json.Serialization;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -27,7 +28,10 @@ builder.Services.AddTypeMetadataProvider(
 	typeof(FooContosoEvent));
 builder.Services.AddSingleton<JsonSerializerContext>(ContosoJsonSerializerContext.Default);
 builder.Services.AddSingleton(ContosoJsonSerializerContext.DefaultOptions);
-builder.Services.AddSingleton<ContosoInMemoryProjection>();
+// Projection is non-multitenant in-memory: no DI-resolvable singleton — the factory/provider produce
+// a ContosoInMemoryProjection per stream at the call site (Home.razor resolves it for the Contoso
+// feature stream via IProjectionProvider). The IndexedDb event store above stays a singleton.
+builder.Services.AddInMemorySynqraStore<ContosoInMemoryProjection>();
 builder.Services.AddScoped<OpfsPocJsInterop>();
 
 await builder.Build().RunAsync();

--- a/Synqra.CodeGeneration/ModelBindingGenerator.cs
+++ b/Synqra.CodeGeneration/ModelBindingGenerator.cs
@@ -629,7 +629,6 @@ $$"""
 				var task = __store.SubmitCommandAsync(new {{commandTypeName}}
 				{
 					CommandId = GuidExtensions.CreateVersion7(),
-					StreamId = SynqraGuids.SynqraRootStreamId,
 					CollectionId = {{collectionIdExpr}},
 
 					TargetObject = {{targetObjectExpr}},

--- a/Synqra.Model/Components/StoreBoundComponentsCollection.cs
+++ b/Synqra.Model/Components/StoreBoundComponentsCollection.cs
@@ -106,7 +106,6 @@ public sealed class StoreBoundComponentsCollection : IComponentsCollection
 			new AddComponentCommand
 			{
 				CommandId = GuidExtensions.CreateVersion7(),
-				StreamId = SynqraGuids.SynqraRootStreamId,
 				CollectionId = _containerCollectionId,
 				TargetId = containerId,
 				TargetTypeId = containerTypeId,
@@ -131,7 +130,6 @@ public sealed class StoreBoundComponentsCollection : IComponentsCollection
 			new DeleteComponentCommand
 			{
 				CommandId = GuidExtensions.CreateVersion7(),
-				StreamId = SynqraGuids.SynqraRootStreamId,
 				CollectionId = _containerCollectionId,
 				TargetId = containerId,
 				TargetTypeId = containerTypeId,

--- a/Synqra.Model/IEventReplicationService.cs
+++ b/Synqra.Model/IEventReplicationService.cs
@@ -5,6 +5,16 @@ public interface IEventReplicationService
 {
 	bool IsOnline { get; }
 
+	/// <summary>
+	/// Raised after one or more incoming server events have been appended to this client's local
+	/// durable event log. This service is transport-only — it does not touch any projection. The
+	/// projection owner (test node / client component) subscribes and brings its stream's projection
+	/// up to date via <see cref="IProjectionKeeper.MaintainAsync"/> (typically through
+	/// <see cref="IProjectionProvider.GetAsync"/>). The signal is stream-agnostic; each owner catches
+	/// up only its own stream (a no-op if nothing new arrived for it).
+	/// </summary>
+	event Action? EventsReceived;
+
 	void Trigger(Command command, IReadOnlyList<Event> events);
 
 	/// <summary>

--- a/Synqra.Model/IProjection.cs
+++ b/Synqra.Model/IProjection.cs
@@ -131,17 +131,3 @@ public class TypeMetadata
 public interface IProjection : ICommandVisitor<CommandHandlerContext>, IEventVisitor<EventVisitorContext>
 {
 }
-
-/// <summary>
-/// Implemented by a projection that replays its own durable event log into itself on
-/// construction (e.g. InMemoryProjection, when wired with an IAppendStorage). A caller that
-/// ALSO has access to the same durable storage (e.g. EventReplicationService) must await
-/// this instead of replaying that storage a second time — applying the same event twice is
-/// rejected by any uniqueness check on the second application ("ComponentAddedEvent ...
-/// uniqueness ... rejected during replay"), since nothing here is naturally idempotent
-/// against being told "create this" twice.
-/// </summary>
-public interface ISelfLoadingProjection
-{
-	Task LoadStateAsync();
-}

--- a/Synqra.Model/IProjectionKeeper.cs
+++ b/Synqra.Model/IProjectionKeeper.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Synqra;
+
+/// <summary>
+/// A projection that materializes exactly one stream's state by folding in that stream's events.
+/// It carries its own <see cref="StreamId"/> and a <see cref="Cursor"/> (the last applied event id),
+/// so catch-up is always an explicit, incremental delta from the cursor — never an ambient
+/// "first touch" and never a stream baked into a DI registration.
+/// <para>
+/// Extends <see cref="IObjectStore"/> so the projection produced by <see cref="IProjectionFactory"/>/
+/// <see cref="IProjectionProvider"/> is directly usable as a queryable store. This is the
+/// non-multitenant projection family (in-memory today, an instance-per-stream client store like
+/// IndexedDb tomorrow); the multitenant durable projections implement <see cref="IObjectStore"/> +
+/// <see cref="IProjection"/> directly and are resolved ambiently, never via a factory.
+/// </para>
+/// </summary>
+public interface IReplayProjection : IObjectStore, IProjection
+{
+    /// <summary>The single stream this projection is bound to (Todo's ContainerId).</summary>
+    Guid StreamId { get; }
+
+    /// <summary>
+    /// Id of the last event applied to this projection (Todo's CurrentVersion). <see cref="Guid.Empty"/>
+    /// means cold — nothing applied yet.
+    /// </summary>
+    Guid Cursor { get; }
+
+    /// <summary>
+    /// Apply one event to this projection, advancing <see cref="Cursor"/> to the event's id. The
+    /// <see cref="IProjectionKeeper"/> is the only caller during catch-up. <paramref name="isReplay"/>
+    /// suppresses one-shot activator side effects for historical events.
+    /// </summary>
+    Task ApplyAsync(Event ev, bool isReplay = false, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A per-stream event reader/writer. The log knows which stream it is (<see cref="StreamId"/>), so a
+/// misrouted append is caught here rather than silently folded into the wrong projection.
+/// </summary>
+public interface IEventLog
+{
+    /// <summary>The stream this log is scoped to.</summary>
+    Guid StreamId { get; }
+
+    /// <summary>Append one event to this stream's durable log.</summary>
+    Task AppendAsync(Event ev, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Read this stream's events strictly AFTER <paramref name="afterEventId"/> (exclusive), optionally
+    /// stopping once the event with id <paramref name="till"/> has been yielded. Passing
+    /// <see cref="Guid.Empty"/> reads from the beginning.
+    /// </summary>
+    IAsyncEnumerable<Event> ReadFrom(Guid afterEventId = default, Guid? till = null, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Hands out per-stream <see cref="IEventLog"/>s. The result is guaranteed to have
+/// <c>GetEventLog(s).StreamId == s</c>.
+/// </summary>
+public interface IEventLogProvider
+{
+    IEventLog GetEventLog(Guid streamId);
+}
+
+/// <summary>
+/// The one and only replay path. Brings a projection up to date by reading the delta from its
+/// <see cref="IReplayProjection.Cursor"/> forward and applying it. Cheap no-op when already at head,
+/// full replay when cold. Consumers call this before use — they never call a "Load" method.
+/// </summary>
+public interface IProjectionKeeper
+{
+    Task MaintainAsync(IReplayProjection projection, Guid? till = null, bool isReplay = false, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// The projection-area factory: creates a fresh, single-stream <see cref="IReplayProjection"/> bound
+/// to the supplied stream id. The stream id is a runtime argument supplied at the call site (a fresh
+/// random stream in tests, the session stream on a client) — never pinned into a DI registration.
+/// <para>
+/// This is the counterpart to the event-area <see cref="IEventLogProvider"/>. A store whose projection
+/// cannot be multitenant (in-memory today, an instance-per-stream client store like IndexedDb
+/// tomorrow) registers a factory here instead of a DI-resolvable projection singleton. Use this
+/// directly only for an <i>alternative</i> build of a stream; for the regular latest projection of a
+/// stream prefer <see cref="IProjectionProvider"/>.
+/// </para>
+/// </summary>
+public interface IProjectionFactory
+{
+    IReplayProjection Create(Guid streamId);
+}
+
+/// <summary>
+/// Hands out the regular, latest projection for a given stream id: one cached, keeper-maintained
+/// <see cref="IReplayProjection"/> per stream, brought up to head before it is returned. This is what
+/// consumers normally want — the "default provider/factory/DI-key gives me the latest projection of a
+/// specified stream" entry point. Keyed by stream <b>at call time</b>, so it is NOT a stream-bound DI
+/// singleton (mirrors Todo's <c>EventsStreamFactory.Get</c> GetOrAdd caching).
+/// </summary>
+public interface IProjectionProvider
+{
+    Task<IReplayProjection> GetAsync(Guid streamId, CancellationToken cancellationToken = default);
+}

--- a/Synqra.Model/Links/LinkCollections.cs
+++ b/Synqra.Model/Links/LinkCollections.cs
@@ -200,7 +200,6 @@ public abstract class LinkNavCollectionBase<TItem, TLink> : ICollection<TItem>, 
 		var task = store.SubmitCommandAsync(new AddLinkCommand
 		{
 			CommandId = GuidExtensions.CreateVersion7(),
-			StreamId = SynqraGuids.SynqraRootStreamId,
 			LinkTypeId = store.TypeMetadataProvider.GetTypeMetadata(typeof(TLink)).TypeId,
 			LinkId = link.LinkId,
 			SourceId = link.SourceId,
@@ -215,7 +214,6 @@ public abstract class LinkNavCollectionBase<TItem, TLink> : ICollection<TItem>, 
 		var task = Store.SubmitCommandAsync(new RemoveLinkCommand
 		{
 			CommandId = GuidExtensions.CreateVersion7(),
-			StreamId = SynqraGuids.SynqraRootStreamId,
 			LinkId = link.LinkId,
 		});
 		RunSync(task);

--- a/Synqra.Model/StreamPin.cs
+++ b/Synqra.Model/StreamPin.cs
@@ -1,0 +1,30 @@
+namespace Synqra;
+
+/// <summary>
+/// Optional construction-time pin for an omnitenant store (File / Mongo). It is deliberately
+/// <b>never registered in DI</b>: the omnitenant root registration therefore receives <c>null</c> for
+/// its optional <see cref="StreamPin"/> constructor dependency and resolves the caller's ambient
+/// <see cref="SynqraStreamContext"/> scope on every access. A factory that builds a genuinely
+/// single-tenant instance at the point of use passes one of these to bind the store to exactly one
+/// stream — pinning happens at construction by a factory, never by a stream-parameterised DI
+/// registration (that would reintroduce the "singleton bound to a fixed stream" anti-pattern).
+/// <para>
+/// There is no "default stream": a pin always carries a real, non-default stream id (a stream id is a
+/// security boundary).
+/// </para>
+/// </summary>
+public sealed class StreamPin
+{
+	public StreamPin(Guid streamId)
+	{
+		if (streamId == default)
+		{
+			throw new ArgumentException(
+				"A pinned stream id must not be default — there is no default stream (a stream id is a security boundary).",
+				nameof(streamId));
+		}
+		StreamId = streamId;
+	}
+
+	public Guid StreamId { get; }
+}

--- a/Synqra.Model/SynqraGuids.cs
+++ b/Synqra.Model/SynqraGuids.cs
@@ -45,7 +45,12 @@ public static class SynqraGuids
 	 */
 
 	public static Guid SynqraTypeNamespaceId = new("BAD8F923-FA74-4CA0-9AA3-70BB874ACC76"); // NEVER CHANGE THAT! Object type namespace. It does not matter, what pattern it follows, it is just a random but fixed input to sha256 v8 guids it produces from type names.
-	public static Guid SynqraRootStreamId    = new("C0DEADD0-1032-8000-800C-000000000000"); // class 0x00C: root/default stream (see the "Well-known classes" note above for why the byte is "C").
+
+	// (removed) SynqraRootStreamId — there is no default/root stream. A stream id is a first-class,
+	// mandatory value (a security boundary). Multitenant stores read the ambient
+	// SynqraStreamContext.Current (entered per request); single-tenant stores take an explicit stream
+	// id at registration / borrow a projection for an explicit stream from the provider. The reserved
+	// value C0DEADD0-1032-8000-800C-* documented above is retired.
 
 	/*
 	 * Principles behind MasterId:

--- a/Synqra.Model/SynqraStreamContext.cs
+++ b/Synqra.Model/SynqraStreamContext.cs
@@ -32,6 +32,11 @@ public static class SynqraStreamContext
 	public static Guid Current => _current.Value
 		?? throw new InvalidOperationException("No stream context is active. Establish one with SynqraStreamContext.Enter(streamId) before touching a stream-scoped store.");
 
+	/// <summary>The stream_id in effect for the calling async flow, or <c>null</c> if no <see cref="Enter"/>
+	/// scope is active. Unlike <see cref="Current"/> this never throws — it is the non-throwing peek a
+	/// store uses to <i>compare</i> the ambient scope against a stream it is pinned to.</summary>
+	public static Guid? CurrentOrNull => _current.Value;
+
 	/// <summary>
 	/// Scopes <see cref="Current"/> to <paramref name="streamId"/> for the calling async flow (and
 	/// anything it awaits) until the returned scope is disposed. Nests correctly — disposing restores
@@ -47,6 +52,41 @@ public static class SynqraStreamContext
 		var previous = _current.Value;
 		_current.Value = streamId;
 		return new Scope(previous);
+	}
+
+	/// <summary>
+	/// Resolve the stream id a store call is scoped to, for a store that can register <b>either</b> as
+	/// the process-wide multitenant root (no pinned stream — it reads the caller's ambient scope on
+	/// every access, so one instance serves however many concurrent streams the process has) <b>or</b>
+	/// pinned to a single stream. The policy is identical across every such store (currently the MongoDb
+	/// and File projections), so it lives here once rather than being copy-pasted into each — the ambient
+	/// scope is only the carrier; deciding what to do with it is this one method.
+	/// <para>
+	/// <paramref name="pinnedStreamId"/> is <c>null</c> => the store is the multitenant root: return the
+	/// ambient <see cref="Current"/> (which throws if no scope is active — there is no default stream, a
+	/// stream id is a security boundary).
+	/// </para>
+	/// <para>
+	/// A value => the store is pinned to that one stream: return it, but an ambient scope for a
+	/// <i>different</i> stream is a caller bug (entered stream B, then touched a store bound to stream A)
+	/// and throws. A matching scope, or no scope at all, passes — so a pinned store stays usable both
+	/// outside any scope and inside a correctly-matching one.
+	/// </para>
+	/// </summary>
+	public static Guid Resolve(Guid? pinnedStreamId)
+	{
+		if (pinnedStreamId is Guid pinned)
+		{
+			if (CurrentOrNull is Guid ambient && ambient != pinned)
+			{
+				throw new InvalidOperationException(
+					$"Stream-context conflict: this store is pinned to stream {pinned}, but an ambient "
+					+ $"SynqraStreamContext scope for a different stream {ambient} is active. A store pinned "
+					+ "to one stream must only be touched outside any scope, or inside a scope for its own stream.");
+			}
+			return pinned;
+		}
+		return Current;
 	}
 
 	sealed class Scope(Guid? previous) : IDisposable

--- a/Synqra.Projection.File/_DI.cs
+++ b/Synqra.Projection.File/_DI.cs
@@ -1,20 +1,12 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
-using Microsoft.VisualBasic;
 using Synqra.AppendStorage;
 using Synqra.BinarySerializer;
 using System.Collections;
 using System.Collections.Concurrent;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Globalization;
-using System.Net;
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Synqra.Projection.File;
@@ -29,6 +21,18 @@ public static class FileSynqraExtensions
 		_ = typeof(IAppendStorage<Event, Guid>);
 	}
 
+	/// <summary>
+	/// Register a file-backed Synqra store as the <b>multitenant root</b> — it captures no stream at
+	/// construction and reads the caller's ambient <see cref="SynqraStreamContext"/> scope on every
+	/// access, so one instance serves however many concurrent streams the process has.
+	/// <para>
+	/// There is deliberately no stream-id overload. A store is never pinned to a stream at DI
+	/// registration — that is the "singleton bound to a fixed stream" anti-pattern this whole design
+	/// removes. A caller that operates on one stream enters a <see cref="SynqraStreamContext.Enter"/>
+	/// scope (exactly as a production request handler does); a genuinely single-tenant instance is
+	/// built by a factory at the point of use, not registered here.
+	/// </para>
+	/// </summary>
 	public static IHostApplicationBuilder AddFileSynqraStore(this IHostApplicationBuilder builder)
 	{
 		builder.Services.AddSingleton<AppendStores>();
@@ -78,17 +82,6 @@ public static class FileSynqraExtensions
 		GetOrCreate, // 10 1
 	}
 
-	private class FileObjectStoreConfig
-	{
-		// in future container is sort of "database". For multitanent storage, every user has a set of his own containers, e.g. "settings", "nodes"
-		// - user1 // container (like sql database filtered by user)
-		// - user2 // container (like sql database filtered by user)
-		//   - collection type: "node" collectionName: "" // main collection
-		//   - collection type: "node" collectionName: "archive" // additional named collection
-		//   - collection "userSettings"
-		public Guid StreamId { get; set; } = SynqraGuids.SynqraRootStreamId; // for current phase this is global root container, no distinction yet, just to pass validations
-	}
-
 	private class FileObjectStore : IObjectStore
 	{
 		private readonly Dictionary<Guid, FileObjectCollection> _collections = new Dictionary<Guid, FileObjectCollection>();
@@ -98,11 +91,14 @@ public static class FileSynqraExtensions
 		private byte _attachedMaintain;
 		public ISbxSerializerFactory SerializerFactory { get; }
 		private readonly Lazy<IProjection> _lazyFileProjection;
-		private readonly IOptions<FileObjectStoreConfig> _options;
+		// null => multitenant root (resolve the ambient scope per call); a value => pinned to one stream.
+		private readonly Guid? _pinnedStreamId;
 
 		private FileProjection _fileProjection => (FileProjection)_lazyFileProjection.Value;
 
-		public Guid StreamId { get; } = SynqraGuids.SynqraRootStreamId; // for current phase this is global root container, no distinction yet, just to pass validations
+		// Omnitenant: pinned to a single stream when constructed with one, otherwise resolves the ambient
+		// SynqraStreamContext scope (multitenant). See SynqraStreamContext.Resolve.
+		public Guid StreamId => SynqraStreamContext.Resolve(_pinnedStreamId);
 
 		public ITypeMetadataProvider TypeMetadataProvider { get; }
 
@@ -114,17 +110,16 @@ public static class FileSynqraExtensions
 			  ITypeMetadataProvider typeMetadataProvider
 			, ISbxSerializerFactory serializerFactory
 			, Lazy<IProjection> fileProjection
-			, IOptions<FileObjectStoreConfig> options
 			, AppendStores appendStores
+			, StreamPin? pin = null
 			, GuidExtensions.Generator? generator = null
 			)
 		{
 			TypeMetadataProvider = typeMetadataProvider;
 			SerializerFactory = serializerFactory;
 			_lazyFileProjection = fileProjection;
-			_options = options;
 			AppendStores = appendStores;
-			StreamId = options.Value.StreamId;
+			_pinnedStreamId = pin?.StreamId;
 			GuidGenerator = generator ?? new GuidExtensions.Generator();
 		}
 
@@ -602,6 +597,19 @@ public static class FileSynqraExtensions
 			if (newCommand is not Command cmd)
 			{
 				throw new Exception("Only Syncra.Command can be an implementation of ICommand, please derive from Syncra.Command");
+			}
+			// Single normalization point (mirrors InMemoryProjection / MongoProjection): a command
+			// arriving without a stream id (e.g. from the generated setter / component / link visitors)
+			// inherits this store's stream; one carrying a different stream is a misroute and throws.
+			var streamId = _objectStore.StreamId;
+			if (cmd.StreamId == default)
+			{
+				cmd.StreamId = streamId;
+			}
+			else if (cmd.StreamId != streamId)
+			{
+				throw new InvalidOperationException(
+					$"Command stream {cmd.StreamId} does not match this store's stream {streamId} — refusing misrouted command {cmd.CommandId}.");
 			}
 			await cmd.AcceptAsync(this, commandHandlingContext);
 			var eventVisitorContext = new EventVisitorContext();

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Synqra.AppendStorage;
 using Synqra.BinarySerializer;
 using Synqra.Projection;
@@ -38,7 +38,7 @@ public static class InMemoryStoreContextExtensions
 /// It can be used to replay events from scratch
 /// It can also be treated like EF DataContext
 /// </summary>
-public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<CommandHandlerContext>, IEventVisitor<EventVisitorContext>, ILinkIndex, ISelfLoadingProjection
+public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<CommandHandlerContext>, IEventVisitor<EventVisitorContext>, ILinkIndex, IReplayProjection
 {
 	private static UTF8Encoding _utf8nobom = new UTF8Encoding(false, false);
 	static InMemoryProjection()
@@ -76,6 +76,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	public InMemoryProjection(
 		  ISbxSerializerFactory serializerFactory
 		, ITypeMetadataProvider typeMetadataProvider
+		, Guid streamId
 		, IAppendStorage<Event, Guid>? eventStorage = null
 		, IEventReplicationService? eventReplicationService = null
 		, JsonSerializerOptions? jsonSerializerOptions = null
@@ -83,6 +84,24 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		, IServiceProvider? serviceProvider = null
 		)
 	{
+		// The stream id is a first-class construction value — an InMemoryProjection is inherently
+		// single-tenant: one instance materializes exactly one stream's state, so it is pinned to
+		// exactly one stream up front and never reads an ambient SynqraStreamContext scope. It is
+		// supplied at runtime by IProjectionFactory.Create(streamId) (the caller resolves the stream
+		// at the call site — a fresh random stream in tests, the session stream on a client), NOT
+		// baked into a DI registration. Unlike the omnitenant Mongo/File stores (which resolve the
+		// ambient scope per call when unpinned, via the shared SynqraStreamContext.Resolve), this store
+		// returns its pinned stream unconditionally. It does NOT replay itself here — a freshly created
+		// projection is cold (Cursor == Guid.Empty); IProjectionKeeper.MaintainAsync folds in the delta
+		// from the stream's IEventLog before first use.
+		StreamId = streamId;
+		if (StreamId == default)
+		{
+			throw new InvalidOperationException(
+				"InMemoryProjection requires an explicit StreamId. Create it via "
+				+ "IProjectionFactory.Create(streamId). "
+				+ "There is no default stream — a stream id is a security boundary.");
+		}
 		_serializerFactory = serializerFactory;
 		TypeMetadataProvider = typeMetadataProvider;
 		_eventStorage = eventStorage;
@@ -111,46 +130,22 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		}
 
 		// since it is in-memory, we have to roll state in
-		_ = LoadStateAsync();
 	}
 
 	public string? ProjectionStatus { get; set; }
 
-	Task? _loading;
+	public Guid Cursor { get; private set; }
 
-	public Task LoadStateAsync()
+	/// <summary>
+	/// Apply one event, advancing <see cref="Cursor"/> (in <see cref="AfterVisitAsync(Event, EventVisitorContext)"/>).
+	/// The <see cref="IProjectionKeeper"/> is the only caller during catch-up; <paramref name="isReplay"/>
+	/// suppresses one-shot activator side effects for historical events.
+	/// </summary>
+	public async Task ApplyAsync(Event ev, bool isReplay = false, CancellationToken cancellationToken = default)
 	{
-		return _loading ??= LoadStateCoreAsync();
+		await ev.AcceptAsync(this, new EventVisitorContext { IsReplay = isReplay });
 	}
 
-	async Task LoadStateCoreAsync()
-	{
-		try
-		{
-			if (_eventStorage != null)
-			{
-				ProjectionStatus = "Loading...";
-				var sw = Stopwatch.StartNew();
-				// Replay mode: activators with one-shot side effects skip during this loop.
-				var ctx = new EventVisitorContext { IsReplay = true };
-				long cnt = 0;
-				await foreach (var item in _eventStorage.GetAllAsync())
-				{
-					await item.AcceptAsync(this, ctx);
-					cnt++;
-				}
-				ProjectionStatus = $"Loaded ({sw.Elapsed.TotalMilliseconds:F0} ms for {cnt} items)";
-				CommandProcessed?.Invoke(this, EventArgs.Empty);
-			}
-		}
-		catch (Exception ex)
-		{
-			ProjectionStatus = $"Error: {ex.Message}";
-			CommandProcessed?.Invoke(this, EventArgs.Empty);
-			Console.Error.WriteLine($"{ex}");
-			throw;
-		}
-	}
 
 	internal AttachedObjectData Attach(object model, StoreCollection collection)
 	{
@@ -367,7 +362,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		return TypeMetadataProvider.GetTypeMetadata(rootType).GetCollectionId(name);
 	}
 
-	public Guid StreamId { get; } = SynqraGuids.SynqraRootStreamId;
+	public Guid StreamId { get; }
 
 	ISynqraCollection IObjectStore.GetCollection(Type type, string? collectionName)
 	{
@@ -445,6 +440,11 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			if (cmd.StreamId == default)
 			{
 				cmd.StreamId = StreamId;
+			}
+			else if (cmd.StreamId != StreamId)
+			{
+				throw new InvalidOperationException(
+					$"Command stream {cmd.StreamId} does not match this projection's stream {StreamId} — refusing misrouted command {cmd.CommandId}.");
 			}
 		}
 		if (newCommand is SingleObjectCommand soc)
@@ -838,6 +838,15 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 
 	public Task AfterVisitAsync(Event ev, EventVisitorContext ctx)
 	{
+		// Single apply choke point for every path (local command, keeper catch-up, live). A stream
+		// mismatch means a misrouted event — never silently fold it into the wrong projection. A
+		// default (unset) StreamId is tolerated as legacy/unrouted in a single-stream log.
+		if (ev.StreamId != default && ev.StreamId != StreamId)
+		{
+			throw new InvalidOperationException(
+				$"Event stream {ev.StreamId} does not match projection stream {StreamId} — misrouted event {ev.EventId}.");
+		}
+		Cursor = ev.EventId;
 		return Task.CompletedTask;
 	}
 

--- a/Synqra.Projection.InMemory/_DI.cs
+++ b/Synqra.Projection.InMemory/_DI.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Synqra.AppendStorage;
 
 namespace Synqra.Projection.InMemory;
@@ -11,32 +11,46 @@ public static class InMemorySynqraExtensions
 		// AOT ROOTS:
 		_ = typeof(IAppendStorage<Event, Guid>);
 	}
-	public static void AddInMemorySynqraStore(this IServiceCollection builder)
-	{
-		builder.AddInMemorySynqraStore<InMemoryProjection, InMemoryProjection>();
-	}
 
-	public static void AddInMemorySynqraStore<TI, T>(this IServiceCollection services)
-		where TI : class, IObjectStore // it is very confusing, but it really means it is - interface! Because next line trigger multiple inheritance otherwise
-		where T : InMemoryProjection, TI
+	/// <summary>
+	/// Register the stream-agnostic in-memory projection-area contracts: a factory that creates a
+	/// single-stream <see cref="InMemoryProjection"/> on demand (<see cref="IProjectionFactory"/>), a
+	/// provider that hands out the cached latest projection per stream
+	/// (<see cref="IProjectionProvider"/>), the per-stream event-log provider
+	/// (<see cref="IEventLogProvider"/>), and the keeper that drives delta catch-up
+	/// (<see cref="IProjectionKeeper"/>).
+	/// <para>
+	/// No stream is pinned here — there is deliberately no <c>AddInMemorySynqraStore(streamId)</c> that
+	/// registers a projection singleton bound to a fixed stream (a stream id is a security boundary,
+	/// not a DI key). Callers obtain a projection per stream at runtime via the provider/factory (a
+	/// fresh random stream in tests, the session stream on a client); the provider brings it up to date
+	/// with <see cref="IProjectionKeeper.MaintainAsync"/> before hand-out.
+	/// </para>
+	/// The in-memory <b>projection</b> is strictly non-multitenant: one instance == one stream, so it
+	/// is never a DI singleton. The in-memory <b>event store</b> (<c>IAppendStorage&lt;Event,Guid&gt;</c>,
+	/// registered separately by the append-storage package) IS multitenant — it holds every stream and
+	/// the per-stream <see cref="IEventLog"/> filters by <see cref="Event.StreamId"/> — so it stays a
+	/// singleton, exactly like the durable Mongo/File event stores.
+	/// </summary>
+	public static void AddInMemorySynqraStore(this IServiceCollection services)
 	{
-		services.AddSingleton<TI, T>();
-		services.AddSingleton<IObjectStore>(sp => sp.GetRequiredService<T>());
-		services.AddSingleton<IProjection>(sp => sp.GetRequiredService<T>());
-		// builder.AddSingleton(typeof(IStoreCollection<>), (sp, s) => sp.GetRequiredService<IStoreContext>().Get<>); // Example storage implementation
-		// return services;
+		services.TryAddSingleton<IProjectionFactory, InMemoryProjectionFactory>();
+		services.TryAddSingleton<IProjectionProvider, InMemoryProjectionProvider>();
+		services.TryAddSingleton<IEventLogProvider, EventLogProvider>();
+		services.TryAddSingleton<IProjectionKeeper, ProjectionKeeper>();
 	}
 
 	/// <summary>
-	/// Keyed variant — see <see cref="Synqra.Projection.MongoDb.MongoSynqraStoreExtensions"/>'s
-	/// keyed overload doc for the full rationale. Use when a single process hosts more than one
-	/// independent Synqra-backed feature: each gets its own InMemoryProjection under its own key
-	/// rather than racing for the global, unkeyed IObjectStore/IProjection singleton slot.
+	/// As <see cref="AddInMemorySynqraStore(IServiceCollection)"/>, but the factory/provider produce a
+	/// domain subclass of <see cref="InMemoryProjection"/> (e.g. Contoso's
+	/// <c>ContosoInMemoryProjection</c>) instead of the base projection.
 	/// </summary>
-	public static void AddInMemorySynqraStore(this IServiceCollection services, string serviceKey)
+	public static void AddInMemorySynqraStore<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] TProjection>(this IServiceCollection services)
+		where TProjection : InMemoryProjection
 	{
-		services.AddKeyedSingleton<InMemoryProjection>(serviceKey);
-		services.AddKeyedSingleton<IObjectStore>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<InMemoryProjection>(key));
-		services.AddKeyedSingleton<IProjection>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<InMemoryProjection>(key));
+		services.TryAddSingleton<IProjectionFactory, InMemoryProjectionFactory<TProjection>>();
+		services.TryAddSingleton<IProjectionProvider, InMemoryProjectionProvider>();
+		services.TryAddSingleton<IEventLogProvider, EventLogProvider>();
+		services.TryAddSingleton<IProjectionKeeper, ProjectionKeeper>();
 	}
 }

--- a/Synqra.Projection.InMemory/_ProjectionKeeper.cs
+++ b/Synqra.Projection.InMemory/_ProjectionKeeper.cs
@@ -1,0 +1,227 @@
+using Microsoft.Extensions.DependencyInjection;
+using Synqra.AppendStorage;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Synqra.Projection.InMemory;
+
+/// <summary>
+/// The projection-area factory for the in-memory store. Creates a single-stream
+/// <typeparamref name="TProjection"/> (an <see cref="InMemoryProjection"/> or a domain subclass such
+/// as Contoso's) on demand. The stream id is a runtime argument supplied at the call site (a fresh
+/// random stream in tests, the session stream on a client) — never pinned into a DI registration.
+/// In-memory projections cannot be multitenant, so there is no DI-resolvable projection singleton:
+/// callers use this factory (for an alternative build) or <see cref="IProjectionProvider"/> (for the
+/// regular latest projection of a stream).
+/// </summary>
+public class InMemoryProjectionFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TProjection> : IProjectionFactory
+	where TProjection : InMemoryProjection
+{
+	private readonly IServiceProvider _serviceProvider;
+
+	public InMemoryProjectionFactory(IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+	}
+
+	public IReplayProjection Create(Guid streamId)
+	{
+		if (streamId == default)
+		{
+			throw new ArgumentException(
+				"A non-default stream id is required — there is no default stream (a stream id is a security boundary).",
+				nameof(streamId));
+		}
+		// ActivatorUtilities.CreateInstance<T> carries [DynamicallyAccessedMembers(PublicConstructors)]
+		// on T; the matching annotation on TProjection above flows it through, so the WASM trimmer
+		// preserves the constructor and its optional parameters — streamId binds to the Guid ctor
+		// param, the rest resolve from DI.
+		return ActivatorUtilities.CreateInstance<TProjection>(_serviceProvider, streamId);
+	}
+}
+
+/// <summary>Default in-memory projection factory producing the base <see cref="InMemoryProjection"/>.</summary>
+public sealed class InMemoryProjectionFactory : InMemoryProjectionFactory<InMemoryProjection>
+{
+	public InMemoryProjectionFactory(IServiceProvider serviceProvider) : base(serviceProvider)
+	{
+	}
+}
+
+/// <summary>
+/// The regular latest-projection provider for the in-memory store: one cached, keeper-maintained
+/// <see cref="InMemoryProjection"/> per stream. Keyed by stream at call time (a
+/// <see cref="ConcurrentDictionary{Guid, IReplayProjection}"/>), not a stream-bound DI singleton —
+/// mirrors Todo's <c>EventsStreamFactory.Get</c> GetOrAdd caching. Each returned projection is brought
+/// up to head via <see cref="IProjectionKeeper.MaintainAsync"/> before hand-out.
+/// </summary>
+public sealed class InMemoryProjectionProvider : IProjectionProvider
+{
+	private readonly IProjectionFactory _factory;
+	private readonly IProjectionKeeper _keeper;
+	private readonly ConcurrentDictionary<Guid, Entry> _byStream = new();
+
+	public InMemoryProjectionProvider(IProjectionFactory factory, IProjectionKeeper keeper)
+	{
+		_factory = factory;
+		_keeper = keeper;
+	}
+
+	// One entry per stream: the cached projection, a gate that serializes catch-up (GetAsync is
+	// called on every "new events available" signal from the transport, possibly concurrently), and
+	// a cold-load flag so only the very first catch-up is applied as a historical replay.
+	private sealed class Entry
+	{
+		public IReplayProjection? Projection;
+		public readonly SemaphoreSlim Gate = new(1, 1);
+		public bool ColdLoaded;
+	}
+
+	public async Task<IReplayProjection> GetAsync(Guid streamId, CancellationToken cancellationToken = default)
+	{
+		if (streamId == default)
+		{
+			throw new ArgumentException("A non-default stream id is required.", nameof(streamId));
+		}
+		var entry = _byStream.GetOrAdd(streamId, _ => new Entry());
+		await entry.Gate.WaitAsync(cancellationToken);
+		try
+		{
+			entry.Projection ??= _factory.Create(streamId);
+			// A freshly created projection is cold (Cursor == Guid.Empty): the whole durable log is
+			// historical, so apply it as a replay (suppresses one-shot activator side effects). Once
+			// caught up the first time, later live deltas are not replay.
+			await _keeper.MaintainAsync(entry.Projection, isReplay: !entry.ColdLoaded, cancellationToken: cancellationToken);
+			entry.ColdLoaded = true;
+			return entry.Projection;
+		}
+		finally
+		{
+			entry.Gate.Release();
+		}
+	}
+}
+
+/// <summary>
+/// An <see cref="IEventLog"/> over a multitenant <see cref="IAppendStorage{Event, Guid}"/>. The store
+/// holds every stream (events are keyed by globally-unique v7 <see cref="Event.EventId"/> and carry
+/// their own <see cref="Event.StreamId"/>), so reads are filtered to this log's stream — exactly
+/// Todo's shared <c>RamEventsStore</c> filtered by ContainerId. The stream id also rejects a misrouted
+/// append and satisfies the provider's <c>StreamId == streamId</c> guarantee.
+/// </summary>
+public sealed class AppendStorageEventLog : IEventLog
+{
+	private readonly IAppendStorage<Event, Guid> _storage;
+
+	public AppendStorageEventLog(Guid streamId, IAppendStorage<Event, Guid> storage)
+	{
+		StreamId = streamId;
+		_storage = storage;
+	}
+
+	public Guid StreamId { get; }
+
+	public Task AppendAsync(Event ev, CancellationToken cancellationToken = default)
+	{
+		if (ev.StreamId != default && ev.StreamId != StreamId)
+		{
+			throw new InvalidOperationException(
+				$"Event stream {ev.StreamId} does not match log stream {StreamId} — refusing misrouted append of {ev.EventId}.");
+		}
+		return _storage.AppendAsync(ev);
+	}
+
+	public async IAsyncEnumerable<Event> ReadFrom(
+		  Guid afterEventId = default
+		, Guid? till = null
+		, [EnumeratorCancellation] CancellationToken cancellationToken = default
+		)
+	{
+		// Backend-agnostic incremental read. IAppendStorage.GetAllAsync(from) is NOT a uniform
+		// range scan across backends — the in-memory store treats `from` as a >= key bound, but the
+		// JsonLines store treats it as a key *prefix* match (returning only the boundary event), and
+		// others may differ. Relying on it for "everything after the cursor" silently returns nothing
+		// on a prefix-match backend, breaking live catch-up. So always do a full read (from: default,
+		// which every backend agrees means "everything") in append/chronological order and skip past
+		// the cursor here. The log is multitenant, so also filter to this stream (a legacy event with
+		// a default StreamId is tolerated — it belongs to whichever single stream owned the store
+		// historically).
+		//
+		// A cold cursor (default) means "apply the whole stream". Otherwise skip every event up to and
+		// including the one whose EventId == cursor (it is already applied), then yield the rest.
+		var reached = afterEventId == default;
+		await foreach (var ev in _storage.GetAllAsync(from: default, cancellationToken))
+		{
+			if (ev.StreamId != default && ev.StreamId != StreamId)
+			{
+				continue;
+			}
+			if (!reached)
+			{
+				if (ev.EventId == afterEventId)
+				{
+					reached = true;
+				}
+				continue;
+			}
+			yield return ev;
+			if (till is Guid t && ev.EventId == t)
+			{
+				yield break;
+			}
+		}
+	}
+}
+
+public sealed class EventLogProvider : IEventLogProvider
+{
+	private readonly IAppendStorage<Event, Guid> _storage;
+
+	public EventLogProvider(IAppendStorage<Event, Guid> storage)
+	{
+		_storage = storage;
+	}
+
+	public IEventLog GetEventLog(Guid streamId)
+	{
+		if (streamId == default)
+		{
+			throw new ArgumentException("A non-default stream id is required.", nameof(streamId));
+		}
+		return new AppendStorageEventLog(streamId, _storage);
+	}
+}
+
+/// <summary>
+/// The one and only replay path: reads the delta from <see cref="IReplayProjection.Cursor"/> forward
+/// out of the stream's <see cref="IEventLog"/> and applies it, advancing the cursor. A cheap no-op
+/// when already at head, a full replay when cold.
+/// </summary>
+public sealed class ProjectionKeeper : IProjectionKeeper
+{
+	private readonly IEventLogProvider _logProvider;
+
+	public ProjectionKeeper(IEventLogProvider logProvider)
+	{
+		_logProvider = logProvider;
+	}
+
+	public async Task MaintainAsync(
+		  IReplayProjection projection
+		, Guid? till = null
+		, bool isReplay = false
+		, CancellationToken cancellationToken = default
+		)
+	{
+		var log = _logProvider.GetEventLog(projection.StreamId);
+		await foreach (var ev in log.ReadFrom(afterEventId: projection.Cursor, till: till, cancellationToken))
+		{
+			await projection.ApplyAsync(ev, isReplay, cancellationToken);
+		}
+	}
+}

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -78,6 +78,9 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	readonly JsonSerializerOptions _jsonSerializerOptions;
 	readonly IServiceProvider? _serviceProvider;
 
+	// null => multitenant (read the ambient scope per call); a value => pinned to that one stream.
+	readonly Guid? _pinnedStreamId;
+
 	// Tracking: model instance <-> id, so generated setters can route ChangeObjectPropertyCommands and
 	// GetId() resolves a live instance to its key. A strong id->model map keeps tracked instances alive
 	// for the projection's lifetime (acceptable for the v1 store; a weak/eviction policy comes later).
@@ -96,14 +99,15 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 	/// (per-user, per-tenant, whatever the caller's stream boundary is) without them leaking into
 	/// each other's queries.
 	/// <para>
-	/// Reads <see cref="SynqraStreamContext.Current"/> on every access rather than capturing a value
-	/// at construction — this type is registered as a process-wide singleton (see
-	/// <see cref="MongoSynqraStoreExtensions"/>), precisely so a server can serve however many
-	/// concurrent streams it has without instantiating (or caching) one projection per stream. The
-	/// caller's ambient context, not this instance, decides which stream a given call sees.
+	/// This store is <b>omnitenant</b>: with no <see cref="StreamPin"/> it is <i>multitenant</i> — it
+	/// captures no stream at construction and reads the caller's ambient <see cref="SynqraStreamContext"/>
+	/// scope on every access, so one server serves however many concurrent streams it has from a single
+	/// instance. A factory that builds a single-tenant instance at the point of use passes an optional
+	/// <see cref="StreamPin"/> (deliberately never registered in DI) to pin it to that one stream. See
+	/// <see cref="SynqraStreamContext.Resolve"/>.
 	/// </para>
 	/// </summary>
-	public Guid StreamId => SynqraStreamContext.Current;
+	public Guid StreamId => SynqraStreamContext.Resolve(_pinnedStreamId);
 
 	public MongoProjection(
 		  IMongoDatabase database
@@ -113,6 +117,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		, JsonSerializerOptions? jsonSerializerOptions = null
 		, JsonSerializerContext? jsonSerializerContext = null
 		, IServiceProvider? serviceProvider = null
+		, StreamPin? pin = null
 		)
 	{
 		_database = database ?? throw new ArgumentNullException(nameof(database));
@@ -121,6 +126,10 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		_eventStorage = eventStorage;
 		_jsonSerializerOptions = jsonSerializerOptions ?? throw new ArgumentException("MongoProjection requires JsonSerializerOptions to materialize documents.", nameof(jsonSerializerOptions));
 		_serviceProvider = serviceProvider;
+
+		// No pin => root/multitenant (resolve the ambient scope per call); a StreamPin (supplied only by
+		// a factory at the point of use, never by DI) => this instance is pinned to that single stream.
+		_pinnedStreamId = pin?.StreamId;
 
 		if (jsonSerializerContext is not null)
 		{
@@ -199,9 +208,17 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		{
 			cmd.CommandId = GuidExtensions.CreateVersion7();
 		}
+		// A command without a stream id inherits this store's stream; one carrying a different stream
+		// is a misroute and throws (mirrors File / InMemory).
+		var streamId = StreamId;
 		if (cmd.StreamId == default)
 		{
-			cmd.StreamId = StreamId;
+			cmd.StreamId = streamId;
+		}
+		else if (cmd.StreamId != streamId)
+		{
+			throw new InvalidOperationException(
+				$"Command stream {cmd.StreamId} does not match this store's stream {streamId} — refusing misrouted command {cmd.CommandId}.");
 		}
 		if (cmd is SingleObjectCommand soc && soc.TargetObject is not null)
 		{

--- a/Synqra/EventReplicationService.cs
+++ b/Synqra/EventReplicationService.cs
@@ -22,7 +22,6 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 	private readonly IAppendStorage<Event, Guid> _storage;
 	private readonly EventReplicationState _eventReplicationState;
 	private readonly JsonSerializerContext? _jsonSerializerContext;
-	private readonly Lazy<IProjection> _synqraStoreContext;
 	private readonly EventReplicationConfig _config;
 
 	private readonly INetworkSerializationService _networkSerializationService;
@@ -35,11 +34,13 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 
 	private Task? _readerTask;
 
+	/// <inheritdoc />
+	public event Action? EventsReceived;
+
 	public EventReplicationService(
 		  IOptions<EventReplicationConfig> options
 		, IAppendStorage<Event, Guid> storage
 		, EventReplicationState eventReplicationState
-		, Lazy<IProjection> synqraStoreContext
 		, INetworkSerializationService networkSerializationService
 		, JsonSerializerContext? jsonSerializerContext = null
 		, EventReplicationConfig? config = null
@@ -47,7 +48,6 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 	{
 		_storage = storage;
 		_eventReplicationState = eventReplicationState;
-		_synqraStoreContext = synqraStoreContext;
 		_networkSerializationService = networkSerializationService;
 		_jsonSerializerContext = jsonSerializerContext;
 		_config = config ?? options.Value;
@@ -55,25 +55,6 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 
 	HashSet<Guid> _skipSet = new HashSet<Guid>();
 	LinkedList<Guid> _skipList = new LinkedList<Guid>();
-
-	async Task ProcessEvent(Event @event)
-	{
-		lock (_skipSet)
-		{
-			if (_skipSet.Contains(@event.EventId))
-			{
-				return;
-			}
-		}
-		await @event.AcceptAsync<EventVisitorContext?>((IEventVisitor<EventVisitorContext?>)_synqraStoreContext.Value, null!);
-		lock (_skipSet)
-		{
-			if (_skipSet.Add(@event.EventId))
-			{
-				_skipList.AddLast(@event.EventId);
-			}
-		}
-	}
 
 	static async Task<byte[]?> ReceiveFullMessageAsync(WebSocket ws, CancellationToken ct)
 	{
@@ -110,20 +91,16 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 
 	protected async override Task ExecuteAsync(CancellationToken stoppingToken)
 	{
-		var ctx = _synqraStoreContext.Value ?? throw new ArgumentException();
-
-		// Seed the by-EventId dedup (_skipSet/_skipList, otherwise only populated by
-		// ProcessEvent for events received live) from whatever's already durably stored
-		// locally — a separate pass from the actual replay below, regardless of which
-		// replay path runs. Without this, the server's backlog replay (see
-		// SynqraReplicationEndpointExtensions.cs) would resend every event this client
-		// already has on every reconnect, and ProcessEvent would re-apply them since it had
-		// never seen their ids before — the exact "unique component rejected on second
-		// application" crash the comment below was written to avoid, just via a new path.
-		// Wrapped together with the actual replay in one try/catch: a corrupt/undeserializable
-		// local record here means this client's local durable log can no longer be trusted at
-		// all — clear it and continue with an empty skip-set and a cold LastEventIdFromServer,
-		// which is now a correct and safe "send me everything" signal (see #2/#3), not a bug.
+		// Seed the by-EventId dedup (_skipSet/_skipList, otherwise only populated as events are
+		// received live) from whatever's already durably stored locally. Without this, the server's
+		// backlog replay on reconnect (see SynqraReplicationEndpointExtensions.cs) would be echoed
+		// straight back to it by the outgoing loop below. This service is transport-only: it never
+		// touches a projection — the projection owner brings its stream up to date via the keeper on
+		// the EventsReceived signal (and on first use through IProjectionProvider.GetAsync).
+		//
+		// A corrupt/undeserializable local record here means this client's local durable log can no
+		// longer be trusted at all — clear it and continue with an empty skip-set and a cold
+		// LastEventIdFromServer, which is a correct and safe "send me everything" signal, not a bug.
 		try
 		{
 			await foreach (var ev in _storage.GetAllAsync(from: default))
@@ -134,26 +111,6 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 					{
 						_skipList.AddLast(ev.EventId);
 					}
-				}
-			}
-
-			if (ctx is ISelfLoadingProjection selfLoading)
-			{
-				// This projection (e.g. InMemoryProjection, when constructed with the same
-				// IAppendStorage this service reads) already replayed its own durable log on
-				// construction — fire-and-forget, started before this method ever runs. Doing
-				// our own replay loop here too would apply every persisted event a second time;
-				// any unique component rejects that on the second application
-				// ("ComponentAddedEvent ... uniqueness ... rejected during replay"), which is
-				// exactly the crash users hit on every page reload. Await the SAME load instead
-				// of repeating it.
-				await selfLoading.LoadStateAsync();
-			}
-			else
-			{
-				await foreach (var ev in _storage.GetAllAsync(from: default))
-				{
-					await ev.AcceptAsync(ctx, null);
 				}
 			}
 		}
@@ -218,12 +175,23 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 					case NewEvent1 ne1:
 						await _storage.AppendAsync(ne1.Event);
 						EmergencyLog.Default.LogInformation($"{GetHashCode():X4} <<< {ne1.Event}");
-						await ProcessEvent(ne1.Event);
+						// Transport-only: dedup so the outgoing loop never echoes a server event back,
+						// then notify the projection owner to fold in the delta via the keeper. The
+						// event is already durably stored, so a missed/awaited-late notification is
+						// harmless — the owner also catches up on next use through the provider.
+						lock (_skipSet)
+						{
+							if (_skipSet.Add(ne1.Event.EventId))
+							{
+								_skipList.AddLast(ne1.Event.EventId);
+							}
+						}
 						// Tracks how far this client's backlog catch-up has progressed —
 						// applies to both a genuine live event and one the server resent as
 						// backlog (see the HELLO region above); mirrors LastEventIdFromMe's
 						// own bookkeeping for outgoing events.
 						_eventReplicationState.LastEventIdFromServer = ne1.Event.EventId;
+						EventsReceived?.Invoke();
 						break;
 					default:
 						throw new NotSupportedException();

--- a/Tests/Synqra.Tests/JsonlStorageTests.cs
+++ b/Tests/Synqra.Tests/JsonlStorageTests.cs
@@ -586,11 +586,12 @@ public class EventsJsonlStorageTests : JsonAppendStorageTests<Event, Guid>
 	[Test]
 	public async Task Should_store_polimorfic_as_jsonl()
 	{
+		var eventId = new Guid("C0DEADD0-1032-8000-800C-000000000000");
 		await _storage.AppendAsync(new ObjectCreatedEvent
 		{
 			CollectionId = default,
 			CommandId = default,
-			EventId = SynqraGuids.SynqraRootStreamId,
+			EventId = eventId,
 			TargetId = default,
 			TargetTypeId = default,
 		});
@@ -598,7 +599,7 @@ public class EventsJsonlStorageTests : JsonAppendStorageTests<Event, Guid>
 		(_storage as IDisposable)?.Dispose();
 		await Assert.That(FileReadAllText(_fileName).NormalizeNewLines()).IsEqualTo($$"""
 {"Synqra.Storage.Jsonl":"0.1","rootItemType":"Synqra.Event"}
-{{SynqraGuids.SynqraRootStreamId.ToString("N")}}§{"_t":"ObjectCreatedEvent","TargetId":"00000000-0000-0000-0000-000000000000","TargetTypeId":"00000000-0000-0000-0000-000000000000","CollectionId":"00000000-0000-0000-0000-000000000000","EventId":"{{SynqraGuids.SynqraRootStreamId}}","CommandId":"00000000-0000-0000-0000-000000000000"}
+{{eventId.ToString("N")}}§{"_t":"ObjectCreatedEvent","TargetId":"00000000-0000-0000-0000-000000000000","TargetTypeId":"00000000-0000-0000-0000-000000000000","CollectionId":"00000000-0000-0000-0000-000000000000","EventId":"{{eventId}}","CommandId":"00000000-0000-0000-0000-000000000000"}
 
 """.NormalizeNewLines());
 	}

--- a/Tests/Synqra.Tests/LinksTests.cs
+++ b/Tests/Synqra.Tests/LinksTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using Synqra.BinarySerializer;
+using Synqra.AppendStorage.InMemory;
 using Synqra.Projection.InMemory;
 
 namespace Synqra.Tests;
@@ -164,9 +165,19 @@ public class LinksTests
 			typeof(TaggedWith)
 		);
 		services.AddSbxSerializer();
+		// Event-store area (multitenant in-memory singleton, keyed by v7 EventId) + projection area.
+		InMemoryAppendStorageExtensions.AddAppendStorageInMemory<Event, Guid>(services, x => x.EventId);
 		services.AddInMemorySynqraStore();
 		return services.BuildServiceProvider();
 	}
+
+	// These are same-session in-memory tests; each builds its own ServiceProvider with its own empty
+	// in-memory store, so a single fixed stream is fully isolated per test. The in-memory projection
+	// is non-multitenant (factory-only, no DI singleton), so it is borrowed from the provider.
+	static readonly Guid StreamId = new Guid("11110000-0000-4000-8000-000000000001");
+
+	static IObjectStore ResolveStore(IServiceProvider sp)
+		=> (IObjectStore)sp.GetRequiredService<IProjectionProvider>().GetAsync(StreamId).GetAwaiter().GetResult();
 
 	static TestGraphNode AddNode(IObjectStore store, string name)
 	{
@@ -181,7 +192,7 @@ public class LinksTests
 	public async Task Should_navigate_single_parent_and_children()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var parent = AddNode(store, "parent");
 		var child = AddNode(store, "child");
@@ -201,7 +212,7 @@ public class LinksTests
 	public async Task Should_support_multiple_parents_via_the_same_link_type()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var parentA = AddNode(store, "parentA");
 		var parentB = AddNode(store, "parentB");
@@ -221,7 +232,7 @@ public class LinksTests
 	public async Task Should_carry_payload_on_the_link_itself()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var parent = AddNode(store, "parent");
 		var child = AddNode(store, "child");
@@ -243,7 +254,7 @@ public class LinksTests
 	public async Task Should_differentiate_coexisting_link_types_between_the_same_endpoints()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 		var index = (ILinkIndex)store;
 
 		var a = AddNode(store, "a");
@@ -270,7 +281,7 @@ public class LinksTests
 	public async Task Should_treat_re_adding_an_existing_link_as_a_no_op()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var a = AddNode(store, "a");
 		var b = AddNode(store, "b");
@@ -287,7 +298,7 @@ public class LinksTests
 	public async Task Should_reject_a_structurally_duplicate_directed_link_submitted_directly()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var a = AddNode(store, "a");
 		var b = AddNode(store, "b");
@@ -314,7 +325,7 @@ public class LinksTests
 	public async Task Should_allow_the_reverse_direction_of_a_directed_link_as_distinct()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var a = AddNode(store, "a");
 		var b = AddNode(store, "b");
@@ -332,7 +343,7 @@ public class LinksTests
 	public async Task Should_treat_undirected_link_as_incident_from_either_endpoint()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var a = AddNode(store, "a");
 		var b = AddNode(store, "b");
@@ -349,7 +360,7 @@ public class LinksTests
 	public async Task Should_reject_the_reverse_direction_of_an_undirected_link_as_a_structural_duplicate()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var a = AddNode(store, "a");
 		var b = AddNode(store, "b");
@@ -367,7 +378,7 @@ public class LinksTests
 	public async Task Should_resolve_typed_endpoints_across_different_node_types()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var doc = new TestDocNode { Title = "spec" };
 		var folder = new TestFolderNode { Name = "inbox" };
@@ -389,7 +400,7 @@ public class LinksTests
 	public async Task Should_carry_payload_on_a_cross_type_link()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var doc = new TestDocNode { Title = "spec" };
 		var tag = new TestTagNode { Label = "urgent" };
@@ -415,7 +426,7 @@ public class LinksTests
 	public async Task Should_remove_a_link_via_the_collection()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var parent = AddNode(store, "parent");
 		var child = AddNode(store, "child");
@@ -433,7 +444,7 @@ public class LinksTests
 	public async Task Should_clear_all_links_of_a_type_via_the_collection()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var parent = AddNode(store, "parent");
 		var childA = AddNode(store, "childA");
@@ -455,7 +466,7 @@ public class LinksTests
 	public async Task Should_assign_parent_via_the_opt_in_setter()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var parent = AddNode(store, "parent");
 		var child = AddNode(store, "child");
@@ -471,7 +482,7 @@ public class LinksTests
 	public async Task Should_replace_the_existing_parent_when_the_setter_is_assigned_again()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var oldParent = AddNode(store, "oldParent");
 		var newParent = AddNode(store, "newParent");
@@ -489,7 +500,7 @@ public class LinksTests
 	public async Task Should_clear_the_parent_when_the_setter_is_assigned_null()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var parent = AddNode(store, "parent");
 		var child = AddNode(store, "child");
@@ -509,7 +520,7 @@ public class LinksTests
 	public async Task Should_raise_PropertyChanged_for_Children_and_Parent_on_both_endpoints_when_a_link_is_added()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var parent = AddNode(store, "parent");
 		var child = AddNode(store, "child");
@@ -530,7 +541,7 @@ public class LinksTests
 	public async Task Should_raise_PropertyChanged_on_both_endpoints_when_a_link_is_removed()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var parent = AddNode(store, "parent");
 		var child = AddNode(store, "child");
@@ -551,7 +562,7 @@ public class LinksTests
 	public async Task Should_not_raise_PropertyChanged_for_an_unrelated_nav_property_on_a_different_link_type()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var a = AddNode(store, "a");
 		var b = AddNode(store, "b");
@@ -569,7 +580,7 @@ public class LinksTests
 	public async Task Should_raise_PropertyChanged_for_RelatedNodes_on_both_endpoints_of_an_undirected_link()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var a = AddNode(store, "a");
 		var b = AddNode(store, "b");
@@ -593,7 +604,7 @@ public class LinksTests
 	public async Task Should_throw_a_clear_error_when_GetCollection_is_called_for_a_link_type()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var a = AddNode(store, "a");
 		var b = AddNode(store, "b");
@@ -613,7 +624,7 @@ public class LinksTests
 	public async Task Should_throw_a_clear_error_when_the_non_generic_GetCollection_is_called_for_a_link_type()
 	{
 		var sp = BuildServices();
-		var store = sp.GetRequiredService<IObjectStore>();
+		var store = ResolveStore(sp);
 
 		var ex = await Assert.ThrowsAsync(async () =>
 		{

--- a/Tests/Synqra.Tests/MongoObjectStoreEndToEndTests.cs
+++ b/Tests/Synqra.Tests/MongoObjectStoreEndToEndTests.cs
@@ -56,6 +56,11 @@ public class MongoObjectStoreEndToEndTests : BaseTest
 		hostApplicationBuilder.Services.AddInMemorySynqraStore();
 	}
 
+	// A fresh stream per test instance (stable across Restart() — an instance field). The in-memory
+	// projection is non-multitenant (factory-only, no DI singleton), so it is borrowed for this
+	// stream from the provider, which brings it up to head via the keeper (replacing LoadStateAsync).
+	readonly Guid _streamId = Guid.NewGuid();
+
 	/// <summary>
 	/// The store, with command-event persistence turned off (durable log = domain events only).
 	/// </summary>
@@ -65,7 +70,7 @@ public class MongoObjectStoreEndToEndTests : BaseTest
 		{
 			throw new Exception("Mongo is not configured 4");
 		}
-		var projection = ServiceProvider.GetRequiredService<InMemoryProjection>();
+		var projection = (InMemoryProjection)ServiceProvider.GetRequiredService<IProjectionProvider>().GetAsync(_streamId).GetAwaiter().GetResult();
 		projection.PersistCommandEvents = false;
 		return projection;
 	}
@@ -112,7 +117,6 @@ public class MongoObjectStoreEndToEndTests : BaseTest
 		// replaying the event log.
 		Restart();
 		var projection = Projection();
-		await projection.LoadStateAsync();
 
 		var store2 = (IObjectStore)projection;
 		var reloaded = store2.GetCollection<DemoModel>().FirstOrDefault(m => store2.GetId(m) == id);

--- a/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
+++ b/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
@@ -95,15 +95,25 @@ internal class SynqraTestNode
 	public Microsoft.AspNetCore.Builder.WebApplication Host { get; private set; }
 #endif
 
-	public IObjectStore StoreContext
-	{
-		get =>
+	/// <summary>
+	/// The stream this node projects/replicates. All nodes in one test (master + clients) share the
+	/// same stream id — it is passed in at construction, never pinned into a DI registration. The
+	/// node OWNS its projection for this stream (obtained at startup from <see cref="IProjectionProvider"/>),
+	/// which is why there is no DI-resolvable projection singleton anymore.
+	/// </summary>
+	public Guid StreamId { get; }
+
+	// The node's own projection for StreamId, resolved once at startup via the provider (cached, so
+	// every consumer here — StoreContext, the master WS apply loop, the client EventsReceived
+	// catch-up — shares the one instance).
+	private IReplayProjection? _projection;
+
+	public IObjectStore StoreContext =>
 #if NETFRAMEWORK
-			throw new NotImplementedException();
+		throw new NotImplementedException();
 #else
-			field ??= Host.Services.GetRequiredService<IObjectStore>(); private set;
+		_projection ?? throw new InvalidOperationException("Projection not initialized yet — await node.Started first.");
 #endif
-	}
 
 	public IAppendStorage<Event, Guid> Events
 	{
@@ -127,8 +137,13 @@ internal class SynqraTestNode
 	SemaphoreSlim _semaphoreSlim = new(1, 1);
 	long _masterSeq = 0;
 
-	public SynqraTestNode(Action<IHostApplicationBuilder>? configureHost = null, bool masterHost = false)
+	public SynqraTestNode(Guid streamId, Action<IHostApplicationBuilder>? configureHost = null, bool masterHost = false)
 	{
+		if (streamId == default)
+		{
+			throw new ArgumentException("A non-default stream id is required — all nodes in a test share one explicit stream.", nameof(streamId));
+		}
+		StreamId = streamId;
 		#region Folder
 
 		var utils = new TestUtils();
@@ -367,7 +382,7 @@ internal class SynqraTestNode
 						}
 						var operation = networkSerializationService.Deserialize<TransportOperation>(messageBytes);
 
-						var storeCtx = app.Services.GetRequiredService<IProjection>();
+						var storeCtx = _projection ?? throw new InvalidOperationException("Master projection not initialized.");
 						if (operation is NewEvent1 newEvent1)
 						{
 							if (!knownEvents.TryAdd(newEvent1.Event.EventId, null))
@@ -439,6 +454,22 @@ internal class SynqraTestNode
 			// Kestrel bound to 127.0.0.1:0 — publish the OS-assigned port so clients can
 			// target it. Client nodes keep the master port assigned by the test instead.
 			Port = checked((ushort)new Uri(app.Urls.First()).Port);
+		}
+
+		// Own the projection for this node's stream. The provider caches per stream and brings it to
+		// head via the keeper, so this single instance is what StoreContext, the master apply loop,
+		// and the client catch-up below all share — no DI-registered projection singleton.
+		var provider = app.Services.GetRequiredService<IProjectionProvider>();
+		_projection = await provider.GetAsync(StreamId);
+
+		if (!masterHost)
+		{
+			// Transport-only replication service: when it appends incoming server events to local
+			// durable storage it raises EventsReceived; fold them into this node's projection via the
+			// keeper (cheap no-op if nothing new for this stream). Tests poll for the result, so a
+			// fire-and-forget catch-up is fine; the provider serializes concurrent catch-ups.
+			var ers = app.Services.GetRequiredService<IEventReplicationService>();
+			ers.EventsReceived += () => _ = provider.GetAsync(StreamId);
 		}
 	}
 #endif

--- a/Tests/Synqra.Tests/Syncronization/BacklogReplaySyncronizationTests.cs
+++ b/Tests/Synqra.Tests/Syncronization/BacklogReplaySyncronizationTests.cs
@@ -22,13 +22,14 @@ internal class BacklogReplaySyncronizationTests : BaseTest
 	[Test]
 	public async Task Should_replay_existing_history_to_a_client_that_connects_after_the_data_already_exists()
 	{
-		var nodeMaster = new SynqraTestNode(builder => { }, masterHost: true);
+		var streamId = Guid.NewGuid();
+		var nodeMaster = new SynqraTestNode(streamId, builder => { }, masterHost: true);
 		await nodeMaster.Started;
 
 		// Node A writes data and syncs it to the master BEFORE node C ever exists — the
 		// scenario the old protocol silently failed: a client's history predates the
 		// connecting client by definition, since it never even existed yet.
-		var nodeA = new SynqraTestNode(builder => { }) { Port = nodeMaster.Port };
+		var nodeA = new SynqraTestNode(streamId, builder => { }) { Port = nodeMaster.Port };
 		await nodeA.Started;
 		await WaitForOnlineAsync(nodeA);
 
@@ -48,7 +49,7 @@ internal class BacklogReplaySyncronizationTests : BaseTest
 
 		// Node C has never connected before — a cold LastEventIdFromServer cursor, exactly
 		// like a brand-new device or a cleared browser.
-		var nodeC = new SynqraTestNode(builder => { }) { Port = nodeMaster.Port };
+		var nodeC = new SynqraTestNode(streamId, builder => { }) { Port = nodeMaster.Port };
 		await nodeC.Started;
 		await WaitForOnlineAsync(nodeC);
 

--- a/Tests/Synqra.Tests/Syncronization/BasicModelSyncronizationTests.cs
+++ b/Tests/Synqra.Tests/Syncronization/BasicModelSyncronizationTests.cs
@@ -25,10 +25,11 @@ internal class BasicModelSyncronizationTests : BaseTest
 	[Before(Test)]
 	public async Task SetUp()
 	{
-		_nodeMaster = new SynqraTestNode(builder => { }, masterHost: true);
+		var streamId = Guid.NewGuid();
+		_nodeMaster = new SynqraTestNode(streamId, builder => { }, masterHost: true);
 		await _nodeMaster.Started; // master Port is the OS-assigned one, known only after bind
-		_nodeA = new SynqraTestNode(builder => { }) { Port = _nodeMaster.Port, };
-		_nodeB = new SynqraTestNode(builder => { }) { Port = _nodeMaster.Port, };
+		_nodeA = new SynqraTestNode(streamId, builder => { }) { Port = _nodeMaster.Port, };
+		_nodeB = new SynqraTestNode(streamId, builder => { }) { Port = _nodeMaster.Port, };
 		await _nodeA.Started;
 		await _nodeB.Started;
 		// Console.WriteLine("Master: "+ _nodeMaster.Host.Environment.ContentRootPath);

--- a/Tests/Synqra.Tests/SynqraStoreMatrixTests.cs
+++ b/Tests/Synqra.Tests/SynqraStoreMatrixTests.cs
@@ -16,9 +16,10 @@ using Synqra.Tests.SampleModels;
 using Synqra.Tests.TestHelpers;
 using TUnit.Assertions.Extensions;
 
-//// MEMO
-/// Why Cobra?
-/// Because I were adding 11 classes in 1 shot and LLM named them with service type prefixes, so very hard to find in tree. Cobra is a codename for this entire testing effort.
+// Store resolution here no longer pins the well-known SynqraGuids.SynqraRootStreamId: each test uses
+// a fresh per-instance stream id (the Mongo store variants enter it as the ambient scope; the
+// in-memory store variants borrow their projection for it from the provider). Nothing in this file
+// touches the obsolete root stream anymore.
 
 namespace Synqra.Tests.Cobra;
 
@@ -65,6 +66,11 @@ public abstract class Cobra_SynqraStoreContractTests : BaseTest
 	// inline, on the test method's own call stack, is what actually keeps it in scope for real.
 	IDisposable? _streamScope;
 
+	// A fresh stream per test instance (stable across Restart() — an instance field), replacing the
+	// old shared SynqraGuids.SynqraRootStreamId. The Mongo store variant enters it as the ambient
+	// scope; the in-memory store variant borrows its projection for this stream from the provider.
+	readonly Guid _streamId = Guid.NewGuid();
+
 	protected override void Register(IHostApplicationBuilder hostBuilder)
 	{
 		base.Register(hostBuilder);
@@ -105,14 +111,27 @@ public abstract class Cobra_SynqraStoreContractTests : BaseTest
 	/// </summary>
 	protected IObjectStore ResolveStore()
 	{
-		_streamScope ??= SynqraStreamContext.Enter(SynqraGuids.SynqraRootStreamId);
-		var store = ServiceProvider.GetRequiredService<IObjectStore>();
+		_streamScope ??= SynqraStreamContext.Enter(_streamId);
+		var store = ResolveStoreInstance();
 		if (store is InMemoryProjection projection)
 		{
 			projection.PersistCommandEvents = false;
 		}
 		return store;
 	}
+
+	/// <summary>
+	/// Obtain the store instance under test. Default = resolve the multitenant <see cref="IObjectStore"/>
+	/// singleton directly (the Mongo projection resolves the ambient stream scope entered above). The
+	/// in-memory store has no DI singleton — a projection is non-multitenant, factory-only — so its
+	/// variants override this to borrow the cached projection for this test's stream from the provider,
+	/// which also brings it up to head via the keeper (replacing the old explicit LoadStateAsync).
+	/// </summary>
+	protected virtual IObjectStore ResolveStoreInstance() => ServiceProvider.GetRequiredService<IObjectStore>();
+
+	/// <summary>In-memory store resolution: the provider's cached, keeper-maintained projection for this test's stream.</summary>
+	protected IObjectStore ResolveInMemoryStoreForStream()
+		=> (IObjectStore)ServiceProvider.GetRequiredService<IProjectionProvider>().GetAsync(_streamId).GetAwaiter().GetResult();
 
 	protected IAppendStorage<Event, Guid> Events() => ServiceProvider.GetRequiredService<IAppendStorage<Event, Guid>>();
 
@@ -313,10 +332,6 @@ public abstract class Cobra_DurableSynqraStoreContractTests : Cobra_SynqraStoreC
 		Restart();
 
 		var store2 = ResolveStore();
-		if (store2 is InMemoryProjection projection)
-		{
-			await projection.LoadStateAsync();
-		}
 
 		var reloaded = store2.GetCollection<DemoModel>().FirstOrDefault(m => store2.GetId(m) == id);
 		await Assert.That(reloaded).IsNotNull();
@@ -333,10 +348,6 @@ public abstract class Cobra_DurableSynqraStoreContractTests : Cobra_SynqraStoreC
 		Restart();
 
 		var store2 = ResolveStore();
-		if (store2 is InMemoryProjection projection)
-		{
-			await projection.LoadStateAsync();
-		}
 
 		await AssertGraph(store2, ids);
 	}
@@ -358,10 +369,6 @@ public abstract class Cobra_DurableSynqraStoreContractTests : Cobra_SynqraStoreC
 		Restart();
 
 		var store2 = ResolveStore();
-		if (store2 is InMemoryProjection projection)
-		{
-			await projection.LoadStateAsync();
-		}
 
 		var nodes = store2.GetCollection<TestGraphNode>().ToList();
 		var a2 = nodes.First(n => store2.GetId(n) == idA);
@@ -418,6 +425,7 @@ public abstract class Cobra_InMemoryEventStorageContract : Cobra_SynqraStoreCont
 public sealed class Cobra_Mongo_Storage_With_InMemory_Store : Cobra_MongoEventStorageContract
 {
 	protected override void RegisterStore(IServiceCollection services) => services.AddInMemorySynqraStore();
+	protected override IObjectStore ResolveStoreInstance() => ResolveInMemoryStoreForStream();
 }
 
 [InheritsTests]
@@ -431,6 +439,7 @@ public sealed class Cobra_Mongo_Storage_With_Mongo_Store : Cobra_MongoEventStora
 public sealed class Cobra_SbxFile_Storage_With_InMemory_Store : Cobra_SbxFileEventStorageContract
 {
 	protected override void RegisterStore(IServiceCollection services) => services.AddInMemorySynqraStore();
+	protected override IObjectStore ResolveStoreInstance() => ResolveInMemoryStoreForStream();
 }
 
 [InheritsTests]
@@ -444,6 +453,7 @@ public sealed class Cobra_SbxFile_Storage_With_Mongo_Store : Cobra_SbxFileEventS
 public sealed class Cobra_InMemory_Storage_With_InMemory_Store : Cobra_InMemoryEventStorageContract
 {
 	protected override void RegisterStore(IServiceCollection services) => services.AddInMemorySynqraStore();
+	protected override IObjectStore ResolveStoreInstance() => ResolveInMemoryStoreForStream();
 }
 
 [InheritsTests]
@@ -470,6 +480,9 @@ public sealed class Cobra_Mongo_Store_Components_Tests : BaseTest
 	// See Cobra_SynqraStoreContractTests.ResolveStore's remark — a [Before(Test)] hook's AsyncLocal
 	// does not flow into the test body under TUnit, so this is entered inline from Store instead.
 	IDisposable? _streamScope;
+
+	// A fresh Mongo stream per test instance (replaces the old shared SynqraGuids.SynqraRootStreamId).
+	readonly Guid _streamId = Guid.NewGuid();
 
 	protected override void Register(IHostApplicationBuilder hostBuilder)
 	{
@@ -507,7 +520,7 @@ public sealed class Cobra_Mongo_Store_Components_Tests : BaseTest
 	{
 		get
 		{
-			_streamScope ??= SynqraStreamContext.Enter(SynqraGuids.SynqraRootStreamId);
+			_streamScope ??= SynqraStreamContext.Enter(_streamId);
 			return ServiceProvider.GetRequiredService<IObjectStore>();
 		}
 	}
@@ -549,7 +562,7 @@ public sealed class Cobra_Mongo_Store_Components_Tests : BaseTest
 			await store.SubmitCommandAsync(new AddComponentCommand
 			{
 				CommandId = GuidExtensions.CreateVersion7(),
-				StreamId = SynqraGuids.SynqraRootStreamId,
+				StreamId = _streamId,
 				TargetTypeId = store.TypeMetadataProvider.GetTypeMetadata(typeof(TestGeneratedContainerNode)).TypeId,
 				TargetId = store.GetId(node),
 				CollectionId = store.TypeMetadataProvider.GetTypeMetadata(typeof(TestGeneratedContainerNode)).GetCollectionId(""),

--- a/Tests/Synqra.Tests/TestsStateManagement.cs
+++ b/Tests/Synqra.Tests/TestsStateManagement.cs
@@ -40,6 +40,31 @@ public class TestsStateManageementInMemory : TestsStateManagement
 		hostApplicationBuilder.Services.AddInMemorySynqraStore();
 	}
 
+	// A fresh stream per test instance (stable across Reopen() — an instance field). The in-memory
+	// projection is non-multitenant (factory-only), so it is borrowed for this stream from the
+	// provider, which brings it up to head via the keeper on first hand-out (replacing the old
+	// LoadStateAsync).
+	readonly Guid _streamId = Guid.NewGuid();
+
+	// The projection is the live command target here: obtain it ONCE per host and reuse it, so
+	// local commands mutate that single instance. Re-borrowing (and thus re-running MaintainAsync)
+	// on every access would re-fold already-applied local events. Reopen() rebuilds the host — a new
+	// provider instance — so we re-borrow then, getting a fresh projection that cold-replays the
+	// carried-over durable log exactly once.
+	IProjectionProvider? _boundProvider;
+	IReplayProjection? _boundProjection;
+
+	protected override IObjectStore ResolveSut()
+	{
+		var provider = ServiceProvider.GetRequiredService<IProjectionProvider>();
+		if (!ReferenceEquals(provider, _boundProvider))
+		{
+			_boundProvider = provider;
+			_boundProjection = provider.GetAsync(_streamId).GetAwaiter().GetResult();
+		}
+		return (IObjectStore)_boundProjection!;
+	}
+
 	// ---- Optimistic concurrency tests (InMemoryProjection only) ----
 	//
 	// These verify the projection-side precondition check, which only the
@@ -614,10 +639,31 @@ public class TestsStateManageementFile : TestsStateManagement
 {
 	string _folder;
 
+	// A fresh stream per test instance (stable across Reopen()). The file store is the omnitenant root
+	// (never pinned at DI registration); this test enters a SynqraStreamContext scope for its stream,
+	// exactly as a production request handler would — see ResolveSut below.
+	readonly Guid _fileStreamId = Guid.NewGuid();
+	IDisposable? _streamScope;
+
 	[Before(Test)]
 	public void Setup()
 	{
 		_folder = CreateTestFolder();
+	}
+
+	[After(Test)]
+	public void ExitStreamScope()
+	{
+		_streamScope?.Dispose();
+		_streamScope = null;
+	}
+
+	// The omnitenant file store reads the ambient stream per call; enter the scope lazily on first
+	// resolve (mirrors SynqraStoreMatrixTests). Held for the whole test, so it survives Reopen().
+	protected override IObjectStore ResolveSut()
+	{
+		_streamScope ??= SynqraStreamContext.Enter(_fileStreamId);
+		return base.ResolveSut();
 	}
 
 	protected override void Register(IHostApplicationBuilder hostApplicationBuilder)
@@ -730,8 +776,14 @@ public class TestExtendedSqliteDatabaseContext : SqliteDatabaseContext
 
 #endif
 
-public abstract class TestsStateManagement : BaseTest<IObjectStore>
+public abstract class TestsStateManagement : BaseTest
 {
+	// The store under test. Default = the multitenant IObjectStore singleton (File/Mongo). The
+	// in-memory variant has no such singleton (a projection is non-multitenant, factory-only), so it
+	// overrides this to borrow its projection for a fresh stream from the provider.
+	protected virtual IObjectStore ResolveSut() => ServiceProvider.GetRequiredService<IObjectStore>();
+	protected IObjectStore _sut => ResolveSut();
+
 	JsonSerializerOptions _jsonSerializerOptions => ServiceProvider.GetRequiredService<JsonSerializerOptions>();
 	// ISynqraStoreContext _sut => ServiceProvider.GetRequiredService<ISynqraStoreContext>();
 	FakeAppendStorage _fakeStorage => (FakeAppendStorage)ServiceProvider.GetService<IAppendStorage>(); // ServiceProvider.GetService<FakeAppendStorage>() ?? (FakeAppendStorage)ServiceProvider.GetService<IAppendStorage<Event, Guid>>() ?? (FakeAppendStorage)ServiceProvider.GetService<IAppendStorage>();
@@ -899,10 +951,6 @@ public abstract class TestsStateManagement : BaseTest<IObjectStore>
 
 		// reopen
 		Reopen();
-		if (_sut is InMemoryProjection imp)
-		{
-			await imp.LoadStateAsync();
-		}
 
 		//var bt = (StateManagementTests)Activator.CreateInstance(GetType());
 		//bt.ServiceCollection.AddSingleton(_fakeStorage);
@@ -938,10 +986,6 @@ public abstract class TestsStateManagement : BaseTest<IObjectStore>
 
 		// reopen
 		Reopen();
-		if (_sut is InMemoryProjection imp)
-		{
-			await imp.LoadStateAsync();
-		}
 
 		var tasks = _sut.GetCollection<MyPocoTask>();
 		await Assert.That(tasks).HasCount(1);


### PR DESCRIPTION
There is no default/root stream — a stream id is a mandatory, first-class value (a security boundary). The command-emitting visitors used to stamp SynqraGuids.SynqraRootStreamId onto every command, which pre-empted each store's real stream resolution (SubmitCommandAsync only fills cmd.StreamId when it is default).

## Changes
- Remove StreamId = SynqraRootStreamId from the generated setter template (ModelBindingGenerator), StoreBoundComponentsCollection, and LinkCollections.
- Single-tenant stores take an explicit stream id at construction from DI config: new InMemoryProjectionOptions (via IOptions<>); InMemoryProjection and FileObjectStore now fail fast on a default StreamId. AddInMemorySynqraStore(streamId) / AddFileSynqraStore(streamId) require a non-default id.
- FileProjection.ProcessCommandAsync now normalizes a default StreamId to the store's stream (mirrors InMemoryProjection / MongoProjection).
- Mark SynqraGuids.SynqraRootStreamId [Obsolete]; retained only so unit tests can pin a well-known stream value (suppressed locally).

Multitenant MongoProjection is unchanged — it already reads the ambient SynqraStreamContext.Current per call.

## Tests
All 174 Synqra unit tests pass on net8/net9/net10 (store matrix: InMemory/File/Mongo, link/component visitor paths, Mongo stream-isolation).