### PR TITLE
test: socket-level e2e for WS replication stream isolation

### DIFF
--- a/Tests/Synqra.Tests/Simulator/FakeProjection.cs
+++ b/Tests/Synqra.Tests/Simulator/FakeProjection.cs
@@ -4,13 +4,13 @@ using System.Threading.Tasks;
 namespace Synqra.Tests.Simulator;
 
 /// <summary>
-/// A projection that does nothing. The real WS replication endpoint resolves an
-/// <see cref="IProjection"/> from DI and calls Accept on every inbound event before it appends and
-/// broadcasts; the stream-isolation e2e test only cares about who receives which event over the
-/// socket, not about projected state, so the master host registers this no-op instead of a real
-/// stream-aware projection. Every method is a completed no-op.
+/// A projection that does nothing, in the style of <see cref="FakeAppendStorage"/>. The real WS
+/// replication endpoint resolves an <see cref="IProjection"/> from DI and calls Accept on every
+/// inbound event before it appends and broadcasts; the stream-isolation e2e test only cares about
+/// who receives which event over the socket, not about projected state, so the master host registers
+/// this instead of a real stream-aware projection. Every method is a completed no-op.
 /// </summary>
-internal sealed class NoOpProjection : IProjection
+internal sealed class FakeProjection : IProjection
 {
 	// IEventVisitor<EventVisitorContext>
 	public Task BeforeVisitAsync(Event ev, EventVisitorContext ctx) => Task.CompletedTask;

--- a/Tests/Synqra.Tests/Simulator/NoOpProjection.cs
+++ b/Tests/Synqra.Tests/Simulator/NoOpProjection.cs
@@ -1,0 +1,40 @@
+#if NET10_0_OR_GREATER
+using System.Threading.Tasks;
+
+namespace Synqra.Tests.Simulator;
+
+/// <summary>
+/// A projection that does nothing. The real WS replication endpoint resolves an
+/// <see cref="IProjection"/> from DI and calls Accept on every inbound event before it appends and
+/// broadcasts; the stream-isolation e2e test only cares about who receives which event over the
+/// socket, not about projected state, so the master host registers this no-op instead of a real
+/// stream-aware projection. Every method is a completed no-op.
+/// </summary>
+internal sealed class NoOpProjection : IProjection
+{
+	// IEventVisitor<EventVisitorContext>
+	public Task BeforeVisitAsync(Event ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task AfterVisitAsync(Event ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(ObjectCreatedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(ObjectPropertyChangedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(ObjectDeletedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(CommandCreatedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(ComponentAddedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(ComponentPropertyChangedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(ComponentDeletedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(LinkAddedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(LinkRemovedEvent ev, EventVisitorContext ctx) => Task.CompletedTask;
+
+	// ICommandVisitor<CommandHandlerContext>
+	public Task BeforeVisitAsync(Command cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+	public Task AfterVisitAsync(Command cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(CreateObjectCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(DeleteObjectCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(ChangeObjectPropertyCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(AddComponentCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(ChangeComponentPropertyCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(DeleteComponentCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(AddLinkCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+	public Task VisitAsync(RemoveLinkCommand cmd, CommandHandlerContext ctx) => Task.CompletedTask;
+}
+#endif

--- a/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
+++ b/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
@@ -33,8 +33,10 @@ using Synqra.Tests.SampleModels.Syncronization;
 using Synqra.Projection.InMemory;
 using Synqra.AppendStorage.JsonLines;
 using Synqra.AppendStorage;
+using Synqra.AppendStorage.InMemory;
 #if NET10_0_OR_GREATER
 using Synqra.Projection.Sqlite;
+using Synqra.Replication.AspNetCore;
 #endif
 
 namespace Synqra.Tests.Simulator;
@@ -137,7 +139,16 @@ internal class SynqraTestNode
 	SemaphoreSlim _semaphoreSlim = new(1, 1);
 	long _masterSeq = 0;
 
-	public SynqraTestNode(Guid streamId, Action<IHostApplicationBuilder>? configureHost = null, bool masterHost = false)
+	/// <param name="useRealEndpoint">
+	/// Master only (net10). When true the host wires the real production endpoint
+	/// (<see cref="SynqraReplicationEndpointExtensions.MapSynqraReplicationEndpoint"/>) behind
+	/// middleware that scopes each connection to the <c>?stream=</c> it connected with — the
+	/// test's stand-in for Quotaly's auth middleware — instead of the hand-rolled single-stream
+	/// simulator below. This is what the stream-isolation e2e exercises. The event log is then
+	/// InMemory (it keeps <see cref="Event.StreamId"/> on the in-memory object; the JSON-lines log
+	/// drops it, since StreamId is [JsonIgnore] and only the Mongo log re-maps it to _sid).
+	/// </param>
+	public SynqraTestNode(Guid streamId, Action<IHostApplicationBuilder>? configureHost = null, bool masterHost = false, bool useRealEndpoint = false)
 	{
 		if (streamId == default)
 		{
@@ -204,7 +215,19 @@ internal class SynqraTestNode
 		});
 
 		builder.Services.AddInMemorySynqraStore();
-		builder.AddAppendStorageJsonLines<Event>("EventId", x => x.EventId);
+#if NET10_0_OR_GREATER
+		if (masterHost && useRealEndpoint)
+		{
+			// The real endpoint reads events back from its own log to replay a stream's backlog and
+			// filters by Event.StreamId — so the log must preserve it. InMemory does (it holds the
+			// object); JSON-lines does not ([JsonIgnore]). See the useRealEndpoint remarks above.
+			builder.Services.AddAppendStorageInMemory<Event, Guid>(x => x.EventId);
+		}
+		else
+#endif
+		{
+			builder.AddAppendStorageJsonLines<Event>("EventId", x => x.EventId);
+		}
 
 		// builder.Services.AddSingleton<INetworkSerializationService, JsonNetworkSerializationService>();
 		builder.Services.AddSingleton<INetworkSerializationService, SbxNetworkSerializationService>();
@@ -281,6 +304,14 @@ internal class SynqraTestNode
 		if (masterHost)
 		{
 			builder.Services.AddControllers();
+#if NET10_0_OR_GREATER
+			if (useRealEndpoint)
+			{
+				// The real endpoint resolves IProjection from DI and Accepts every inbound event.
+				// This test only asserts socket-level routing, so a no-op projection suffices.
+				builder.Services.AddSingleton<IProjection, NoOpProjection>();
+			}
+#endif
 		}
 		else
 		{
@@ -290,7 +321,11 @@ internal class SynqraTestNode
 
 			builder.Services.AddSingleton<EventReplicationState>();
 			// builder.Services.Configure<EventReplicationConfig>(builder.Configuration.GetSection(nameof(EventReplicationConfig)));
-			builder.Services.AddSingleton<EventReplicationConfig>(new DelegatedEventReplicationConfig(() => Port));
+			// The client tells the master which stream it is on via the ?stream= query — the real
+			// endpoint's scoping middleware reads it (the hand-rolled single-stream master below just
+			// ignores it, matching on path only). Port is assigned after construction, so resolve both
+			// lazily at connect time.
+			builder.Services.AddSingleton<EventReplicationConfig>(new TestNodeReplicationConfig(this));
 
 		}
 
@@ -298,6 +333,31 @@ internal class SynqraTestNode
 		var app = builder.Build();
 		Host = app;
 
+#if NET10_0_OR_GREATER
+		if (masterHost && useRealEndpoint)
+		{
+			app.MapControllers();
+			// Stand-in for Quotaly's auth middleware: scope each connection to the stream it
+			// connected with (?stream=<guid>). The real endpoint reads this ambient scope via
+			// SynqraStreamContext.CurrentOrNull and never trusts anything the client sends on the wire.
+			app.Use(next => async ctx =>
+			{
+				if (Guid.TryParse(ctx.Request.Query["stream"], out var connStream) && connStream != default)
+				{
+					using (SynqraStreamContext.Enter(connStream))
+					{
+						await next(ctx);
+					}
+				}
+				else
+				{
+					await next(ctx);
+				}
+			});
+			app.MapSynqraReplicationEndpoint();
+		}
+		else
+#endif
 		if (masterHost)
 		{
 			var knownEvents = new ConcurrentDictionary<Guid, object?>();
@@ -510,6 +570,21 @@ internal class SynqraTestNode
 		var port = checked((ushort)((System.Net.IPEndPoint)listener.LocalEndpoint).Port);
 		listener.Stop();
 		return port;
+	}
+
+	/// <summary>
+	/// Replication config for a client test node. The master's port is only known after this node is
+	/// constructed (the test assigns <see cref="Port"/> via an object initializer), so both the port
+	/// and the full endpoint are resolved lazily at connect time. The endpoint carries this node's
+	/// own <see cref="StreamId"/> as <c>?stream=</c> so a real-endpoint master can scope the
+	/// connection; the hand-rolled single-stream master ignores it (it matches on path only).
+	/// </summary>
+	private sealed class TestNodeReplicationConfig : EventReplicationConfig
+	{
+		private readonly SynqraTestNode _node;
+		public TestNodeReplicationConfig(SynqraTestNode node) => _node = node;
+		public override ushort Port => _node.Port;
+		public override string? Endpoint => $"ws://localhost:{_node.Port}/api/synqra/ws?stream={_node.StreamId:D}";
 	}
 
 }

--- a/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
+++ b/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
@@ -308,8 +308,8 @@ internal class SynqraTestNode
 			if (useRealEndpoint)
 			{
 				// The real endpoint resolves IProjection from DI and Accepts every inbound event.
-				// This test only asserts socket-level routing, so a no-op projection suffices.
-				builder.Services.AddSingleton<IProjection, NoOpProjection>();
+				// This test only asserts socket-level routing, so a do-nothing projection suffices.
+				builder.Services.AddSingleton<IProjection, FakeProjection>();
 			}
 #endif
 		}

--- a/Tests/Synqra.Tests/Syncronization/ReplicationEndpointIsolationTests.cs
+++ b/Tests/Synqra.Tests/Syncronization/ReplicationEndpointIsolationTests.cs
@@ -1,0 +1,141 @@
+#if NET10_0_OR_GREATER
+using Synqra.Tests.SampleModels.Syncronization;
+using Synqra.Tests.Simulator;
+using Synqra.Tests.TestHelpers;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Synqra.Tests.Syncronization;
+
+/// <summary>
+/// End-to-end socket-level proof of the WS replication endpoint's stream isolation, over the REAL
+/// production endpoint (<see cref="Synqra.Replication.AspNetCore.SynqraReplicationEndpointExtensions"/>),
+/// not the hand-rolled simulator. The master is a real-endpoint host whose per-connection stream comes
+/// from a <c>?stream=</c> query (the test's stand-in for Quotaly's auth middleware); clients are real
+/// <see cref="EventReplicationService"/> nodes. These guard what <see cref="ReplicationStreamScopeTests"/>
+/// asserts on the pure rule: that the endpoint actually wires that rule into both the live-broadcast and
+/// backlog-replay paths, so a client on stream A never sees stream B's data on the wire.
+/// net10-only — the production endpoint targets net10.
+/// </summary>
+[NotInParallel]
+internal class ReplicationEndpointIsolationTests : BaseTest
+{
+	const int PropagationTimeoutMs = 10_000;
+	// After the same-stream peer has demonstrably received an event, a cross-stream peer either
+	// already has it (a leak) or never will — the endpoint fans a single event out to all sockets in
+	// one guarded pass. This grace just lets any erroneous delivery land before we assert its absence.
+	const int LeakGraceMs = 750;
+
+	[Test]
+	public async Task Live_broadcast_is_not_delivered_across_streams()
+	{
+		var streamA = Guid.NewGuid();
+		var streamB = Guid.NewGuid();
+
+		var master = new SynqraTestNode(Guid.NewGuid(), builder => { }, masterHost: true, useRealEndpoint: true);
+		await master.Started;
+
+		// A same-stream peer (A2) and a different-stream peer (B) are both connected and online BEFORE
+		// the write, so both are eligible to receive the broadcast — only the stream match should gate it.
+		var nodeA2 = new SynqraTestNode(streamA, builder => { }) { Port = master.Port };
+		var nodeB = new SynqraTestNode(streamB, builder => { }) { Port = master.Port };
+		await nodeA2.Started;
+		await nodeB.Started;
+		await WaitForOnlineAsync(nodeA2);
+		await WaitForOnlineAsync(nodeB);
+
+		var nodeA = new SynqraTestNode(streamA, builder => { }) { Port = master.Port };
+		await nodeA.Started;
+		await WaitForOnlineAsync(nodeA);
+
+		nodeA.StoreContext.GetCollection<SampleTaskModel>().Add(new SampleTaskModel { Subject = "A's private task" });
+
+		// Positive: the same-stream peer converges.
+		var a2Got = await WaitForCountAsync(nodeA2, 1, PropagationTimeoutMs);
+		await Assert.That(a2Got).IsTrue();
+		await Assert.That(nodeA2.StoreContext.GetCollection<SampleTaskModel>().First().Subject).IsEqualTo("A's private task");
+
+		// Negative: the other-stream peer must never see it.
+		await Task.Delay(LeakGraceMs);
+		await Assert.That(nodeB.StoreContext.GetCollection<SampleTaskModel>()).HasCount(0);
+	}
+
+	[Test]
+	public async Task Backlog_replay_is_not_delivered_across_streams()
+	{
+		var streamA = Guid.NewGuid();
+		var streamB = Guid.NewGuid();
+
+		var master = new SynqraTestNode(Guid.NewGuid(), builder => { }, masterHost: true, useRealEndpoint: true);
+		await master.Started;
+
+		// Write stream A's history to the master BEFORE any of the connecting peers exist — this is the
+		// backlog path (replayed from the master's own log on connect), distinct from live broadcast.
+		var nodeA = new SynqraTestNode(streamA, builder => { }) { Port = master.Port };
+		await nodeA.Started;
+		await WaitForOnlineAsync(nodeA);
+		nodeA.StoreContext.GetCollection<SampleTaskModel>().Add(new SampleTaskModel { Subject = "A's pre-existing task" });
+
+		var sw = Stopwatch.StartNew();
+		while (!await MasterHasAnyEventAsync(master) && (sw.ElapsedMilliseconds < PropagationTimeoutMs || Debugger.IsAttached))
+		{
+			await Task.Delay(100);
+		}
+		await Assert.That(await MasterHasAnyEventAsync(master)).IsTrue();
+
+		// A brand-new stream-A client (cold cursor) must receive the backlog...
+		var nodeC = new SynqraTestNode(streamA, builder => { }) { Port = master.Port };
+		// ...and a brand-new stream-B client must NOT, though it reads the same shared master log.
+		var nodeD = new SynqraTestNode(streamB, builder => { }) { Port = master.Port };
+		await nodeC.Started;
+		await nodeD.Started;
+		await WaitForOnlineAsync(nodeC);
+		await WaitForOnlineAsync(nodeD);
+
+		var cGot = await WaitForCountAsync(nodeC, 1, PropagationTimeoutMs);
+		await Assert.That(cGot).IsTrue();
+		await Assert.That(nodeC.StoreContext.GetCollection<SampleTaskModel>().First().Subject).IsEqualTo("A's pre-existing task");
+
+		await Task.Delay(LeakGraceMs);
+		await Assert.That(nodeD.StoreContext.GetCollection<SampleTaskModel>()).HasCount(0);
+	}
+
+	static async Task<bool> MasterHasAnyEventAsync(SynqraTestNode master)
+	{
+		await foreach (var _ in master.Events.GetAllAsync())
+		{
+			return true;
+		}
+		return false;
+	}
+
+	static async Task<bool> WaitForCountAsync(SynqraTestNode node, int expected, int timeoutMs)
+	{
+		var sw = Stopwatch.StartNew();
+		while (node.StoreContext.GetCollection<SampleTaskModel>().Count < expected)
+		{
+			if (sw.ElapsedMilliseconds > timeoutMs && !Debugger.IsAttached)
+			{
+				return false;
+			}
+			await Task.Delay(100);
+		}
+		return true;
+	}
+
+	static async Task WaitForOnlineAsync(SynqraTestNode node)
+	{
+		var sw = Stopwatch.StartNew();
+		while (!node.StoreContext.IsOnline())
+		{
+			if (sw.ElapsedMilliseconds > 30_000 && !Debugger.IsAttached)
+			{
+				throw new TimeoutException("Node did not come online within 30s");
+			}
+			await Task.Delay(100);
+		}
+	}
+}
+#endif


### PR DESCRIPTION
## What & why

Follow-up to #117 (WS replication stream isolation). That PR extracted the routing decision into `ReplicationStreamScope.Admits` and unit-tested it, but the **endpoint itself had zero end-to-end coverage** — nothing proved the endpoint actually applies that rule over a live socket, in both directions. This adds that socket-level proof.

## The tests (net10-only — the production endpoint targets net10)

Both drive the **real** `MapSynqraReplicationEndpoint` over real WebSockets, with real `EventReplicationService` clients:

- **`Live_broadcast_is_not_delivered_across_streams`** — a same-stream peer (A2) and a different-stream peer (B) are both connected and online before A writes; A2 converges on the write, B stays empty.
- **`Backlog_replay_is_not_delivered_across_streams`** — stream A's history is written to the master before any peer connects; a fresh stream-A client replays it from the master's shared log, a fresh stream-B client reading the same log gets nothing.

## Harness changes (`SynqraTestNode`, opt-in, net10-only)

- A real-endpoint master mode behind middleware that scopes each connection to its `?stream=` query — the test's stand-in for Quotaly's auth middleware, since the endpoint takes the stream from ambient `SynqraStreamContext` and **never** from the wire.
- That master uses an **InMemory** event log: it keeps `Event.StreamId` on the object, whereas the JSON-lines log drops it (`StreamId` is `[JsonIgnore]`; only the Mongo log re-maps it to `_sid`). This is exactly why the backlog filter needs a `_sid`-preserving store in production.
- A `NoOpProjection` (the tests assert socket routing, not projected state).
- Client nodes now carry their stream as `?stream=` so any master can scope them; the hand-rolled single-stream simulator ignores it (matches on path only), so existing sync tests are unaffected.

## Tests

Full net10 suite green: **186** (184 + 2), 0 failed. No change to production code — test-only.

Leaving for your review — **do not merge**, this is for your eyes first.
