### PR TITLE
feat: WS replication endpoint isolates events per authorized stream

### DIFF
--- a/Synqra.Replication.AspNetCore/ReplicationStreamScope.cs
+++ b/Synqra.Replication.AspNetCore/ReplicationStreamScope.cs
@@ -1,0 +1,28 @@
+namespace Synqra.Replication.AspNetCore;
+
+/// <summary>
+/// The per-connection stream-routing rule for <see cref="SynqraReplicationEndpointExtensions"/>,
+/// factored out so the isolation decision is asserted directly rather than only through a live
+/// WebSocket. One rule covers both directions the endpoint filters on:
+/// <list type="bullet">
+/// <item>backlog replay — an event is sent to a connection only if it belongs to that connection's stream;</item>
+/// <item>live broadcast — an event is fanned out to a peer socket only if that peer is on the event's stream.</item>
+/// </list>
+/// <para>
+/// <paramref name="connectionStream"/> is the stream the receiving connection is authorized for — the
+/// ambient <see cref="SynqraStreamContext"/> the host established (for Quotaly, the authenticated
+/// user's own stream). <c>null</c> means the host set no scope at all — a single-tenant deployment —
+/// in which case every event is admitted, exactly the pre-isolation behavior.
+/// </para>
+/// </summary>
+internal static class ReplicationStreamScope
+{
+	/// <summary>
+	/// True if an event on stream <paramref name="candidateStream"/> may be delivered to a connection
+	/// scoped to <paramref name="connectionStream"/>. A scoped connection only ever sees its own
+	/// stream (a peer that carries no stream, <c>null</c>, is never admitted onto a scoped connection);
+	/// an unscoped connection sees everything.
+	/// </summary>
+	public static bool Admits(System.Guid? candidateStream, System.Guid? connectionStream)
+		=> connectionStream is not System.Guid stream || candidateStream == stream;
+}

--- a/Synqra.Replication.AspNetCore/Synqra.Replication.AspNetCore.csproj
+++ b/Synqra.Replication.AspNetCore/Synqra.Replication.AspNetCore.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <InternalsVisibleTo Include="Synqra.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
+++ b/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Synqra;
 using Synqra.AppendStorage;
 
 namespace Synqra.Replication.AspNetCore;
@@ -37,7 +38,12 @@ public static class SynqraReplicationEndpointExtensions
 	{
 		app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(20) });
 
-		var sockets = new ConcurrentBag<WebSocket>();
+		// Each connected socket is tagged with the stream it is authorized for, so a broadcast
+		// only reaches peers on the same stream (see the broadcast loop below). Was a
+		// ConcurrentBag<WebSocket> — a set with no per-socket stream and, worse, no removal, so
+		// dead sockets accumulated forever. A dictionary gives both the stream tag and O(1)
+		// removal on disconnect.
+		var sockets = new ConcurrentDictionary<WebSocket, Guid?>();
 		var broadcastGate = new SemaphoreSlim(1, 1);
 		var knownEvents = new ConcurrentDictionary<Guid, object?>();
 
@@ -50,6 +56,14 @@ public static class SynqraReplicationEndpointExtensions
 				return;
 			}
 			using var socket = await ctx.WebSockets.AcceptWebSocketAsync();
+
+			// The stream this connection is authorized for, taken from the ambient
+			// SynqraStreamContext the host established for the request (for Quotaly that is the
+			// authenticated user's own stream, set by the auth middleware that wraps this whole
+			// connection's read loop). It is NEVER taken from anything the client sends — a client
+			// must not be able to name another user's stream. null means the host set no scope at
+			// all (a single-tenant deployment): everything below then behaves as before, unscoped.
+			var connectionStream = SynqraStreamContext.CurrentOrNull;
 
 			#region HELLO — from client
 			// 8 bytes magic + 16 bytes the client's own "last event id it already received
@@ -84,7 +98,7 @@ public static class SynqraReplicationEndpointExtensions
 			await broadcastGate.WaitAsync(ctx.RequestAborted);
 			try
 			{
-				sockets.Add(socket);
+				sockets[socket] = connectionStream;
 				await socket.SendAsync(magicBytes, WebSocketMessageType.Binary, endOfMessage: true, ctx.RequestAborted);
 
 				var storage = serviceKey is null
@@ -95,6 +109,14 @@ public static class SynqraReplicationEndpointExtensions
 				{
 					await foreach (var ev in storage.GetAllAsync(from: clientCursor, ctx.RequestAborted))
 					{
+						// Replay only THIS connection's stream. The log is one shared multitenant
+						// collection; ev.StreamId (persisted as _sid) says which stream each event
+						// belongs to. Without this filter the backlog leaked every stream's events
+						// to any connecting client. Unscoped host (connectionStream null) → send all.
+						if (!ReplicationStreamScope.Admits(ev.StreamId, connectionStream))
+						{
+							continue;
+						}
 						knownEvents.TryAdd(ev.EventId, null);
 						var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, backlogBuffer);
 						await socket.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
@@ -110,6 +132,9 @@ public static class SynqraReplicationEndpointExtensions
 				broadcastGate.Release();
 			}
 			#endregion
+
+			try
+			{
 
 			while (!ctx.RequestAborted.IsCancellationRequested && socket.State == WebSocketState.Open)
 			{
@@ -132,6 +157,15 @@ public static class SynqraReplicationEndpointExtensions
 				try
 				{
 					var ev = newEvent1.Event;
+					// The event's stream is set authoritatively from THIS connection's authorized
+					// stream — never trusted from the wire (Event.StreamId is not even on the SBX
+					// wire format; it arrives default). This both stamps _sid correctly on the
+					// durable append and forbids a client from injecting an event into any other
+					// stream: whatever it claims, the event is filed under the stream it connected as.
+					if (connectionStream is Guid stream)
+					{
+						ev.StreamId = stream;
+					}
 					var projection = serviceKey is null
 						? ctx.RequestServices.GetRequiredService<IProjection>()
 						: ctx.RequestServices.GetRequiredKeyedService<IProjection>(serviceKey);
@@ -145,9 +179,18 @@ public static class SynqraReplicationEndpointExtensions
 					try
 					{
 						var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, buffer);
-						foreach (var other in sockets)
+						foreach (var (other, otherStream) in sockets)
 						{
 							if (other == socket || other.State != WebSocketState.Open) { continue; }
+							// Only fan out to peers on the same stream as the event. Without this a
+							// client's event was broadcast to every connected socket regardless of
+							// stream — a live cross-tenant leak. Unscoped host (connectionStream null)
+							// → broadcast to all, as before. (connectionStream == ev.StreamId here,
+							// since inbound events were stamped with it above.)
+							if (!ReplicationStreamScope.Admits(otherStream, connectionStream))
+							{
+								continue;
+							}
 							try
 							{
 								await other.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
@@ -172,6 +215,13 @@ public static class SynqraReplicationEndpointExtensions
 				{
 					broadcastGate.Release();
 				}
+			}
+			}
+			finally
+			{
+				// Stop tracking a closed socket — otherwise the registry (and the broadcast loop
+				// that walks it) grew without bound across the server's lifetime.
+				sockets.TryRemove(socket, out _);
 			}
 		});
 

--- a/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
+++ b/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Synqra;
 using Synqra.AppendStorage;
 
@@ -50,6 +51,7 @@ public static class SynqraReplicationEndpointExtensions
 		app.Map(path, async ctx =>
 		{
 			var networkSerializationService = ctx.RequestServices.GetRequiredService<INetworkSerializationService>();
+			var logger = ctx.RequestServices.GetService<ILoggerFactory>()?.CreateLogger("Synqra.Replication.Endpoint");
 			if (!ctx.WebSockets.IsWebSocketRequest)
 			{
 				ctx.Response.StatusCode = 400;
@@ -195,9 +197,10 @@ public static class SynqraReplicationEndpointExtensions
 							{
 								await other.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
 							}
-							catch
+							catch (Exception broadcastEx)
 							{
 								// best-effort broadcast — a dead peer socket shouldn't fail this client's request
+								logger?.LogDebug(broadcastEx, "Synqra replication: dropping event {EventId} to a peer socket failed (peer likely gone).", ev.EventId);
 							}
 						}
 					}
@@ -206,10 +209,11 @@ public static class SynqraReplicationEndpointExtensions
 						ArrayPool<byte>.Shared.Return(buffer);
 					}
 				}
-				catch
+				catch (Exception eventEx)
 				{
 					// One bad event must not kill this whole connection (every other
 					// message on it, and the connection itself) — log and keep going.
+					logger?.LogWarning(eventEx, "Synqra replication: failed to apply/broadcast an inbound event on stream {Stream}; connection continues.", connectionStream);
 				}
 				finally
 				{

--- a/Tests/Synqra.Tests/ReplicationStreamScopeTests.cs
+++ b/Tests/Synqra.Tests/ReplicationStreamScopeTests.cs
@@ -1,0 +1,46 @@
+#if NET10_0_OR_GREATER
+using Synqra.Replication.AspNetCore;
+using TUnit.Assertions.Extensions;
+
+namespace Synqra.Tests;
+
+/// <summary>
+/// The stream-routing rule the WS replication endpoint applies in both directions (backlog replay
+/// and live broadcast). net10-only: <c>Synqra.Replication.AspNetCore</c> — like the endpoint it
+/// guards — targets net10 only. See <see cref="ReplicationStreamScope"/> for why one rule covers both.
+/// </summary>
+public class ReplicationStreamScopeTests
+{
+	static readonly Guid StreamA = Guid.NewGuid();
+	static readonly Guid StreamB = Guid.NewGuid();
+
+	[Test]
+	public async Task A_scoped_connection_admits_only_its_own_stream()
+	{
+		// The core isolation guarantee: a connection authorized for stream A sees A's events and
+		// nothing else. Before this rule the backlog and broadcast admitted every stream.
+		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA)).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(StreamB, StreamA)).IsFalse();
+	}
+
+	[Test]
+	public async Task A_scoped_connection_rejects_an_unstamped_or_zero_stream_event()
+	{
+		// A legacy/unstamped event (StreamId null or default) must NOT leak onto a scoped
+		// connection — the whole point of stamping inbound events and backfilling _sid.
+		await Assert.That(ReplicationStreamScope.Admits(null, StreamA)).IsFalse();
+		await Assert.That(ReplicationStreamScope.Admits(Guid.Empty, StreamA)).IsFalse();
+	}
+
+	[Test]
+	public async Task An_unscoped_connection_admits_everything()
+	{
+		// A single-tenant host establishes no stream scope (connectionStream null) — the endpoint
+		// then behaves exactly as it did before isolation: every event is delivered.
+		await Assert.That(ReplicationStreamScope.Admits(StreamA, null)).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(StreamB, null)).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(null, null)).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(Guid.Empty, null)).IsTrue();
+	}
+}
+#endif

--- a/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
+++ b/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
@@ -315,6 +315,12 @@ internal class SynqraTestNode
 				// broadcast protocol, kept in sync by hand — Synqra.Replication.AspNetCore
 				// (the real production endpoint) is net10.0-only, but this test project also
 				// builds for net8.0/net9.0, so it can't just call the real thing on every TFM.
+				//
+				// One intentional difference: the production endpoint additionally scopes backlog
+				// replay and broadcast to each connection's own stream (ReplicationStreamScope).
+				// This simulator is single-stream by construction (every node in a test shares one
+				// StreamId, and there is no per-connection stream scope here), so that filter would
+				// be a no-op — it is deliberately omitted rather than duplicated as dead code.
 
 				#region HELLO - from client
 				// 8 bytes magic + 16 bytes the client's own "last event id it already

--- a/Tests/Synqra.Tests/Synqra.Tests.csproj
+++ b/Tests/Synqra.Tests/Synqra.Tests.csproj
@@ -51,6 +51,8 @@
     <ProjectReference Include="..\..\Synqra.Projection.InMemory\Synqra.Projection.InMemory.csproj" />
     <ProjectReference Include="..\..\Synqra.Projection.MongoDb\Synqra.Projection.MongoDb.csproj" />
     <ProjectReference Include="..\..\Synqra.Projection.Sqlite\Synqra.Projection.Sqlite.csproj" Condition="'$(TargetFramework)'=='net10.0'" />
+    <!-- The production WS replication endpoint is net10-only; its stream-isolation test is too. -->
+    <ProjectReference Include="..\..\Synqra.Replication.AspNetCore\Synqra.Replication.AspNetCore.csproj" Condition="'$(TargetFramework)'=='net10.0'" />
     <ProjectReference Include="..\..\Synqra.Utils\Synqra.Utils.csproj" />
     <ProjectReference Include="..\..\Synqra\Synqra.csproj" />
     <ProjectReference Include="..\Synqra.Tests.TestHelpers\Synqra.Tests.TestHelpers.csproj" />


### PR DESCRIPTION
## What & why

The master-side WebSocket replication endpoint replayed and broadcast **every** event to **every** connected client, ignoring which stream each client was authorized for. On a multi-tenant deployment (Quotaly, where each user has their own Scene stream) that is a **cross-tenant data leak**: connect a socket, receive everyone's events. It also never removed a socket on disconnect, so the broadcast registry grew unbounded for the life of the process.

This is the isolation follow-up flagged when `_sid` stream persistence landed (Synqra #112/#114): now that every event durably carries its stream (`_sid`), the endpoint can and must route by it.

## The fix (server-only — the wire protocol is unchanged)

The stream a connection is authorized for is taken from the ambient `SynqraStreamContext` the **host** established for the request — for Quotaly that is the authenticated user's own stream, set by the auth middleware that wraps the whole read loop — and **never** from anything the client sends. `Event.StreamId` isn't even on the SBX wire; it arrives default and is stamped server-side.

- **Backlog replay** filters to the connection's own stream.
- **Inbound events** are stamped with the connection's stream before projection + append — authoritative `_sid`, and a client cannot inject an event into another user's stream no matter what it claims.
- **Live broadcast** fans out only to peers on the same stream.
- `ConcurrentBag<WebSocket>` → `ConcurrentDictionary<WebSocket, Guid?>`: each socket carries its stream tag and is removed on disconnect (O(1)), fixing the unbounded-growth leak.
- An **unscoped host** (`connectionStream` null — a single-tenant deployment) admits everything, exactly the prior behavior.

The routing decision is extracted into `ReplicationStreamScope.Admits(candidateStream, connectionStream)` and unit-tested directly (net10-only, via `InternalsVisibleTo`) rather than only through a live socket — deterministic, no WebSocket/timing flakiness.

## Tests

- New `ReplicationStreamScopeTests` (3 cases): scoped connection admits only its own stream; scoped connection rejects null/`Guid.Empty` (legacy unstamped) events; unscoped connection admits everything.
- Full suite green across all TFMs: **net10 184**, net8/9 181, 0 failed.

## Recommended follow-up (not in this PR)

- **End-to-end WS coverage** — the endpoint had **zero** e2e coverage before this. A real two-socket test (client A must not receive client B's event over a live socket) would guard the wiring, not just the rule. Deferred here to keep this change deterministic and reviewable; worth its own PR.

---

## Production-readiness backlog (brainstorm — for prioritization, not all in this PR)

This PR knocks out **#1**. The rest, ranked:

1. ✅ **WS replication stream isolation** — cross-tenant leak. *(this PR)*
2. **E2e WS isolation test** — lock the above in at the socket level (see follow-up above).
3. **Rate limiting / abuse protection** on the WS endpoint and any external ingestion — no per-connection or per-stream throttle today; one client can flood the broadcast gate.
4. **Scene-feature test coverage** — the ring/permalink/seed logic added this session has unit coverage on the layout algorithm but no integration coverage of the multi-stream union (Main Menu + personal stream).
5. **Health/readiness endpoints** — the auto-upgrade infra probes stores at boot but nothing exposes liveness/readiness for the orchestrator.
6. ✅ **Structured logging on the endpoint's swallowed catches** — the "one bad event mustn't kill the connection" and "best-effort broadcast" catches were silent; now logged (2nd commit in this PR). *(also this PR)*

Left for review per request — **do not merge**, this is for your eyes first.
