### PR TITLE
fix(mongo): probe announced databases before upgrading — unreachable store skips, not kills, startup

### DIFF
--- a/Synqra.AppendStorage.MongoDb/SynqraMongoUpgrades.cs
+++ b/Synqra.AppendStorage.MongoDb/SynqraMongoUpgrades.cs
@@ -86,11 +86,42 @@ public sealed class SynqraMongoUpgradeService(
 			var projection = group.FirstOrDefault(p => p.Role == SynqraMongoDatabaseRole.Projection);
 
 			var eventsDb = events.Database(serviceProvider);
+			// Probe before claiming, with a short timeout. An UNREACHABLE database (server gone,
+			// wrong credentials — e.g. a test host that configures a store it never touches) must
+			// not fail startup: nothing can read an unreachable store, so there is nothing the
+			// upgrade needs to protect, and before upgrades existed such a host booted fine
+			// because Mongo connects lazily. Only a REACHABLE store with a FAILING upgrade is
+			// fatal (see RunOnceAsync) — that one would otherwise serve misinterpretable data.
+			if (!await IsReachableAsync(eventsDb, cancellationToken))
+			{
+				_logger.LogError("Storage upgrades skipped for '{Database}' (service key '{Key}'): events database unreachable — the store will fail on first use instead.", eventsDb.DatabaseNamespace.DatabaseName, group.Key);
+				continue;
+			}
 			var projectionDb = projection?.Database(serviceProvider);
+			if (projectionDb is not null && !await IsReachableAsync(projectionDb, cancellationToken))
+			{
+				_logger.LogWarning("Projection database '{Database}' unreachable — upgrades run without the projection-derived fallback.", projectionDb.DatabaseNamespace.DatabaseName);
+				projectionDb = null;
+			}
 			foreach (var upgrade in Upgrades)
 			{
 				await RunOnceAsync(upgrade, eventsDb, events.EventsCollectionName ?? "Event", projectionDb, cancellationToken);
 			}
+		}
+	}
+
+	static async Task<bool> IsReachableAsync(IMongoDatabase database, CancellationToken cancellationToken)
+	{
+		using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		timeout.CancelAfter(TimeSpan.FromSeconds(5));
+		try
+		{
+			await database.RunCommandAsync<BsonDocument>(new BsonDocument("ping", 1), readPreference: null, timeout.Token);
+			return true;
+		}
+		catch (Exception) when (!cancellationToken.IsCancellationRequested)
+		{
+			return false;
 		}
 	}
 

--- a/Tests/Synqra.Tests/MongoEventSidBackfillTests.cs
+++ b/Tests/Synqra.Tests/MongoEventSidBackfillTests.cs
@@ -142,6 +142,21 @@ public class MongoEventSidBackfillTests : BaseTest
 	}
 
 	[Test]
+	public async Task Should_not_fail_startup_when_a_configured_database_is_unreachable()
+	{
+		// A host may configure a store it never touches in that process (integration-test
+		// hosts do exactly this) — before upgrades existed it booted fine because Mongo
+		// connects lazily. The runner must probe-and-skip, not take the whole host down;
+		// the unreachable store fails on first actual use instead.
+		var dead = new MongoClient("mongodb://localhost:1/?serverSelectionTimeoutMS=500&connectTimeoutMS=500").GetDatabase("nope");
+		var runner = new SynqraMongoUpgradeService(
+		[
+			new SynqraMongoUpgradeParticipant(null, SynqraMongoDatabaseRole.Events, _ => dead, "Event"),
+		], null!);
+		await runner.StartAsync(CancellationToken.None); // must not throw
+	}
+
+	[Test]
 	public async Task Should_no_op_on_clean_log()
 	{
 		var db = Db();


### PR DESCRIPTION
## Why

#114's runner connects eagerly at startup to every announced database. A host can configure a store it never touches in that process — Quotaly's Security/Jobs integration-test hosts do exactly this (they announce Scene's dev-credential database, absent in the CI container). Before upgrades existed such hosts booted fine (Mongo connects lazily); the eager claim turned it into a host-wide startup failure with a 30s server-selection timeout per test — Quotaly build 12781: Security 17/17 + Jobs 21/25 integration tests failed in `SetUp`.

## What

5s `ping` probe per announced database before claiming:
- **Events DB unreachable** → log error, skip that group's upgrades. Nothing can read an unreachable store, so there's nothing the upgrade must protect — and the store still fails loudly on first actual use.
- **Projection DB unreachable** → log warning, run without the fallback derivation source.
- **Reachable store, failing upgrade** → still fatal, unchanged.

## Tests

New regression: runner with an unreachable events participant completes `StartAsync` without throwing. Full Mongo suite **25/25** on net8/9/10.