### PR TITLE
feat(mongo): automatic storage upgrades with a single-node claim in _synqra_upgrades

### DIFF
--- a/Synqra.AppendStorage.MongoDb/MongoAppendStorageExtensions.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoAppendStorageExtensions.cs
@@ -83,8 +83,45 @@ public static class MongoAppendStorageExtensions
 		});
 
 		services.TryAddSingleton<IAppendStorage<T, TKey>, MongoAppendStorage<T, TKey>>();
+		services.AnnounceForUpgrades<T>(serviceKey: null, sp =>
+		{
+			var options = sp.GetRequiredService<IOptions<MongoAppendStorageOptions>>().Value;
+			return (OpenDatabase(options.ConnectionString), ResolveCollectionName<T>(options.CollectionName));
+		});
 		return services;
 	}
+
+	/// <summary>
+	/// Announce an opened event-log database to <see cref="SynqraMongoUpgradeService"/> and make
+	/// sure the runner itself is registered (TryAddEnumerable — once per host no matter how many
+	/// stores announce). This is what makes storage upgrades automatic: opening a store IS opting
+	/// into its upgrades; a consumer never wires anything. Only <see cref="Event"/> stores
+	/// announce — the known upgrades are event-log upgrades.
+	/// </summary>
+	static void AnnounceForUpgrades<T>(this IServiceCollection services, string? serviceKey, Func<IServiceProvider, (IMongoDatabase Database, string CollectionName)> open)
+	{
+		if (!typeof(Event).IsAssignableFrom(typeof(T)))
+		{
+			return;
+		}
+		services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, SynqraMongoUpgradeService>());
+		services.AddSingleton(sp =>
+		{
+			var (database, collectionName) = open(sp);
+			return new SynqraMongoUpgradeParticipant(serviceKey, SynqraMongoDatabaseRole.Events, _ => database, collectionName);
+		});
+	}
+
+	static IMongoDatabase OpenDatabase(string connectionString)
+	{
+		var url = new MongoUrl(connectionString);
+		return new MongoClient(connectionString).GetDatabase(string.IsNullOrWhiteSpace(url.DatabaseName) ? "synqra" : url.DatabaseName);
+	}
+
+	static string ResolveCollectionName<T>(string? template)
+		=> (template ?? MongoAppendStorageOptions.DefaultCollectionName)
+			.Replace("[TypeName]", typeof(T).Name)
+			.Replace("[Type]", typeof(T).Name);
 
 	/// <summary>
 	/// Keyed variant — same reasoning as <see cref="Synqra.Projection.MongoDb.MongoSynqraStoreExtensions"/>'s
@@ -122,6 +159,7 @@ public static class MongoAppendStorageExtensions
 
 		services.AddKeyedSingleton<IAppendStorage<T, TKey>>(serviceKey, (sp, key) =>
 			ActivatorUtilities.CreateInstance<MongoAppendStorage<T, TKey>>(sp, sp.GetRequiredKeyedService<IMongoCollection<T>>(key)));
+		services.AnnounceForUpgrades<T>(serviceKey, _ => (OpenDatabase(connectionString), ResolveCollectionName<T>(collectionName)));
 		return services;
 	}
 

--- a/Synqra.AppendStorage.MongoDb/MongoEventSidBackfill.cs
+++ b/Synqra.AppendStorage.MongoDb/MongoEventSidBackfill.cs
@@ -5,11 +5,11 @@ using MongoDB.Driver;
 namespace Synqra.AppendStorage.MongoDb;
 
 /// <summary>
-/// One-time, idempotent upgrade for event logs written before <see cref="Event.StreamId"/> was
-/// persisted as <c>_sid</c> (see <see cref="MongoEventClassMaps"/>): those documents carry no
-/// stream column at all, so the per-stream <c>AppendStorageEventLog</c> cannot isolate them and
-/// every stream sees them. This backfills <c>_sid</c> onto every legacy event from the data the
-/// log (and its projection) already contains — no operator input, safe to run on every startup:
+/// Upgrade for event logs written before <see cref="Event.StreamId"/> was persisted as
+/// <c>_sid</c> (see <see cref="MongoEventClassMaps"/>): those documents carry no stream column
+/// at all, so the per-stream <c>AppendStorageEventLog</c> cannot isolate them and every stream
+/// sees them. Backfills <c>_sid</c> onto every legacy event from data the log (and its
+/// projection) already contain:
 /// <list type="number">
 /// <item><b>CommandCreatedEvent join:</b> a <c>CommandCreatedEvent</c>'s embedded command
 /// (<c>Data.StreamId</c>) names its stream outright — that resolves the CommandCreatedEvent
@@ -20,29 +20,17 @@ namespace Synqra.AppendStorage.MongoDb;
 /// (MongoProjection has stamped it since stream scoping landed).</item>
 /// </list>
 /// Anything still unresolved after both passes is left untouched and reported — an event whose
-/// stream genuinely cannot be derived should be looked at by a human, not guessed at.
+/// stream genuinely cannot be derived should be looked at by a human, not guessed at. Idempotent
+/// (a single count when there is nothing to do); invoked only by
+/// <see cref="SynqraMongoUpgradeService"/> under its single-node claim.
 /// </summary>
-public static class MongoEventSidBackfill
+internal sealed class EventSidBackfillUpgrade : ISynqraMongoUpgrade
 {
 	const string StreamIdField = "_sid";
 
-	/// <summary>
-	/// Backfills <c>_sid</c> on every event document that lacks one. Idempotent and cheap when
-	/// there is nothing to do (a single indexed-by-nothing count on a small collection; the
-	/// full scan work only happens when legacy documents actually exist).
-	/// </summary>
-	/// <param name="eventsDatabase">Database holding the event log collection.</param>
-	/// <param name="projectionDatabase">Database holding the materialized projection collections
-	/// (may be the same database). Used only for the fallback pass.</param>
-	/// <param name="eventsCollectionName">Event log collection name (default "Event").</param>
-	/// <returns>(backfilled, unresolved) counts.</returns>
-	public static async Task<(long Backfilled, long Unresolved)> BackfillAsync(
-		  IMongoDatabase eventsDatabase
-		, IMongoDatabase projectionDatabase
-		, string eventsCollectionName = "Event"
-		, ILogger? logger = null
-		, CancellationToken cancellationToken = default
-		)
+	public string Id => "event-sid-backfill/1";
+
+	public async Task RunAsync(IMongoDatabase eventsDatabase, string eventsCollectionName, IMongoDatabase? projectionDatabase, ILogger logger, CancellationToken cancellationToken)
 	{
 		var events = eventsDatabase.GetCollection<BsonDocument>(eventsCollectionName);
 		var missingFilter = Builders<BsonDocument>.Filter.Exists(StreamIdField, false);
@@ -50,9 +38,9 @@ public static class MongoEventSidBackfill
 		var missingCount = await events.CountDocumentsAsync(missingFilter, cancellationToken: cancellationToken);
 		if (missingCount == 0)
 		{
-			return (0, 0);
+			return;
 		}
-		logger?.LogWarning("Event log upgrade: {Count} event document(s) lack {Field} — backfilling from CommandCreatedEvent joins and the projection.", missingCount, StreamIdField);
+		logger.LogWarning("Event log upgrade: {Count} event document(s) lack {Field} — backfilling from CommandCreatedEvent joins and the projection.", missingCount, StreamIdField);
 
 		// Pass 1 source: CommandId -> StreamId from every CommandCreatedEvent whose embedded
 		// command names its stream. Read once up front — the log is append-only, so this map
@@ -81,11 +69,12 @@ public static class MongoEventSidBackfill
 		// _sid on every materialized document since stream scoping landed, so any object a legacy
 		// event created/updated resolves here even when its command was never logged.
 		var projectionCollections = new List<IMongoCollection<BsonDocument>>();
-		using (var names = await projectionDatabase.ListCollectionNamesAsync(cancellationToken: cancellationToken))
+		if (projectionDatabase is not null)
 		{
+			using var names = await projectionDatabase.ListCollectionNamesAsync(cancellationToken: cancellationToken);
 			foreach (var name in await names.ToListAsync(cancellationToken))
 			{
-				if (!name.StartsWith("system.", StringComparison.Ordinal))
+				if (!name.StartsWith("system.", StringComparison.Ordinal) && name != "_synqra_upgrades")
 				{
 					projectionCollections.Add(projectionDatabase.GetCollection<BsonDocument>(name));
 				}
@@ -103,7 +92,7 @@ public static class MongoEventSidBackfill
 			{
 				// Explicit BsonBinaryData, not a raw Guid: a raw Guid in a filter resolves the
 				// driver's ambient GuidSerializer, which throws when no process-wide
-				// representation was ever configured — this helper must not depend on any
+				// representation was ever configured — this upgrade must not depend on any
 				// class-map/serializer registration having happened first.
 				var doc = await collection
 					.Find(Builders<BsonDocument>.Filter.Eq("_id", new BsonBinaryData(targetId, GuidRepresentation.Standard)))
@@ -148,7 +137,7 @@ public static class MongoEventSidBackfill
 					else
 					{
 						unresolved++;
-						logger?.LogWarning("Event log upgrade: cannot derive a stream for event {EventId} ({Type}) — leaving it without {Field}.", doc.GetValue("_id", BsonNull.Value), doc.GetValue("_t", BsonNull.Value), StreamIdField);
+						logger.LogWarning("Event log upgrade: cannot derive a stream for event {EventId} ({Type}) — leaving it without {Field}.", doc.GetValue("_id", BsonNull.Value), doc.GetValue("_t", BsonNull.Value), StreamIdField);
 					}
 				}
 			}
@@ -157,7 +146,6 @@ public static class MongoEventSidBackfill
 		{
 			await events.BulkWriteAsync(updates, new BulkWriteOptions { IsOrdered = false }, cancellationToken);
 		}
-		logger?.LogWarning("Event log upgrade: backfilled {Backfilled} event(s); {Unresolved} left unresolved.", backfilled, unresolved);
-		return (backfilled, unresolved);
+		logger.LogWarning("Event log upgrade: backfilled {Backfilled} event(s); {Unresolved} left unresolved.", backfilled, unresolved);
 	}
 }

--- a/Synqra.AppendStorage.MongoDb/SynqraMongoUpgrades.cs
+++ b/Synqra.AppendStorage.MongoDb/SynqraMongoUpgrades.cs
@@ -1,0 +1,174 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Synqra.AppendStorage.MongoDb;
+
+/// <summary>
+/// Which half of a Synqra store a registered Mongo database is — an upgrade declares which
+/// roles it needs, and the runner matches them up per service key.
+/// </summary>
+public enum SynqraMongoDatabaseRole
+{
+	/// <summary>The append-only event log (source of truth).</summary>
+	Events,
+	/// <summary>The materialized projection / read models (rebuildable).</summary>
+	Projection,
+}
+
+/// <summary>
+/// One Mongo database a Synqra DI extension opened, announced for the upgrade runner. Every
+/// extension that opens a database (<c>AddAppendStorageMongoDb</c>, <c>AddMongoDbSynqraStore</c>)
+/// contributes one of these — that is what makes upgrades fully automatic: Synqra upgrades
+/// whatever storage it opens, and a host never wires anything. The database is a factory so
+/// nothing connects until the runner actually starts.
+/// </summary>
+public sealed record SynqraMongoUpgradeParticipant(
+	  string? ServiceKey
+	, SynqraMongoDatabaseRole Role
+	, Func<IServiceProvider, IMongoDatabase> Database
+	, string? EventsCollectionName = null
+	);
+
+/// <summary>A single, versioned, idempotent storage upgrade the runner can apply.</summary>
+internal interface ISynqraMongoUpgrade
+{
+	/// <summary>Stable identity — the claim key in <c>_synqra_upgrades</c>. Never reuse or rename.</summary>
+	string Id { get; }
+
+	Task RunAsync(IMongoDatabase events, string eventsCollectionName, IMongoDatabase? projection, ILogger logger, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Runs every applicable storage upgrade at host startup, before the app serves traffic —
+/// registered automatically by the same DI extensions that open the databases, so consumers
+/// never call anything. Multi-node safe: an upgrade is claimed by inserting its
+/// <see cref="ISynqraMongoUpgrade.Id"/> as <c>_id</c> into the <c>_synqra_upgrades</c>
+/// collection of the events database being upgraded — the unique index on <c>_id</c>
+/// guarantees exactly one node wins the insert and performs the upgrade; every other node
+/// waits for the winner's completion marker. A crashed winner's claim (no completion marker
+/// after a generous stale window) is taken over by deleting the stale claim and re-claiming.
+/// A failed or timed-out upgrade fails startup on purpose: booting into a store the readers
+/// cannot correctly interpret is worse than not booting.
+/// </summary>
+public sealed class SynqraMongoUpgradeService(
+	  IEnumerable<SynqraMongoUpgradeParticipant> participants
+	, IServiceProvider serviceProvider
+	, ILogger<SynqraMongoUpgradeService>? logger = null
+	) : IHostedService
+{
+	const string UpgradesCollectionName = "_synqra_upgrades";
+	static readonly TimeSpan CompletionWaitTimeout = TimeSpan.FromMinutes(5);
+	static readonly TimeSpan StaleClaimAge = TimeSpan.FromMinutes(15);
+	static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(2);
+
+	internal static readonly ISynqraMongoUpgrade[] Upgrades =
+	[
+		new EventSidBackfillUpgrade(),
+	];
+
+	readonly ILogger _logger = logger ?? NullLogger<SynqraMongoUpgradeService>.Instance;
+
+	public async Task StartAsync(CancellationToken cancellationToken)
+	{
+		// Group what was opened by service key: a process hosting several independent
+		// Synqra-backed features upgrades each feature's own databases separately. Duplicate
+		// contributions (an extension called twice) collapse — same key+role is the same DB.
+		foreach (var group in participants.GroupBy(p => p.ServiceKey))
+		{
+			var events = group.FirstOrDefault(p => p.Role == SynqraMongoDatabaseRole.Events);
+			if (events is null)
+			{
+				continue; // nothing upgradeable without an event log
+			}
+			var projection = group.FirstOrDefault(p => p.Role == SynqraMongoDatabaseRole.Projection);
+
+			var eventsDb = events.Database(serviceProvider);
+			var projectionDb = projection?.Database(serviceProvider);
+			foreach (var upgrade in Upgrades)
+			{
+				await RunOnceAsync(upgrade, eventsDb, events.EventsCollectionName ?? "Event", projectionDb, cancellationToken);
+			}
+		}
+	}
+
+	async Task RunOnceAsync(ISynqraMongoUpgrade upgrade, IMongoDatabase eventsDb, string eventsCollectionName, IMongoDatabase? projectionDb, CancellationToken cancellationToken)
+	{
+		var claims = eventsDb.GetCollection<BsonDocument>(UpgradesCollectionName);
+		var started = DateTime.UtcNow;
+		while (true)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var claimedAt = DateTime.UtcNow;
+			try
+			{
+				await claims.InsertOneAsync(new BsonDocument
+				{
+					["_id"] = upgrade.Id,
+					["claimedAt"] = claimedAt,
+					["claimedBy"] = Environment.MachineName,
+				}, options: null, cancellationToken);
+			}
+			catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+			{
+				// Someone else holds (or held) the claim — wait for their completion marker.
+				var winner = await WaitForCompletionAsync(claims, upgrade.Id, cancellationToken);
+				if (winner is not null && winner.Contains("completedAt"))
+				{
+					return; // already upgraded (now, or on some earlier deployment)
+				}
+				// No completion and the claim is stale — the winner most likely crashed
+				// mid-upgrade (the upgrade itself is idempotent, so re-running is safe).
+				// Delete exactly the stale claim we observed (claimedAt match keeps two
+				// takeover attempts from double-deleting a fresh claim) and re-claim.
+				if (winner is not null)
+				{
+					await claims.DeleteOneAsync(
+						  Builders<BsonDocument>.Filter.Eq("_id", upgrade.Id)
+						& Builders<BsonDocument>.Filter.Eq("claimedAt", winner["claimedAt"])
+						& Builders<BsonDocument>.Filter.Exists("completedAt", false)
+						, cancellationToken);
+				}
+				continue;
+			}
+
+			_logger.LogInformation("Storage upgrade '{Upgrade}' claimed on '{Database}' — running.", upgrade.Id, eventsDb.DatabaseNamespace.DatabaseName);
+			await upgrade.RunAsync(eventsDb, eventsCollectionName, projectionDb, _logger, cancellationToken);
+			await claims.UpdateOneAsync(
+				  Builders<BsonDocument>.Filter.Eq("_id", upgrade.Id)
+				, Builders<BsonDocument>.Update.Set("completedAt", DateTime.UtcNow)
+				, options: null, cancellationToken);
+			_logger.LogInformation("Storage upgrade '{Upgrade}' completed on '{Database}'.", upgrade.Id, eventsDb.DatabaseNamespace.DatabaseName);
+			return;
+		}
+	}
+
+	/// <summary>Polls the claim doc until it carries <c>completedAt</c>, the claim goes stale, or the
+	/// wait times out (which fails startup — see class remarks). Returns the last observed doc.</summary>
+	async Task<BsonDocument?> WaitForCompletionAsync(IMongoCollection<BsonDocument> claims, string upgradeId, CancellationToken cancellationToken)
+	{
+		var waitStarted = DateTime.UtcNow;
+		while (true)
+		{
+			var doc = await claims.Find(Builders<BsonDocument>.Filter.Eq("_id", upgradeId)).FirstOrDefaultAsync(cancellationToken);
+			if (doc is null || doc.Contains("completedAt"))
+			{
+				return doc; // gone (stale claim deleted by another waiter) or done
+			}
+			if (doc["claimedAt"].ToUniversalTime() < DateTime.UtcNow - StaleClaimAge)
+			{
+				return doc; // stale — caller takes over
+			}
+			if (DateTime.UtcNow - waitStarted > CompletionWaitTimeout)
+			{
+				throw new TimeoutException($"Storage upgrade '{upgradeId}' is still running on another node after {CompletionWaitTimeout} — refusing to serve a store mid-upgrade.");
+			}
+			_logger.LogInformation("Storage upgrade '{Upgrade}' is running on another node — waiting.", upgradeId);
+			await Task.Delay(PollInterval, cancellationToken);
+		}
+	}
+
+	public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Synqra.Projection.MongoDb/_DI.cs
+++ b/Synqra.Projection.MongoDb/_DI.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using Synqra.AppendStorage;
+using Synqra.AppendStorage.MongoDb;
 
 namespace Synqra.Projection.MongoDb;
 
@@ -74,7 +75,28 @@ public static class MongoSynqraStoreExtensions
 		});
 		services.AddSingleton<IObjectStore>(sp => sp.GetRequiredService<MongoProjection>());
 		services.AddSingleton<IProjection>(sp => sp.GetRequiredService<MongoProjection>());
+		services.AnnounceProjectionForUpgrades(serviceKey: null, sp => sp.GetRequiredService<IOptions<MongoProjectionOptions>>().Value);
 		return services;
+	}
+
+	/// <summary>
+	/// Announce the opened projection database to <see cref="SynqraMongoUpgradeService"/> — the
+	/// upgrade runner (registered by the event-storage side; opening a projection alone never
+	/// triggers upgrades) uses it as a derivation source (e.g. resolving a legacy event's stream
+	/// from its target's materialized document). Consumers wire nothing — see the runner's remarks.
+	/// </summary>
+	static void AnnounceProjectionForUpgrades(this IServiceCollection services, string? serviceKey, Func<IServiceProvider, MongoProjectionOptions> getOptions)
+	{
+		services.AddSingleton(sp =>
+		{
+			var options = getOptions(sp);
+			var url = new MongoUrl(options.ConnectionString);
+			var databaseName = !string.IsNullOrWhiteSpace(options.DatabaseName)
+				? options.DatabaseName!
+				: string.IsNullOrWhiteSpace(url.DatabaseName) ? "synqra" : url.DatabaseName;
+			var database = new MongoClient(options.ConnectionString).GetDatabase(databaseName);
+			return new SynqraMongoUpgradeParticipant(serviceKey, SynqraMongoDatabaseRole.Projection, _ => database);
+		});
 	}
 
 	static IServiceCollection AddMongoDbSynqraStoreCore(this IServiceCollection services, string serviceKey)
@@ -101,6 +123,7 @@ public static class MongoSynqraStoreExtensions
 		});
 		services.AddKeyedSingleton<IObjectStore>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<MongoProjection>(key));
 		services.AddKeyedSingleton<IProjection>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<MongoProjection>(key));
+		services.AnnounceProjectionForUpgrades(serviceKey, sp => sp.GetRequiredService<IOptionsMonitor<MongoProjectionOptions>>().Get(serviceKey));
 		return services;
 	}
 }

--- a/Tests/Synqra.Tests/MongoEventSidBackfillTests.cs
+++ b/Tests/Synqra.Tests/MongoEventSidBackfillTests.cs
@@ -7,12 +7,12 @@ using TUnit.Assertions.Extensions;
 namespace Synqra.Tests;
 
 /// <summary>
-/// <see cref="MongoEventSidBackfill"/> upgrades event logs written before StreamId was persisted
-/// as _sid. The legacy documents here are inserted raw (BsonDocument, no _sid) to reproduce the
-/// exact production shape: a CommandCreatedEvent whose embedded command names its stream (pass 1
-/// join source), sibling events sharing its CommandId, a command-less event resolvable only via
-/// its target's materialized projection document (pass 2), and one genuinely unresolvable event
-/// that must be left alone and reported rather than guessed at.
+/// <see cref="SynqraMongoUpgradeService"/> auto-upgrades whatever Mongo storage Synqra opens —
+/// exercised here exactly the way a host runs it (the hosted service with announced
+/// participants), never by calling an upgrade directly. Covers the first real upgrade
+/// (event-sid-backfill: CommandCreatedEvent join + projection fallback, unresolvable left
+/// alone), the <c>_synqra_upgrades</c> claim bookkeeping, idempotent re-runs, and the
+/// single-winner guarantee under concurrent nodes.
 /// </summary>
 public class MongoEventSidBackfillTests : BaseTest
 {
@@ -23,6 +23,12 @@ public class MongoEventSidBackfillTests : BaseTest
 	}
 
 	static BsonBinaryData Bin(Guid g) => new(g, GuidRepresentation.Standard);
+
+	static SynqraMongoUpgradeService Runner(IMongoDatabase db) => new(
+	[
+		new SynqraMongoUpgradeParticipant(null, SynqraMongoDatabaseRole.Events, _ => db, "Event"),
+		new SynqraMongoUpgradeParticipant(null, SynqraMongoDatabaseRole.Projection, _ => db),
+	], null!);
 
 	[Test]
 	public async Task Should_backfill_sid_from_command_join_and_projection_fallback()
@@ -85,9 +91,7 @@ public class MongoEventSidBackfillTests : BaseTest
 			["_sid"] = Bin(streamB),
 		});
 
-		var (backfilled, unresolved) = await MongoEventSidBackfill.BackfillAsync(db, db);
-		await Assert.That(backfilled).IsEqualTo(3);
-		await Assert.That(unresolved).IsEqualTo(1);
+		await Runner(db).StartAsync(CancellationToken.None);
 
 		async Task<BsonDocument> Doc(Guid id) => await events.Find(Builders<BsonDocument>.Filter.Eq("_id", Bin(id))).SingleAsync();
 		await Assert.That((await Doc(cceEventId))["_sid"].AsGuid).IsEqualTo(streamA);
@@ -95,10 +99,46 @@ public class MongoEventSidBackfillTests : BaseTest
 		await Assert.That((await Doc(seededEventId))["_sid"].AsGuid).IsEqualTo(streamB);
 		await Assert.That((await Doc(orphanEventId)).Contains("_sid")).IsFalse();
 
-		// Idempotent: a second run touches nothing new (the orphan stays reported, not guessed).
-		var (again, stillUnresolved) = await MongoEventSidBackfill.BackfillAsync(db, db);
-		await Assert.That(again).IsEqualTo(0);
-		await Assert.That(stillUnresolved).IsEqualTo(1);
+		// The claim is recorded and completed in _synqra_upgrades — that's both the audit trail
+		// and what makes the next boot skip without racing.
+		var claim = await db.GetCollection<BsonDocument>("_synqra_upgrades")
+			.Find(Builders<BsonDocument>.Filter.Eq("_id", "event-sid-backfill/1")).SingleAsync();
+		await Assert.That(claim.Contains("completedAt")).IsTrue();
+
+		// Second boot: completed claim short-circuits; the orphan stays untouched, not guessed.
+		await Runner(db).StartAsync(CancellationToken.None);
+		await Assert.That((await Doc(orphanEventId)).Contains("_sid")).IsFalse();
+	}
+
+	[Test]
+	public async Task Should_let_exactly_one_concurrent_node_win_the_claim()
+	{
+		var db = Db();
+		var events = db.GetCollection<BsonDocument>("Event");
+		var stream = Guid.NewGuid();
+		var commandId = Guid.NewGuid();
+		await events.InsertManyAsync(
+		[
+			new BsonDocument
+			{
+				["_id"] = Bin(Guid.NewGuid()),
+				["_t"] = "CommandCreatedEvent",
+				["CommandId"] = Bin(commandId),
+				["Data"] = new BsonDocument { ["_t"] = "CreateObjectCommand", ["StreamId"] = Bin(stream) },
+			},
+		]);
+
+		// Several "nodes" (independent runner instances) boot at once against the same
+		// database. The unique _id insert into _synqra_upgrades lets exactly one win; the rest
+		// wait for its completion marker. Everyone returns, nothing throws, one claim doc.
+		await Task.WhenAll(Enumerable.Range(0, 5).Select(_ => Task.Run(() => Runner(db).StartAsync(CancellationToken.None))));
+
+		var claims = await db.GetCollection<BsonDocument>("_synqra_upgrades")
+			.Find(Builders<BsonDocument>.Filter.Eq("_id", "event-sid-backfill/1")).ToListAsync();
+		await Assert.That(claims.Count).IsEqualTo(1);
+		await Assert.That(claims[0].Contains("completedAt")).IsTrue();
+		var cce = await events.Find(Builders<BsonDocument>.Filter.Eq("_t", "CommandCreatedEvent")).SingleAsync();
+		await Assert.That(cce["_sid"].AsGuid).IsEqualTo(stream);
 	}
 
 	[Test]
@@ -112,8 +152,9 @@ public class MongoEventSidBackfillTests : BaseTest
 			["CommandId"] = Bin(Guid.NewGuid()),
 			["_sid"] = Bin(Guid.NewGuid()),
 		});
-		var (backfilled, unresolved) = await MongoEventSidBackfill.BackfillAsync(db, db);
-		await Assert.That(backfilled).IsEqualTo(0);
-		await Assert.That(unresolved).IsEqualTo(0);
+		await Runner(db).StartAsync(CancellationToken.None);
+		var claim = await db.GetCollection<BsonDocument>("_synqra_upgrades")
+			.Find(Builders<BsonDocument>.Filter.Eq("_id", "event-sid-backfill/1")).SingleAsync();
+		await Assert.That(claim.Contains("completedAt")).IsTrue();
 	}
 }


### PR DESCRIPTION
## Why

#113 shipped the `_sid` backfill as a **public static helper a consumer had to call** — wrong shape. Upgrades are Synqra's own responsibility: Synqra should auto-upgrade whatever storage it opens, with a guarantee that only one node performs the upgrade.

## What

**Auto-wiring** — the DI extensions that open Mongo databases announce what they opened (`SynqraMongoUpgradeParticipant`: service key + role + lazy DB handle):
- `AddAppendStorageMongoDb` (event log, `Events` role) — also registers the runner (`TryAddEnumerable`, once per host)
- `AddMongoDbSynqraStore` (projection, `Projection` role) — derivation source only

`SynqraMongoUpgradeService` (hosted service) groups participants by service key and runs every applicable upgrade at startup, before traffic. **A consumer wires nothing** — Quotaly's existing `AddSceneMongoStore` already calls both extensions, so its side becomes a pin bump only.

**Single-node claim** — an upgrade is claimed by inserting its id as `_id` into `_synqra_upgrades` in the database being upgraded; the unique index picks exactly one winner. Others wait for the winner's `completedAt` marker. A crashed winner's stale claim (15 min, no marker) is deleted and re-claimed — safe because upgrades are idempotent. Failure/timeout fails startup on purpose.

**First upgrade** — `event-sid-backfill/1`: the former `MongoEventSidBackfill` public static becomes the **internal** `EventSidBackfillUpgrade`, invoked only by the runner. Same derivation: CommandCreatedEvent join, projection-document fallback, unresolved events left alone and logged.

## Tests

Public-path only (the hosted service with announced participants):
- join + fallback + unresolvable-left-alone + idempotent second boot + `_synqra_upgrades` bookkeeping
- **5 concurrent nodes race** → exactly one winner, one claim doc, correct backfill
- clean-log no-op

Full Mongo suite **24/24** green (net8/9/10).