### PR TITLE
fix(mongo): persist Event.StreamId as _sid so the shared event log is stream-isolated

### DIFF
--- a/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventClassMaps.cs
@@ -22,13 +22,23 @@ namespace Synqra.AppendStorage.MongoDb;
 /// </para>
 /// <para>
 /// <see cref="Event.EventId"/> maps to <c>_id</c> (the natural document key).
-/// <see cref="Event.StreamId"/> is intentionally unmapped: like the JSON log, the
-/// stream/container id is an out-of-band routing concern, not part of the persisted
-/// event body.
+/// <see cref="Event.StreamId"/> maps to <c>_sid</c> — the same stream column
+/// <c>MongoProjection</c> stamps on its read-model documents. Unlike the JSON-lines log
+/// (one file per stream, so the stream is out-of-band file routing and the field is
+/// <c>[JsonIgnore]</c>d out), the Mongo log is one shared multitenant collection: every
+/// event MUST carry its own stream, or the per-stream <c>AppendStorageEventLog</c> — which
+/// isolates streams by filtering on <see cref="Event.StreamId"/> after reading them back —
+/// has nothing to filter on and every stream sees every stream's events. Mapping it here is
+/// a Mongo-only document convention (like <c>Link.LinkId → _id</c> below); the model itself
+/// stays MongoDB-free.
 /// </para>
 /// </summary>
 public static class MongoEventClassMaps
 {
+	/// <summary>The per-event stream column — same name and Guid representation MongoProjection
+	/// uses for its own read-model documents, so an event and its materialized state read alike.</summary>
+	const string StreamIdField = "_sid";
+
 	static readonly object _gate = new();
 	static bool _registered;
 
@@ -75,9 +85,15 @@ public static class MongoEventClassMaps
 					// always present even if an event is ever serialized as its concrete type.
 					cm.SetDiscriminatorIsRequired(true);
 					cm.MapIdProperty(e => e.EventId);
-					// StreamId (out-of-band routing) and any other [JsonIgnore] field are not
-					// part of the persisted event body — drop them, matching the JSON log.
+					// Drop every [JsonIgnore] member (materialized/in-memory-only state) so the durable
+					// Mongo log persists the same surface as the JSON log — then re-map StreamId as _sid
+					// below, the one [JsonIgnore] field the shared Mongo log DOES need (see type remarks).
 					UnmapJsonIgnored(cm);
+					// Persist the stream on every event as _sid. Must come after UnmapJsonIgnored and
+					// after AutoMap's JsonIgnoreConvention (both strip [JsonIgnore] members, and StreamId
+					// is one) — this explicit map is the final word. Mapped on the base Event class map,
+					// so every concrete event subtype serializes _sid, exactly like the inherited _id.
+					cm.MapProperty(e => e.StreamId).SetElementName(StreamIdField).SetSerializer(ScopedStandardGuidSerializer);
 				});
 			}
 

--- a/Tests/Synqra.Tests/MongoAppendStorageTests.cs
+++ b/Tests/Synqra.Tests/MongoAppendStorageTests.cs
@@ -5,6 +5,7 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 using Synqra.AppendStorage;
 using Synqra.AppendStorage.MongoDb;
+using Synqra.Projection.InMemory;
 using Synqra.Tests.TestHelpers;
 using TUnit.Assertions.AssertionBuilders.Wrappers;
 using TUnit.Assertions.Extensions;
@@ -74,13 +75,15 @@ public class MongoAppendStorageTests : BaseTest
 		return ServiceProvider.GetRequiredService<IAppendStorage<Event, Guid>>();
 	}
 
-	// A regular, payload-light core event that carries an assertable value.
-	static ObjectPropertyChangedEvent Change(Guid id, string value)
+	// A regular, payload-light core event that carries an assertable value. streamId defaults
+	// to unset (Guid.Empty) — the stream-scoping tests below pass an explicit one.
+	static ObjectPropertyChangedEvent Change(Guid id, string value, Guid streamId = default)
 	{
 		return new ObjectPropertyChangedEvent
 		{
 			EventId = id,
 			CommandId = GuidExtensions.CreateVersion7(),
+			StreamId = streamId,
 			TargetId = Guid.NewGuid(),
 			TargetTypeId = Guid.NewGuid(),
 			CollectionId = Guid.NewGuid(),
@@ -195,5 +198,65 @@ public class MongoAppendStorageTests : BaseTest
 		// from = e2 is inclusive (Gte on _id): e2, e3.
 		var tail = storage.GetAllAsync(e2.EventId).ToBlockingEnumerable().Select(x => x.EventId).ToArray();
 		await Assert.That(tail).IsEquivalentTo(new[] { e2.EventId, e3.EventId });
+	}
+
+	[Test]
+	public async Task Should_M40_stream_id_round_trips_and_persists_as_sid()
+	{
+		var storage = Storage();
+		var stream = Guid.NewGuid();
+		var ev = Change(GuidExtensions.CreateVersion7(), "scoped", stream);
+		await storage.AppendAsync(ev);
+
+		// Round-trip: the event's stream survives persistence. Before StreamId was mapped to
+		// _sid, MongoEventClassMaps unmapped it (matching the JSON log), so it came back
+		// Guid.Empty here and stream isolation had nothing to filter on.
+		var back = storage.GetAllAsync().ToBlockingEnumerable().Single();
+		await Assert.That(back.StreamId).IsEqualTo(stream);
+
+		// And it lands in the durable document as "_sid" — the same stream column
+		// MongoProjection stamps on its read-model docs, so an event and its materialized
+		// state read alike.
+		var url = new MongoUrl(_connectionString);
+		var doc = await new MongoClient(url).GetDatabase(url.DatabaseName)
+			.GetCollection<BsonDocument>("Event")
+			.Find(Builders<BsonDocument>.Filter.Eq("_id", ev.EventId)).SingleAsync();
+		await Assert.That(doc.Contains("_sid")).IsTrue();
+		await Assert.That(doc["_sid"].AsGuid).IsEqualTo(stream);
+	}
+
+	[Test]
+	public async Task Should_M42_event_log_isolates_two_streams_in_one_collection()
+	{
+		var storage = Storage();
+		var streamA = Guid.NewGuid();
+		var streamB = Guid.NewGuid();
+
+		// Two per-stream logs over ONE shared multitenant collection — the production shape
+		// (EventLogProvider hands out one of these per stream over the process's single
+		// IAppendStorage<Event,Guid>).
+		var logA = new AppendStorageEventLog(streamA, storage);
+		var logB = new AppendStorageEventLog(streamB, storage);
+
+		var a = Change(GuidExtensions.CreateVersion7(), "a", streamA);
+		var b = Change(GuidExtensions.CreateVersion7(), "b", streamB);
+		await logA.AppendAsync(a);
+		await logB.AppendAsync(b);
+
+		// Each log reads back ONLY its own stream's events. Before _sid round-tripped, both
+		// logs saw both events — the persisted StreamId came back default, so ReadFrom's
+		// `ev.StreamId != default && != StreamId` guard never skipped the other stream's rows.
+		await Assert.That(await ReadIds(logA)).IsEquivalentTo(new[] { a.EventId });
+		await Assert.That(await ReadIds(logB)).IsEquivalentTo(new[] { b.EventId });
+	}
+
+	static async Task<List<Guid>> ReadIds(IEventLog log)
+	{
+		var ids = new List<Guid>();
+		await foreach (var ev in log.ReadFrom())
+		{
+			ids.Add(ev.EventId);
+		}
+		return ids;
 	}
 }


### PR DESCRIPTION
## Problem

The Mongo event log is **one shared multitenant collection**, but `MongoEventClassMaps` **unmapped `Event.StreamId`** (matching the JSON-lines log, where the stream is out-of-band per-file routing). So:

- Every persisted event document carried **no `_sid`** at all.
- Read back, every event's `StreamId` came back `default`.
- `AppendStorageEventLog` — the per-stream log that isolates streams by filtering read-back events on `Event.StreamId` — had nothing to filter on: its `ev.StreamId != default && != StreamId` guard skipped every row, so **every stream saw every other stream's events**.

This is the multitenancy hole behind "events don't have `_sid`".

## Fix

Map `Event.StreamId → _sid` on the base `Event` class map (after `UnmapJsonIgnored` / AutoMap's `JsonIgnoreConvention` strip it, so the explicit map is the final word). Same stream column `MongoProjection` already stamps on its read-model docs, so an event and its materialized state read alike. It's a Mongo-only document convention (like `Link.LinkId → _id`); `Synqra.Model` stays MongoDB-free.

## Tests

- `Should_M40_stream_id_round_trips_and_persists_as_sid` — StreamId survives persistence **and** the durable doc carries `_sid`.
- `Should_M42_event_log_isolates_two_streams_in_one_collection` — two per-stream `AppendStorageEventLog`s over one Mongo collection each read back only their own events.

Both fail without the mapping. Full Mongo/event suite: **177/177** green (net8.0/9.0/10.0).

## Not in this PR (separate, larger change)

The WS replication endpoint (`SynqraReplicationEndpointExtensions`) is still **stream-blind**: the HELLO protocol carries no stream id, backlog replay (`GetAllAsync(from: cursor)`) is unscoped, and broadcast fans every event out to every connected socket regardless of stream. Making the live replication path multitenant is a protocol change touching client + server — flagged for a follow-up.