### PR TITLE
feat(mongo): idempotent _sid backfill for event logs written before stream persistence

### DIFF
--- a/Synqra.AppendStorage.MongoDb/MongoEventSidBackfill.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventSidBackfill.cs
@@ -1,0 +1,163 @@
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Synqra.AppendStorage.MongoDb;
+
+/// <summary>
+/// One-time, idempotent upgrade for event logs written before <see cref="Event.StreamId"/> was
+/// persisted as <c>_sid</c> (see <see cref="MongoEventClassMaps"/>): those documents carry no
+/// stream column at all, so the per-stream <c>AppendStorageEventLog</c> cannot isolate them and
+/// every stream sees them. This backfills <c>_sid</c> onto every legacy event from the data the
+/// log (and its projection) already contains — no operator input, safe to run on every startup:
+/// <list type="number">
+/// <item><b>CommandCreatedEvent join:</b> a <c>CommandCreatedEvent</c>'s embedded command
+/// (<c>Data.StreamId</c>) names its stream outright — that resolves the CommandCreatedEvent
+/// itself and, joined via <c>CommandId</c>, every other event the same command produced.</item>
+/// <item><b>Projection fallback:</b> events with no surviving CommandCreatedEvent (e.g. an early
+/// seed path that never logged commands) are resolved through their <c>TargetId</c>: the
+/// materialized document for that object in the projection database already carries <c>_sid</c>
+/// (MongoProjection has stamped it since stream scoping landed).</item>
+/// </list>
+/// Anything still unresolved after both passes is left untouched and reported — an event whose
+/// stream genuinely cannot be derived should be looked at by a human, not guessed at.
+/// </summary>
+public static class MongoEventSidBackfill
+{
+	const string StreamIdField = "_sid";
+
+	/// <summary>
+	/// Backfills <c>_sid</c> on every event document that lacks one. Idempotent and cheap when
+	/// there is nothing to do (a single indexed-by-nothing count on a small collection; the
+	/// full scan work only happens when legacy documents actually exist).
+	/// </summary>
+	/// <param name="eventsDatabase">Database holding the event log collection.</param>
+	/// <param name="projectionDatabase">Database holding the materialized projection collections
+	/// (may be the same database). Used only for the fallback pass.</param>
+	/// <param name="eventsCollectionName">Event log collection name (default "Event").</param>
+	/// <returns>(backfilled, unresolved) counts.</returns>
+	public static async Task<(long Backfilled, long Unresolved)> BackfillAsync(
+		  IMongoDatabase eventsDatabase
+		, IMongoDatabase projectionDatabase
+		, string eventsCollectionName = "Event"
+		, ILogger? logger = null
+		, CancellationToken cancellationToken = default
+		)
+	{
+		var events = eventsDatabase.GetCollection<BsonDocument>(eventsCollectionName);
+		var missingFilter = Builders<BsonDocument>.Filter.Exists(StreamIdField, false);
+
+		var missingCount = await events.CountDocumentsAsync(missingFilter, cancellationToken: cancellationToken);
+		if (missingCount == 0)
+		{
+			return (0, 0);
+		}
+		logger?.LogWarning("Event log upgrade: {Count} event document(s) lack {Field} — backfilling from CommandCreatedEvent joins and the projection.", missingCount, StreamIdField);
+
+		// Pass 1 source: CommandId -> StreamId from every CommandCreatedEvent whose embedded
+		// command names its stream. Read once up front — the log is append-only, so this map
+		// cannot go stale under us, and legacy logs are small enough to hold it in memory.
+		var commandStreams = new Dictionary<Guid, Guid>();
+		using (var cursor = await events
+			.Find(Builders<BsonDocument>.Filter.Eq("_t", "CommandCreatedEvent"))
+			.ToCursorAsync(cancellationToken))
+		{
+			while (await cursor.MoveNextAsync(cancellationToken))
+			{
+				foreach (var doc in cursor.Current)
+				{
+					if (doc.TryGetValue("Data", out var data) && data is BsonDocument cmd
+						&& cmd.TryGetValue("StreamId", out var sidValue) && sidValue is BsonBinaryData
+						&& doc.TryGetValue("CommandId", out var cidValue) && cidValue is BsonBinaryData)
+					{
+						commandStreams[cidValue.AsGuid] = sidValue.AsGuid;
+					}
+				}
+			}
+		}
+
+		// Pass 2 source is resolved lazily per TargetId (with a cache): the projection database's
+		// collections are enumerated once, and each is probed by _id. The projection has stamped
+		// _sid on every materialized document since stream scoping landed, so any object a legacy
+		// event created/updated resolves here even when its command was never logged.
+		var projectionCollections = new List<IMongoCollection<BsonDocument>>();
+		using (var names = await projectionDatabase.ListCollectionNamesAsync(cancellationToken: cancellationToken))
+		{
+			foreach (var name in await names.ToListAsync(cancellationToken))
+			{
+				if (!name.StartsWith("system.", StringComparison.Ordinal))
+				{
+					projectionCollections.Add(projectionDatabase.GetCollection<BsonDocument>(name));
+				}
+			}
+		}
+		var targetStreams = new Dictionary<Guid, Guid?>();
+		async Task<Guid?> ResolveByTargetAsync(Guid targetId)
+		{
+			if (targetStreams.TryGetValue(targetId, out var cached))
+			{
+				return cached;
+			}
+			Guid? resolved = null;
+			foreach (var collection in projectionCollections)
+			{
+				// Explicit BsonBinaryData, not a raw Guid: a raw Guid in a filter resolves the
+				// driver's ambient GuidSerializer, which throws when no process-wide
+				// representation was ever configured — this helper must not depend on any
+				// class-map/serializer registration having happened first.
+				var doc = await collection
+					.Find(Builders<BsonDocument>.Filter.Eq("_id", new BsonBinaryData(targetId, GuidRepresentation.Standard)))
+					.Project(Builders<BsonDocument>.Projection.Include(StreamIdField))
+					.FirstOrDefaultAsync(cancellationToken);
+				if (doc is not null && doc.TryGetValue(StreamIdField, out var sid) && sid is BsonBinaryData)
+				{
+					resolved = sid.AsGuid;
+					break;
+				}
+			}
+			targetStreams[targetId] = resolved;
+			return resolved;
+		}
+
+		long backfilled = 0, unresolved = 0;
+		var updates = new List<WriteModel<BsonDocument>>();
+		using (var cursor = await events.Find(missingFilter).ToCursorAsync(cancellationToken))
+		{
+			while (await cursor.MoveNextAsync(cancellationToken))
+			{
+				foreach (var doc in cursor.Current)
+				{
+					Guid? sid = null;
+					if (doc.TryGetValue("CommandId", out var cidValue) && cidValue is BsonBinaryData
+						&& commandStreams.TryGetValue(cidValue.AsGuid, out var fromCommand))
+					{
+						sid = fromCommand;
+					}
+					else if (doc.TryGetValue("TargetId", out var tidValue) && tidValue is BsonBinaryData)
+					{
+						sid = await ResolveByTargetAsync(tidValue.AsGuid);
+					}
+
+					if (sid is Guid resolvedSid)
+					{
+						updates.Add(new UpdateOneModel<BsonDocument>(
+							  Builders<BsonDocument>.Filter.Eq("_id", doc["_id"])
+							, Builders<BsonDocument>.Update.Set(StreamIdField, new BsonBinaryData(resolvedSid, GuidRepresentation.Standard))));
+						backfilled++;
+					}
+					else
+					{
+						unresolved++;
+						logger?.LogWarning("Event log upgrade: cannot derive a stream for event {EventId} ({Type}) — leaving it without {Field}.", doc.GetValue("_id", BsonNull.Value), doc.GetValue("_t", BsonNull.Value), StreamIdField);
+					}
+				}
+			}
+		}
+		if (updates.Count > 0)
+		{
+			await events.BulkWriteAsync(updates, new BulkWriteOptions { IsOrdered = false }, cancellationToken);
+		}
+		logger?.LogWarning("Event log upgrade: backfilled {Backfilled} event(s); {Unresolved} left unresolved.", backfilled, unresolved);
+		return (backfilled, unresolved);
+	}
+}

--- a/Tests/Synqra.Tests/MongoEventSidBackfillTests.cs
+++ b/Tests/Synqra.Tests/MongoEventSidBackfillTests.cs
@@ -1,0 +1,119 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Synqra.AppendStorage.MongoDb;
+using Synqra.Tests.TestHelpers;
+using TUnit.Assertions.Extensions;
+
+namespace Synqra.Tests;
+
+/// <summary>
+/// <see cref="MongoEventSidBackfill"/> upgrades event logs written before StreamId was persisted
+/// as _sid. The legacy documents here are inserted raw (BsonDocument, no _sid) to reproduce the
+/// exact production shape: a CommandCreatedEvent whose embedded command names its stream (pass 1
+/// join source), sibling events sharing its CommandId, a command-less event resolvable only via
+/// its target's materialized projection document (pass 2), and one genuinely unresolvable event
+/// that must be left alone and reported rather than guessed at.
+/// </summary>
+public class MongoEventSidBackfillTests : BaseTest
+{
+	IMongoDatabase Db()
+	{
+		var url = new MongoUrl(_connectionString);
+		return new MongoClient(url).GetDatabase(url.DatabaseName);
+	}
+
+	static BsonBinaryData Bin(Guid g) => new(g, GuidRepresentation.Standard);
+
+	[Test]
+	public async Task Should_backfill_sid_from_command_join_and_projection_fallback()
+	{
+		var db = Db();
+		var events = db.GetCollection<BsonDocument>("Event");
+
+		var streamA = Guid.NewGuid(); // via CommandCreatedEvent join
+		var streamB = Guid.NewGuid(); // via projection fallback
+		var commandId = Guid.NewGuid();
+		var joinedEventId = Guid.NewGuid();
+		var cceEventId = Guid.NewGuid();
+		var seededEventId = Guid.NewGuid();
+		var seededTargetId = Guid.NewGuid();
+		var orphanEventId = Guid.NewGuid();
+
+		await events.InsertManyAsync(
+		[
+			// Pass-1 pair: the CommandCreatedEvent names its stream in the embedded command;
+			// the sibling event only shares the CommandId.
+			new BsonDocument
+			{
+				["_id"] = Bin(cceEventId),
+				["_t"] = "CommandCreatedEvent",
+				["CommandId"] = Bin(commandId),
+				["Data"] = new BsonDocument { ["_t"] = "CreateObjectCommand", ["StreamId"] = Bin(streamA), ["TargetId"] = Bin(Guid.NewGuid()) },
+			},
+			new BsonDocument
+			{
+				["_id"] = Bin(joinedEventId),
+				["_t"] = "ObjectCreatedEvent",
+				["CommandId"] = Bin(commandId),
+				["TargetId"] = Bin(Guid.NewGuid()),
+			},
+			// Pass-2: no CommandCreatedEvent for this CommandId anywhere — resolved through the
+			// target's materialized projection document below.
+			new BsonDocument
+			{
+				["_id"] = Bin(seededEventId),
+				["_t"] = "ComponentAddedEvent",
+				["CommandId"] = Bin(Guid.NewGuid()),
+				["TargetId"] = Bin(seededTargetId),
+			},
+			// Unresolvable: unknown command, target absent from every projection collection.
+			new BsonDocument
+			{
+				["_id"] = Bin(orphanEventId),
+				["_t"] = "ObjectCreatedEvent",
+				["CommandId"] = Bin(Guid.NewGuid()),
+				["TargetId"] = Bin(Guid.NewGuid()),
+			},
+		]);
+
+		// The projection half (same ephemeral database here, like production tests do): the
+		// seeded target's materialized Node document already carries _sid.
+		await db.GetCollection<BsonDocument>("Node").InsertOneAsync(new BsonDocument
+		{
+			["_id"] = Bin(seededTargetId),
+			["_t"] = "Node",
+			["_sid"] = Bin(streamB),
+		});
+
+		var (backfilled, unresolved) = await MongoEventSidBackfill.BackfillAsync(db, db);
+		await Assert.That(backfilled).IsEqualTo(3);
+		await Assert.That(unresolved).IsEqualTo(1);
+
+		async Task<BsonDocument> Doc(Guid id) => await events.Find(Builders<BsonDocument>.Filter.Eq("_id", Bin(id))).SingleAsync();
+		await Assert.That((await Doc(cceEventId))["_sid"].AsGuid).IsEqualTo(streamA);
+		await Assert.That((await Doc(joinedEventId))["_sid"].AsGuid).IsEqualTo(streamA);
+		await Assert.That((await Doc(seededEventId))["_sid"].AsGuid).IsEqualTo(streamB);
+		await Assert.That((await Doc(orphanEventId)).Contains("_sid")).IsFalse();
+
+		// Idempotent: a second run touches nothing new (the orphan stays reported, not guessed).
+		var (again, stillUnresolved) = await MongoEventSidBackfill.BackfillAsync(db, db);
+		await Assert.That(again).IsEqualTo(0);
+		await Assert.That(stillUnresolved).IsEqualTo(1);
+	}
+
+	[Test]
+	public async Task Should_no_op_on_clean_log()
+	{
+		var db = Db();
+		await db.GetCollection<BsonDocument>("Event").InsertOneAsync(new BsonDocument
+		{
+			["_id"] = Bin(Guid.NewGuid()),
+			["_t"] = "ObjectCreatedEvent",
+			["CommandId"] = Bin(Guid.NewGuid()),
+			["_sid"] = Bin(Guid.NewGuid()),
+		});
+		var (backfilled, unresolved) = await MongoEventSidBackfill.BackfillAsync(db, db);
+		await Assert.That(backfilled).IsEqualTo(0);
+		await Assert.That(unresolved).IsEqualTo(0);
+	}
+}


### PR DESCRIPTION
## Why

Production event logs written **before** `Event.StreamId` was persisted as `_sid` (#112) carry no stream column at all — the per-stream `AppendStorageEventLog` cannot isolate them, so every stream sees them. Prod already has such events; a fix-forward alone doesn't help the existing data.

## What

`MongoEventSidBackfill.BackfillAsync(eventsDb, projectionDb)` — a **no-operator-input, idempotent** upgrade, cheap enough to run on every startup (a single count when there's nothing to do). Derives each legacy event's stream from data the log/projection already contain:

1. **CommandCreatedEvent join** — the embedded command's `Data.StreamId` names the stream for the CommandCreatedEvent itself and, joined via `CommandId`, for every event that command produced.
2. **Projection fallback** — command-less legacy events (e.g. early seed paths that never logged commands) resolve through their `TargetId`: the materialized projection document already carries `_sid` (MongoProjection has stamped it since stream scoping landed).

Anything unresolved after both passes is **left untouched and logged** — never guessed at.

Filters use explicit `BsonBinaryData` (Standard representation), so the helper works standalone — no class-map / global serializer registration required first.

## Tests

`MongoEventSidBackfillTests` (ephemeral Mongo, raw legacy-shaped `BsonDocument`s):
- join + fallback + unresolvable-left-alone + idempotent second run
- clean-log no-op

2/2 green on net8/9/10.

## Consumer

Quotaly wires this at startup (Scene host, events DB + projection DB) in a follow-up PR that also bumps the submodule pin — that one call upgrades prod, dev, and every PR deployment alike.