### PR TITLE
Make client replication durable and repairable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
     <!-- Microsoft.Data packages -->
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.3" />
     <!-- Microsoft.EntityFrameworkCore packages -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />

--- a/Synqra.AppendStorage.Abstractions/IAppendStorage.cs
+++ b/Synqra.AppendStorage.Abstractions/IAppendStorage.cs
@@ -37,17 +37,3 @@ public interface IAppendStorage<T, TKey> : IDisposable, IAsyncDisposable
 #endif
 		;
 }
-
-/// <summary>
-/// Optional capability — implemented only where "wipe everything and resync fresh from the
-/// server" is a meaningful, safe recovery action (currently just a client's local IndexedDb
-/// cache; see <see cref="Synqra.BlobStorage.IClearableBlobStorage"/>). Not part of
-/// <see cref="IAppendStorage{T, TKey}"/> itself — File/Sqlite/Mongo-backed storage is the
-/// durable source of truth, not a disposable cache, so most implementations shouldn't have to
-/// implement this at all; check with an `is` pattern match instead (see
-/// EventReplicationService's own use of this).
-/// </summary>
-public interface IClearableAppendStorage
-{
-	Task ClearAllAsync(CancellationToken cancellationToken = default);
-}

--- a/Synqra.AppendStorage.BlobStorage/BlobAppendStorage.cs
+++ b/Synqra.AppendStorage.BlobStorage/BlobAppendStorage.cs
@@ -8,7 +8,7 @@ using Synqra.BlobStorage;
 
 namespace Synqra.AppendStorage.BlobStorage;
 
-public class BlobAppendStorage<T, TKey> : IAppendStorage<T, TKey>, IClearableAppendStorage
+public class BlobAppendStorage<T, TKey> : IAppendStorage<T, TKey>
 	where T : class
 	where TKey : notnull, IComparable<TKey>
 {
@@ -92,18 +92,6 @@ public class BlobAppendStorage<T, TKey> : IAppendStorage<T, TKey>, IClearableApp
 	public Task FlushAsync(CancellationToken cancellationToken = default)
 	{
 		return Task.CompletedTask;
-	}
-
-	public async Task ClearAllAsync(CancellationToken cancellationToken = default)
-	{
-		if (_blobStorage is not IClearableBlobStorage clearable)
-		{
-			throw new NotSupportedException($"{_blobStorage.GetType().Name} does not support clearing — only implementations of IClearableBlobStorage do.");
-		}
-		await clearable.ClearAllAsync(cancellationToken);
-		// The attached-objects cache would otherwise keep serving these same in-memory
-		// instances back out of GetAllAsync/GetAsync even though the backing store is empty.
-		_attachedObjectsById.Clear();
 	}
 
 	public void Dispose()

--- a/Synqra.BlobStorage.Abstractions/IBlobStorage.cs
+++ b/Synqra.BlobStorage.Abstractions/IBlobStorage.cs
@@ -31,15 +31,3 @@ public interface IBlobStorage<TKey> : IDisposable, IAsyncDisposable
 #endif
 		;
 }
-
-/// <summary>
-/// Optional capability — implemented only by backends where "wipe everything and resync
-/// fresh from the server" is a meaningful, safe recovery action (currently just IndexedDb,
-/// a disposable client-local cache). File/Sqlite/Mongo backends are the durable source of
-/// truth themselves, so they don't implement this; check with an `is` pattern match rather
-/// than adding it to <see cref="IBlobStorage{TKey}"/> itself.
-/// </summary>
-public interface IClearableBlobStorage
-{
-	Task ClearAllAsync(CancellationToken cancellationToken = default);
-}

--- a/Synqra.BlobStorage.IndexedDb/IndexedDbBlobStorage.cs
+++ b/Synqra.BlobStorage.IndexedDb/IndexedDbBlobStorage.cs
@@ -4,7 +4,7 @@ using Synqra.BlobStorage;
 
 namespace Synqra.BlobStorage.IndexedDb;
 
-internal class IndexedDbBlobStorage<TKey> : IBlobStorage<TKey>, IJsonMirrorBlobStorage<TKey>, IClearableBlobStorage
+internal class IndexedDbBlobStorage<TKey> : IBlobStorage<TKey>, IJsonMirrorBlobStorage<TKey>
 	where TKey : notnull, IComparable<TKey>
 {
 	private readonly IndexedDbJsInterop _indexedDbInterop;
@@ -92,12 +92,6 @@ internal class IndexedDbBlobStorage<TKey> : IBlobStorage<TKey>, IJsonMirrorBlobS
 			currentFrom = page[^1];
 			fromExclusive = true;
 		}
-	}
-
-	public async Task ClearAllAsync(CancellationToken cancellationToken = default)
-	{
-		await _initTask;
-		await _indexedDbInterop.ClearStoreAsync(_storeName);
 	}
 
 	public void Dispose()

--- a/Synqra.BlobStorage.Sqlite/SqliteBlobStorage.cs
+++ b/Synqra.BlobStorage.Sqlite/SqliteBlobStorage.cs
@@ -8,16 +8,17 @@ namespace Synqra.BlobStorage.Sqlite;
 public class SqliteBlobStorage<TKey> : IBlobStorage<TKey>
 	where TKey : notnull, IComparable<TKey>
 {
-	private readonly SqliteConnection _connection;
+	private readonly string _connectionString;
 	private readonly string _storeName;
 
 	public SqliteBlobStorage(SqliteBlobStorageOptions options, string storeName)
 	{
 		_storeName = storeName;
-		_connection = new SqliteConnection(options.ConnectionString);
-		_connection.Open();
+		_connectionString = options.ConnectionString;
+		EnsureDataSourceDirectory();
+		using var connection = OpenConnection();
 
-		using var cmd = _connection.CreateCommand();
+		using var cmd = connection.CreateCommand();
 		cmd.CommandText = """
 			CREATE TABLE IF NOT EXISTS blobs (
 				store_name TEXT NOT NULL,
@@ -28,7 +29,7 @@ public class SqliteBlobStorage<TKey> : IBlobStorage<TKey>
 			""";
 		cmd.ExecuteNonQuery();
 
-		using var pragma = _connection.CreateCommand();
+		using var pragma = connection.CreateCommand();
 		pragma.CommandText = """
 			PRAGMA journal_mode = WAL;
 			PRAGMA synchronous = NORMAL;
@@ -40,7 +41,8 @@ public class SqliteBlobStorage<TKey> : IBlobStorage<TKey>
 
 	public ValueTask<byte[]> ReadBlobAsync(TKey key, CancellationToken cancellationToken = default)
 	{
-		using var cmd = _connection.CreateCommand();
+		using var connection = OpenConnection();
+		using var cmd = connection.CreateCommand();
 		cmd.CommandText = "SELECT data FROM blobs WHERE store_name = @store_name AND id = @id";
 		cmd.Parameters.AddWithValue("@store_name", _storeName);
 		cmd.Parameters.AddWithValue("@id", EncodeKey(key));
@@ -55,8 +57,13 @@ public class SqliteBlobStorage<TKey> : IBlobStorage<TKey>
 
 	public ValueTask WriteBlobAsync(TKey key, ReadOnlyMemory<byte> blob, CancellationToken cancellationToken = default)
 	{
-		using var cmd = _connection.CreateCommand();
-		cmd.CommandText = "INSERT INTO blobs (store_name, id, data) VALUES (@store_name, @id, @data)";
+		using var connection = OpenConnection();
+		using var cmd = connection.CreateCommand();
+		cmd.CommandText = """
+			INSERT INTO blobs (store_name, id, data)
+			VALUES (@store_name, @id, @data)
+			ON CONFLICT(store_name, id) DO UPDATE SET data = excluded.data
+			""";
 		cmd.Parameters.AddWithValue("@store_name", _storeName);
 		cmd.Parameters.AddWithValue("@id", EncodeKey(key));
 		cmd.Parameters.AddWithValue("@data", blob.ToArray());
@@ -66,7 +73,8 @@ public class SqliteBlobStorage<TKey> : IBlobStorage<TKey>
 
 	public ValueTask DeleteBlobAsync(TKey key, CancellationToken cancellationToken = default)
 	{
-		using var cmd = _connection.CreateCommand();
+		using var connection = OpenConnection();
+		using var cmd = connection.CreateCommand();
 		cmd.CommandText = "DELETE FROM blobs WHERE store_name = @store_name AND id = @id";
 		cmd.Parameters.AddWithValue("@store_name", _storeName);
 		cmd.Parameters.AddWithValue("@id", EncodeKey(key));
@@ -76,7 +84,8 @@ public class SqliteBlobStorage<TKey> : IBlobStorage<TKey>
 
 	public async IAsyncEnumerable<TKey> EnumerateKeysAsync(TKey? from = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 	{
-		using var cmd = _connection.CreateCommand();
+		await using var connection = await OpenConnectionAsync(cancellationToken);
+		await using var cmd = connection.CreateCommand();
 
 		if (from is not null && !Equals(from, default(TKey)))
 		{
@@ -90,18 +99,29 @@ public class SqliteBlobStorage<TKey> : IBlobStorage<TKey>
 
 		cmd.Parameters.AddWithValue("@store_name", _storeName);
 
-		using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
+		await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
+		var keys = new List<TKey>();
 		while (await reader.ReadAsync(cancellationToken))
 		{
 			var blob = (byte[])reader.GetValue(0);
-			yield return DecodeKey(blob);
+			keys.Add(DecodeKey(blob));
+		}
+
+		foreach (var key in keys)
+		{
+			yield return key;
 		}
 	}
 
 	public void WriteBlob(TKey key, ReadOnlySpan<byte> blob)
 	{
-		using var cmd = _connection.CreateCommand();
-		cmd.CommandText = "INSERT INTO blobs (store_name, id, data) VALUES (@store_name, @id, @data)";
+		using var connection = OpenConnection();
+		using var cmd = connection.CreateCommand();
+		cmd.CommandText = """
+			INSERT INTO blobs (store_name, id, data)
+			VALUES (@store_name, @id, @data)
+			ON CONFLICT(store_name, id) DO UPDATE SET data = excluded.data
+			""";
 		cmd.Parameters.AddWithValue("@store_name", _storeName);
 		cmd.Parameters.AddWithValue("@id", EncodeKey(key));
 		cmd.Parameters.AddWithValue("@data", blob.ToArray());
@@ -110,7 +130,8 @@ public class SqliteBlobStorage<TKey> : IBlobStorage<TKey>
 
 	public void DeleteBlob(TKey key)
 	{
-		using var cmd = _connection.CreateCommand();
+		using var connection = OpenConnection();
+		using var cmd = connection.CreateCommand();
 		cmd.CommandText = "DELETE FROM blobs WHERE store_name = @store_name AND id = @id";
 		cmd.Parameters.AddWithValue("@store_name", _storeName);
 		cmd.Parameters.AddWithValue("@id", EncodeKey(key));
@@ -157,13 +178,42 @@ public class SqliteBlobStorage<TKey> : IBlobStorage<TKey>
 		(bytes[6], bytes[7]) = (bytes[7], bytes[6]);
 	}
 
-	public void Dispose()
+	private SqliteConnection OpenConnection()
 	{
-		_connection.Dispose();
+		var connection = new SqliteConnection(_connectionString);
+		connection.Open();
+		return connection;
 	}
 
-	public ValueTask DisposeAsync()
+	private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
 	{
-		return _connection.DisposeAsync();
+		var connection = new SqliteConnection(_connectionString);
+		await connection.OpenAsync(cancellationToken);
+		return connection;
 	}
+
+	private void EnsureDataSourceDirectory()
+	{
+		var connectionOptions = new SqliteConnectionStringBuilder(_connectionString);
+		var dataSource = connectionOptions.DataSource;
+		if (connectionOptions.Mode == SqliteOpenMode.Memory
+			|| string.Equals(dataSource, ":memory:", StringComparison.OrdinalIgnoreCase)
+			|| dataSource.StartsWith("file:", StringComparison.OrdinalIgnoreCase)
+		)
+		{
+			return;
+		}
+
+		var directory = Path.GetDirectoryName(Path.GetFullPath(dataSource));
+		if (directory is not null)
+		{
+			Directory.CreateDirectory(directory);
+		}
+	}
+
+	public void Dispose()
+	{
+	}
+
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/Synqra.Model/CommandSubmissionOptions.cs
+++ b/Synqra.Model/CommandSubmissionOptions.cs
@@ -15,6 +15,13 @@ namespace Synqra;
 public sealed class CommandSubmissionOptions
 {
 	/// <summary>
+	/// Event identities allocated during optimistic command execution. Replication transports these
+	/// identities with the command so authoritative execution preserves the same event lineage; event
+	/// payloads are still produced and validated exclusively by the server.
+	/// </summary>
+	public IReadOnlyList<Guid>? AllocatedEventIds { get; set; }
+
+	/// <summary>
 	/// Optimistic concurrency precondition — content-addressed, in the spirit of
 	/// <c>git push --force-with-lease=&lt;sha&gt;</c>.
 	/// <para>
@@ -37,4 +44,28 @@ public sealed class CommandSubmissionOptions
 	/// </para>
 	/// </summary>
 	public Guid ExpectedLastEventId { get; set; }
+
+	public void ApplyAllocatedEventIds(IReadOnlyList<Event> events)
+	{
+		if (AllocatedEventIds is null)
+		{
+			return;
+		}
+		if (AllocatedEventIds.Count != events.Count)
+		{
+			throw new InvalidDataException(
+				$"The command allocated {AllocatedEventIds.Count} event ids but produced {events.Count} events."
+			);
+		}
+		if (AllocatedEventIds.Any(x => x == Guid.Empty)
+			|| AllocatedEventIds.Distinct().Count() != AllocatedEventIds.Count
+		)
+		{
+			throw new InvalidDataException("Allocated event ids must be non-empty and unique.");
+		}
+		for (var i = 0; i < events.Count; i++)
+		{
+			events[i].EventId = AllocatedEventIds[i];
+		}
+	}
 }

--- a/Synqra.Model/IEventReplicationService.cs
+++ b/Synqra.Model/IEventReplicationService.cs
@@ -6,23 +6,26 @@ public interface IEventReplicationService
 	bool IsOnline { get; }
 
 	/// <summary>
-	/// Raised after one or more incoming server events have been appended to this client's local
-	/// durable event log. This service is transport-only — it does not touch any projection. The
-	/// projection owner (test node / client component) subscribes and brings its stream's projection
-	/// up to date via <see cref="IProjectionKeeper.MaintainAsync"/> (typically through
-	/// <see cref="IProjectionProvider.GetAsync"/>). The signal is stream-agnostic; each owner catches
-	/// up only its own stream (a no-op if nothing new arrived for it).
+	/// Raised when confirmed server events were appended to the logical projection sequence.
 	/// </summary>
 	event Action? EventsReceived;
 
-	void Trigger(Command command, IReadOnlyList<Event> events);
+	/// <summary>
+	/// Raised when repair or command acknowledgement changed an existing logical sequence and the
+	/// projection must be rebuilt before its active layer is replaced.
+	/// </summary>
+	event Action? RebuildRequired;
+
+	Task StageAsync(
+		  Command command
+		, IReadOnlyList<Event> events
+		, CommandSubmissionOptions? options = null
+		, CancellationToken cancellationToken = default
+	);
 
 	/// <summary>
-	/// Wipes this client's local durable event log, if the underlying storage supports it
-	/// (see <see cref="Synqra.AppendStorage.IClearableAppendStorage"/>) — a no-op otherwise.
-	/// Does not itself reconnect or reload anything: this is Synqra core and has no Blazor
-	/// dependency, so a caller (e.g. a "Force Resync" button) is responsible for reloading
-	/// the app afterward to actually rebuild state from the server's fully-synced backlog.
+	/// Drops the current transport connection so changed credentials or endpoint configuration
+	/// are applied by the next connection attempt.
 	/// </summary>
-	Task ClearLocalStorageAsync();
+	Task ReconnectAsync() => Task.CompletedTask;
 }

--- a/Synqra.Model/IProjectionKeeper.cs
+++ b/Synqra.Model/IProjectionKeeper.cs
@@ -103,4 +103,10 @@ public interface IProjectionFactory
 public interface IProjectionProvider
 {
     Task<IReplayProjection> GetAsync(Guid streamId, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Builds a fresh projection layer from the current logical event sequence and atomically makes
+	/// it the provider's active layer for this stream.
+	/// </summary>
+	Task<IReplayProjection> RebuildAsync(Guid streamId, CancellationToken cancellationToken = default);
 }

--- a/Synqra.Projection.File/_DI.cs
+++ b/Synqra.Projection.File/_DI.cs
@@ -363,7 +363,7 @@ public static class FileSynqraExtensions
 			// when ExpectedLastEventId is set here, callers get last-writer-wins semantics
 			// (the same behaviour Sqlite gives today). InMemoryProjection is the reference impl.
 			_ = options;
-			await _fileProjection.ProcessCommandAsync(newCommand);
+			await _fileProjection.ProcessCommandAsync(newCommand, options);
 		}
 	}
 
@@ -591,7 +591,10 @@ public static class FileSynqraExtensions
 		/// <param name="newCommand"></param>
 		/// <returns></returns>
 		/// <exception cref="Exception"></exception>
-		public async Task ProcessCommandAsync(ISynqraCommand newCommand)
+		public async Task ProcessCommandAsync(
+			  ISynqraCommand newCommand
+			, CommandSubmissionOptions? options = null
+		)
 		{
 			var commandHandlingContext = new CommandHandlerContext();
 			if (newCommand is not Command cmd)
@@ -612,17 +615,21 @@ public static class FileSynqraExtensions
 					$"Command stream {cmd.StreamId} does not match this store's stream {streamId} — refusing misrouted command {cmd.CommandId}.");
 			}
 			await cmd.AcceptAsync(this, commandHandlingContext);
+			options?.ApplyAllocatedEventIds(commandHandlingContext.Events);
+			if (_eventReplicationService is not null)
+			{
+				await _eventReplicationService.StageAsync(cmd, commandHandlingContext.Events, options);
+			}
 			var eventVisitorContext = new EventVisitorContext();
 			foreach (var @event in commandHandlingContext.Events)
 			{
 				await @event.AcceptAsync(this, eventVisitorContext); // error handling - how to rollback state of entire model?
 			}
-			if (_eventStorage != null)
+			if (_eventStorage != null && _eventReplicationService is null)
 			{
 				await _eventStorage.AppendBatchAsync(commandHandlingContext.Events); // store event in storage and trigger replication
 			}
 			CommandProcessed?.Invoke(this, EventArgs.Empty);
-			_eventReplicationService?.Trigger(cmd, commandHandlingContext.Events);
 		}
 
 		public async Task BeforeVisitAsync(Command cmd, CommandHandlerContext ctx)

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -499,13 +499,13 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			}
 		}
 
-		return ProcessCommandAsync(newCommand);
+		return ProcessCommandAsync(newCommand, options);
 	}
 
 	// [UnsupportedOSPlatform("browser")]
 	public void SubmitCommand(Command newCommand)
 	{
-		ProcessCommandAsync(newCommand).GetAwaiter().GetResult();
+		ProcessCommandAsync(newCommand, options: null).GetAwaiter().GetResult();
 	}
 
 	/// <summary>
@@ -525,7 +525,10 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	/// <summary>
 	/// Process and apply it locally
 	/// </summary>
-	private async Task ProcessCommandAsync(ISynqraCommand newCommand)
+	private async Task ProcessCommandAsync(
+		  ISynqraCommand newCommand
+		, CommandSubmissionOptions? options
+	)
 	{
 		var commandHandlingContext = new CommandHandlerContext();
 		if (newCommand is not Command cmd)
@@ -533,11 +536,16 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			throw new Exception("Only Syncra.Command can be an implementation of ICommand, please derive from Syncra.Command");
 		}
 		await cmd.AcceptAsync(this, commandHandlingContext);
+		options?.ApplyAllocatedEventIds(commandHandlingContext.Events);
+		if (_eventReplicationService is not null)
+		{
+			await _eventReplicationService.StageAsync(cmd, commandHandlingContext.Events, options);
+		}
 		foreach (var @event in commandHandlingContext.Events)
 		{
 			await ProcessEventAsync(@event); // error handling - how to rollback state of entire model?
 		}
-		if (_eventStorage != null)
+		if (_eventStorage != null && _eventReplicationService is null)
 		{
 			// Domain events are always durable. CommandCreatedEvents are only persisted when
 			// PersistCommandEvents is on — see that property for the temporary opt-out used by
@@ -548,7 +556,6 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			await _eventStorage.AppendBatchAsync(toStore); // store event in storage and trigger replication
 		}
 		CommandProcessed?.Invoke(this, EventArgs.Empty);
-		_eventReplicationService?.Trigger(cmd, commandHandlingContext.Events);
 	}
 
 	public event EventHandler<EventArgs>? CommandProcessed;

--- a/Synqra.Projection.InMemory/_ProjectionKeeper.cs
+++ b/Synqra.Projection.InMemory/_ProjectionKeeper.cs
@@ -105,6 +105,28 @@ public sealed class InMemoryProjectionProvider : IProjectionProvider
 			entry.Gate.Release();
 		}
 	}
+
+	public async Task<IReplayProjection> RebuildAsync(Guid streamId, CancellationToken cancellationToken = default)
+	{
+		if (streamId == default)
+		{
+			throw new ArgumentException("A non-default stream id is required.", nameof(streamId));
+		}
+		var entry = _byStream.GetOrAdd(streamId, _ => new Entry());
+		await entry.Gate.WaitAsync(cancellationToken);
+		try
+		{
+			var projection = _factory.Create(streamId);
+			await _keeper.MaintainAsync(projection, isReplay: true, cancellationToken: cancellationToken);
+			entry.Projection = projection;
+			entry.ColdLoaded = true;
+			return projection;
+		}
+		finally
+		{
+			entry.Gate.Release();
+		}
+	}
 }
 
 /// <summary>

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -237,13 +237,14 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 				soc.TargetTypeId = typeId;
 			}
 		}
-		return ProcessCommandAsync(cmd);
+		return ProcessCommandAsync(cmd, options);
 	}
 
-	async Task ProcessCommandAsync(Command cmd)
+	async Task ProcessCommandAsync(Command cmd, CommandSubmissionOptions? options)
 	{
 		var ctx = new CommandHandlerContext();
 		await cmd.AcceptAsync(this, ctx);
+		options?.ApplyAllocatedEventIds(ctx.Events);
 		foreach (var ev in ctx.Events)
 		{
 			await ev.AcceptAsync(this, null);

--- a/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
+++ b/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
@@ -4,227 +4,172 @@ using System.Net.WebSockets;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Synqra;
 using Synqra.AppendStorage;
 
 namespace Synqra.Replication.AspNetCore;
 
-/// <summary>
-/// Server (master) side of Synqra's event replication protocol — the counterpart to the
-/// client-side <see cref="EventReplicationService"/>. Extracted from the test-only
-/// simulator (Synqra.Tests/Simulator/SynqraTestNode.cs's master-host branch) into a
-/// reusable production endpoint: every event a connected client sends gets applied to
-/// this process's own <see cref="IProjection"/>, durably appended via this process's own
-/// <see cref="IAppendStorage{Event, Guid}"/> (so the server's own backing store — e.g.
-/// Mongo — is the thing that actually persists), and broadcast to every other connected
-/// client so they converge too.
-/// </summary>
 public static class SynqraReplicationEndpointExtensions
 {
-	/// <summary>
-	/// Wires the WebSocket replication endpoint at <paramref name="path"/> (default
-	/// matches <see cref="EventReplicationService"/>'s hardcoded client URL,
-	/// "/api/synqra/ws"). Resolves <see cref="INetworkSerializationService"/>,
-	/// <see cref="IProjection"/>, and <see cref="IAppendStorage{Event, Guid}"/> from DI —
-	/// register those (e.g. AddSbxSerializer + AddMongoDbSynqraStore +
-	/// AddAppendStorageMongoDb&lt;Event, Guid&gt;) before calling this.
-	/// <para>
-	/// Pass <paramref name="serviceKey"/> when the process hosts more than one independent
-	/// Synqra-backed feature — the endpoint will resolve <see cref="IProjection"/> and
-	/// <see cref="IAppendStorage{Event, Guid}"/> from the keyed DI slot so each feature
-	/// operates against its own store rather than sharing one global singleton.
-	/// </para>
-	/// </summary>
-	public static WebApplication MapSynqraReplicationEndpoint(this WebApplication app, string path = "/api/synqra/ws", string? serviceKey = null)
+	public static WebApplication MapSynqraReplicationEndpoint(
+		  this WebApplication app
+		, string path = "/api/synqra/ws"
+		, string? serviceKey = null
+	)
 	{
 		app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(20) });
-
-		// Each connected socket is tagged with the stream it is authorized for, so a broadcast
-		// only reaches peers on the same stream (see the broadcast loop below). Was a
-		// ConcurrentBag<WebSocket> — a set with no per-socket stream and, worse, no removal, so
-		// dead sockets accumulated forever. A dictionary gives both the stream tag and O(1)
-		// removal on disconnect.
 		var sockets = new ConcurrentDictionary<WebSocket, Guid?>();
-		var broadcastGate = new SemaphoreSlim(1, 1);
-		var knownEvents = new ConcurrentDictionary<Guid, object?>();
+		var transportGate = new SemaphoreSlim(1, 1);
 
-		app.Map(path, async ctx =>
+		app.Map(path, async context =>
 		{
-			var networkSerializationService = ctx.RequestServices.GetRequiredService<INetworkSerializationService>();
-			var logger = ctx.RequestServices.GetService<ILoggerFactory>()?.CreateLogger("Synqra.Replication.Endpoint");
-			if (!ctx.WebSockets.IsWebSocketRequest)
+			var logger = context.RequestServices
+				.GetService<ILoggerFactory>()?
+				.CreateLogger("Synqra.Replication.Endpoint");
+			if (!context.WebSockets.IsWebSocketRequest)
 			{
-				ctx.Response.StatusCode = 400;
+				context.Response.StatusCode = 400;
 				return;
 			}
-			using var socket = await ctx.WebSockets.AcceptWebSocketAsync();
 
-			// The stream this connection is authorized for, taken from the ambient
-			// SynqraStreamContext the host established for the request (for Quotaly that is the
-			// authenticated user's own stream, set by the auth middleware that wraps this whole
-			// connection's read loop). It is NEVER taken from anything the client sends — a client
-			// must not be able to name another user's stream. null means the host set no scope at
-			// all (a single-tenant deployment): everything below then behaves as before, unscoped.
+			var protocol = context.RequestServices.GetRequiredService<ReplicationProtocol>();
+			var networkSerializationService = context.RequestServices.GetRequiredService<INetworkSerializationService>();
+			using var socket = await context.WebSockets.AcceptWebSocketAsync();
 			var connectionStream = SynqraStreamContext.CurrentOrNull;
 
-			#region HELLO — from client
-			// 8 bytes magic + 16 bytes the client's own "last event id it already received
-			// from a server" cursor (Guid.Empty means "never synced, send me everything") —
-			// see EventReplicationState.LastEventIdFromServer's own remarks.
-			var helloBytes = await ReceiveFullMessageAsync(socket, ctx.RequestAborted);
-			if (helloBytes is null)
-			{
-				return;
-			}
-			if (helloBytes.Length != 24)
-			{
-				throw new InvalidOperationException($"Protocol negotiation failed: received {helloBytes.Length} bytes instead of 24.");
-			}
-			var magic = BitConverter.ToUInt64(helloBytes, 0);
-			if (magic != networkSerializationService.Magic)
-			{
-				throw new InvalidOperationException($"Protocol negotiation failed: received magic {magic:X16} instead of {networkSerializationService.Magic:X16}.");
-			}
-			var clientCursor = new Guid(helloBytes.AsSpan(8, 16));
-			#endregion
-
-			#region HELLO — to client, then replay this stream's backlog since clientCursor
-			// Register for broadcasts BEFORE answering HELLO, and do both — plus the backlog
-			// replay below — under the same gate as every broadcast SendAsync on this socket:
-			// the moment the client observes the HELLO reply, every later broadcast is
-			// guaranteed to reach it, and none of this can interleave with a concurrent
-			// broadcast write. Holding the gate for the whole backlog replay blocks other
-			// clients' broadcasts briefly — acceptable, this runs once per connection, and
-			// the file already accepts a single global semaphore over throughput elsewhere.
-			var magicBytes = BitConverter.GetBytes(networkSerializationService.Magic);
-			await broadcastGate.WaitAsync(ctx.RequestAborted);
 			try
 			{
-				sockets[socket] = connectionStream;
-				await socket.SendAsync(magicBytes, WebSocketMessageType.Binary, endOfMessage: true, ctx.RequestAborted);
+				var helloFrame = await ReceiveFullMessageAsync(socket, context.RequestAborted)
+					?? throw new InvalidOperationException("Client closed before sending replication hello.");
+				var hello = protocol.ReadHello(helloFrame);
+				if (hello.Magic != networkSerializationService.Magic)
+				{
+					throw new InvalidOperationException(
+						$"Replication magic {hello.Magic:X16} does not match {networkSerializationService.Magic:X16}."
+					);
+				}
 
-				var storage = serviceKey is null
-					? ctx.RequestServices.GetRequiredService<IAppendStorage<Event, Guid>>()
-					: ctx.RequestServices.GetRequiredKeyedService<IAppendStorage<Event, Guid>>(serviceKey);
-				var backlogBuffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
+				await transportGate.WaitAsync(context.RequestAborted);
 				try
 				{
-					await foreach (var ev in storage.GetAllAsync(from: clientCursor, ctx.RequestAborted))
-					{
-						// Replay only THIS connection's stream. The log is one shared multitenant
-						// collection; ev.StreamId (persisted as _sid) says which stream each event
-						// belongs to. Without this filter the backlog leaked every stream's events
-						// to any connecting client. Unscoped host (connectionStream null) → send all.
-						if (!ReplicationStreamScope.Admits(ev.StreamId, connectionStream))
-						{
-							continue;
-						}
-						knownEvents.TryAdd(ev.EventId, null);
-						var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, backlogBuffer);
-						await socket.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
-					}
+					sockets[socket] = connectionStream;
+					await SendAsync(
+						socket,
+						protocol.CreateHelloAccepted(networkSerializationService.Magic),
+						context.RequestAborted
+					);
+					await RepairConfirmedEventsAsync(
+						  context.RequestServices
+						, socket
+						, connectionStream
+						, hello.ConfirmedEvents
+						, protocol
+						, serviceKey
+						, context.RequestAborted
+					);
 				}
 				finally
 				{
-					ArrayPool<byte>.Shared.Return(backlogBuffer);
-				}
-			}
-			finally
-			{
-				broadcastGate.Release();
-			}
-			#endregion
-
-			try
-			{
-
-			while (!ctx.RequestAborted.IsCancellationRequested && socket.State == WebSocketState.Open)
-			{
-				var messageBytes = await ReceiveFullMessageAsync(socket, ctx.RequestAborted);
-				if (messageBytes is null)
-				{
-					break;
-				}
-				var operation = networkSerializationService.Deserialize<TransportOperation>(messageBytes);
-				if (operation is not NewEvent1 newEvent1)
-				{
-					throw new NotSupportedException($"Unsupported transport operation: {operation.GetType()}.");
-				}
-				if (!knownEvents.TryAdd(newEvent1.Event.EventId, null))
-				{
-					continue; // already applied/broadcast — e.g. an echo from this same client
+					transportGate.Release();
 				}
 
-				await broadcastGate.WaitAsync(ctx.RequestAborted);
-				try
+				while (!context.RequestAborted.IsCancellationRequested
+					&& socket.State == WebSocketState.Open
+				)
 				{
-					var ev = newEvent1.Event;
-					// The event's stream is set authoritatively from THIS connection's authorized
-					// stream — never trusted from the wire (Event.StreamId is not even on the SBX
-					// wire format; it arrives default). This both stamps _sid correctly on the
-					// durable append and forbids a client from injecting an event into any other
-					// stream: whatever it claims, the event is filed under the stream it connected as.
-					if (connectionStream is Guid stream)
+					var frame = await ReceiveFullMessageAsync(socket, context.RequestAborted);
+					if (frame is null)
 					{
-						ev.StreamId = stream;
+						break;
 					}
-					var projection = serviceKey is null
-						? ctx.RequestServices.GetRequiredService<IProjection>()
-						: ctx.RequestServices.GetRequiredKeyedService<IProjection>(serviceKey);
-					await ev.AcceptAsync<EventVisitorContext?>((IEventVisitor<EventVisitorContext?>)projection, null!);
-					var storage = serviceKey is null
-						? ctx.RequestServices.GetRequiredService<IAppendStorage<Event, Guid>>()
-						: ctx.RequestServices.GetRequiredKeyedService<IAppendStorage<Event, Guid>>(serviceKey);
-					await storage.AppendAsync(ev);
+					if (protocol.ReadKind(frame) != ReplicationFrameKind.SubmitCommand)
+					{
+						throw new InvalidDataException("The server accepts only command submissions after repair.");
+					}
 
-					var buffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
+					var submitted = protocol.ReadSubmittedCommand(frame);
+					if (connectionStream is Guid streamId)
+					{
+						submitted.Command.StreamId = streamId;
+					}
+
+					await transportGate.WaitAsync(context.RequestAborted);
 					try
 					{
-						var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, buffer);
-						foreach (var (other, otherStream) in sockets)
+						var storage = ResolveStorage(context.RequestServices, serviceKey);
+						var events = await ReadCommandEventsAsync(
+							storage,
+							submitted.Command.CommandId,
+							connectionStream,
+							context.RequestAborted
+						);
+						var wasAlreadyProcessed = events.Count > 0;
+						if (!wasAlreadyProcessed)
 						{
-							if (other == socket || other.State != WebSocketState.Open) { continue; }
-							// Only fan out to peers on the same stream as the event. Without this a
-							// client's event was broadcast to every connected socket regardless of
-							// stream — a live cross-tenant leak. Unscoped host (connectionStream null)
-							// → broadcast to all, as before. (connectionStream == ev.StreamId here,
-							// since inbound events were stamped with it above.)
-							if (!ReplicationStreamScope.Admits(otherStream, connectionStream))
+							var objectStore = await ResolveObjectStoreAsync(
+								  context.RequestServices
+								, serviceKey
+								, connectionStream
+								, context.RequestAborted
+							);
+							await objectStore.SubmitCommandAsync(submitted.Command, submitted.Options);
+							events = await ReadCommandEventsAsync(
+								storage,
+								submitted.Command.CommandId,
+								connectionStream,
+								context.RequestAborted
+							);
+						}
+
+						foreach (var ev in events)
+						{
+							if (connectionStream is Guid eventStream)
 							{
-								continue;
+								ev.StreamId = eventStream;
 							}
-							try
+							var eventFrame = protocol.CreateConfirmedEvent(ev);
+							foreach (var (peer, peerStream) in sockets)
 							{
-								await other.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
+								if (peer.State != WebSocketState.Open
+									|| wasAlreadyProcessed && peer != socket
+									|| !ReplicationStreamScope.Admits(peerStream, connectionStream)
+								)
+								{
+									continue;
+								}
+								await SendAsync(peer, eventFrame, context.RequestAborted);
 							}
-							catch (Exception broadcastEx)
-							{
-								// best-effort broadcast — a dead peer socket shouldn't fail this client's request
-								logger?.LogDebug(broadcastEx, "Synqra replication: dropping event {EventId} to a peer socket failed (peer likely gone).", ev.EventId);
-							}
+						}
+						await SendAsync(
+							socket,
+							protocol.CreateCommandAcknowledged(submitted.Command.CommandId),
+							context.RequestAborted
+						);
+					}
+					catch (Exception ex)
+					{
+						logger?.LogWarning(
+							ex,
+							"Synqra replication rejected command {CommandId} on stream {Stream}.",
+							submitted.Command.CommandId,
+							connectionStream
+						);
+						if (socket.State == WebSocketState.Open)
+						{
+							await SendAsync(
+								socket,
+								protocol.CreateCommandRejected(submitted.Command.CommandId, ex.Message),
+								context.RequestAborted
+							);
 						}
 					}
 					finally
 					{
-						ArrayPool<byte>.Shared.Return(buffer);
+						transportGate.Release();
 					}
 				}
-				catch (Exception eventEx)
-				{
-					// One bad event must not kill this whole connection (every other
-					// message on it, and the connection itself) — log and keep going.
-					logger?.LogWarning(eventEx, "Synqra replication: failed to apply/broadcast an inbound event on stream {Stream}; connection continues.", connectionStream);
-				}
-				finally
-				{
-					broadcastGate.Release();
-				}
-			}
 			}
 			finally
 			{
-				// Stop tracking a closed socket — otherwise the registry (and the broadcast loop
-				// that walks it) grew without bound across the server's lifetime.
 				sockets.TryRemove(socket, out _);
 			}
 		});
@@ -232,34 +177,143 @@ public static class SynqraReplicationEndpointExtensions
 		return app;
 	}
 
-	static async Task<byte[]?> ReceiveFullMessageAsync(WebSocket ws, CancellationToken ct)
+	private static async Task RepairConfirmedEventsAsync(
+		  IServiceProvider serviceProvider
+		, WebSocket socket
+		, Guid? connectionStream
+		, IReadOnlyDictionary<Guid, uint> clientDigests
+		, ReplicationProtocol protocol
+		, string? serviceKey
+		, CancellationToken cancellationToken
+	)
 	{
-		var rent = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
+		var remainingClientEvents = clientDigests.ToDictionary();
+		var storage = ResolveStorage(serviceProvider, serviceKey);
+		await foreach (var ev in storage.GetAllAsync(cancellationToken: cancellationToken))
+		{
+			if (!ReplicationStreamScope.Admits(ev.StreamId, connectionStream))
+			{
+				continue;
+			}
+			if (!remainingClientEvents.Remove(ev.EventId, out var clientHash)
+				|| clientHash != protocol.HashEvent(ev)
+			)
+			{
+				await SendAsync(socket, protocol.CreateConfirmedEvent(ev), cancellationToken);
+			}
+		}
+		foreach (var eventId in remainingClientEvents.Keys)
+		{
+			await SendAsync(socket, protocol.CreateDeleteConfirmedEvent(eventId), cancellationToken);
+		}
+		await SendAsync(socket, protocol.CreateRepairComplete(), cancellationToken);
+	}
+
+	private static async Task<List<Event>> ReadCommandEventsAsync(
+		  IAppendStorage<Event, Guid> storage
+		, Guid commandId
+		, Guid? connectionStream
+		, CancellationToken cancellationToken
+	)
+	{
+		var result = new List<Event>();
+		await foreach (var ev in storage.GetAllAsync(cancellationToken: cancellationToken))
+		{
+			if (ev.CommandId == commandId
+				&& ReplicationStreamScope.Admits(ev.StreamId, connectionStream)
+			)
+			{
+				result.Add(ev);
+			}
+		}
+		return result;
+	}
+
+	private static IAppendStorage<Event, Guid> ResolveStorage(
+		  IServiceProvider serviceProvider
+		, string? serviceKey
+	)
+	{
+		return serviceKey is null
+			? serviceProvider.GetRequiredService<IAppendStorage<Event, Guid>>()
+			: serviceProvider.GetRequiredKeyedService<IAppendStorage<Event, Guid>>(serviceKey);
+	}
+
+	private static async Task<IObjectStore> ResolveObjectStoreAsync(
+		  IServiceProvider serviceProvider
+		, string? serviceKey
+		, Guid? streamId
+		, CancellationToken cancellationToken
+	)
+	{
+		var store = serviceKey is null
+			? serviceProvider.GetService<IObjectStore>()
+			: serviceProvider.GetKeyedService<IObjectStore>(serviceKey);
+		if (store is not null)
+		{
+			return store;
+		}
+		if (streamId is not Guid stream || stream == Guid.Empty)
+		{
+			throw new InvalidOperationException(
+				"Replication requires an object store, or a projection provider and an authenticated stream."
+			);
+		}
+
+		var provider = serviceKey is null
+			? serviceProvider.GetService<IProjectionProvider>()
+			: serviceProvider.GetKeyedService<IProjectionProvider>(serviceKey);
+		if (provider is null)
+		{
+			throw new InvalidOperationException("No object store or projection provider is registered for replication.");
+		}
+		return (IObjectStore)await provider.GetAsync(stream, cancellationToken);
+	}
+
+	private static async Task<byte[]?> ReceiveFullMessageAsync(
+		  WebSocket socket
+		, CancellationToken cancellationToken
+	)
+	{
+		var buffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
 		try
 		{
-			using var ms = new MemoryStream(EventReplicationService.DefaultFrameSize);
-			while (!ct.IsCancellationRequested)
+			using var stream = new MemoryStream(EventReplicationService.DefaultFrameSize);
+			while (!cancellationToken.IsCancellationRequested)
 			{
-				var seg = new ArraySegment<byte>(rent);
-				var res = await ws.ReceiveAsync(seg, ct);
-				if (res.MessageType == WebSocketMessageType.Close)
+				var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+				if (result.MessageType == WebSocketMessageType.Close)
 				{
 					return null;
 				}
-				if (res.Count > 0)
+				if (result.Count > 0)
 				{
-					ms.Write(rent, 0, res.Count);
+					stream.Write(buffer, 0, result.Count);
 				}
-				if (res.EndOfMessage)
+				if (result.EndOfMessage)
 				{
-					break;
+					return stream.ToArray();
 				}
 			}
-			return ms.ToArray();
+			return null;
 		}
 		finally
 		{
-			ArrayPool<byte>.Shared.Return(rent);
+			ArrayPool<byte>.Shared.Return(buffer);
 		}
+	}
+
+	private static async Task SendAsync(
+		  WebSocket socket
+		, byte[] frame
+		, CancellationToken cancellationToken
+	)
+	{
+		await socket.SendAsync(
+			frame,
+			WebSocketMessageType.Binary,
+			endOfMessage: true,
+			cancellationToken
+		);
 	}
 }

--- a/Synqra/BlobClientEventStore.cs
+++ b/Synqra/BlobClientEventStore.cs
@@ -1,0 +1,351 @@
+using System.Runtime.CompilerServices;
+using Synqra.AppendStorage;
+using Synqra.BlobStorage;
+
+namespace Synqra;
+
+public sealed class BlobClientEventStore : IClientEventStore
+{
+	private readonly IBlobStorage<Guid> _confirmedStorage;
+	private readonly IBlobStorage<Guid> _pendingStorage;
+	private readonly ReplicationRecordCodec _codec;
+	private readonly SemaphoreSlim _gate = new(1, 1);
+
+	public BlobClientEventStore(
+		  IBlobStorage<Guid> confirmedStorage
+		, IBlobStorage<Guid> pendingStorage
+		, ReplicationRecordCodec codec
+	)
+	{
+		_confirmedStorage = confirmedStorage;
+		_pendingStorage = pendingStorage;
+		_codec = codec;
+	}
+
+	public async Task StageAsync(
+		  Command command
+		, IReadOnlyList<Event> events
+		, CommandSubmissionOptions? options = null
+		, CancellationToken cancellationToken = default
+	)
+	{
+		if (command.StreamId == Guid.Empty)
+		{
+			throw new ArgumentException("A pending command requires a stream id.", nameof(command));
+		}
+		if (events.Any(x => x.CommandId != command.CommandId))
+		{
+			throw new ArgumentException("Every optimistic event must belong to the staged command.", nameof(events));
+		}
+
+		var batch = new PendingCommandBatch
+		{
+			Command = command,
+			Events = events,
+			Options = options,
+		};
+		await _gate.WaitAsync(cancellationToken);
+		try
+		{
+			await _pendingStorage.WriteBlobAsync(
+				command.CommandId,
+				_codec.EncodePendingBatch(batch),
+				cancellationToken
+			);
+		}
+		finally
+		{
+			_gate.Release();
+		}
+	}
+
+	public async IAsyncEnumerable<PendingCommandBatch> GetPendingAsync(
+		  Guid streamId
+		, [EnumeratorCancellation] CancellationToken cancellationToken = default
+	)
+	{
+		foreach (var batch in await ReadPendingAsync(cancellationToken))
+		{
+			if (batch.Command.StreamId == streamId)
+			{
+				yield return batch;
+			}
+		}
+	}
+
+	public async IAsyncEnumerable<ConfirmedEventDigest> GetConfirmedDigestsAsync(
+		  Guid streamId
+		, [EnumeratorCancellation] CancellationToken cancellationToken = default
+	)
+	{
+		foreach (var record in await ReadConfirmedRecordsAsync(cancellationToken))
+		{
+			var ev = _codec.DecodeConfirmedRecord(record.Data);
+			if (ev.StreamId == streamId)
+			{
+				yield return new ConfirmedEventDigest(ev.EventId, _codec.HashConfirmedRecord(record.Data));
+			}
+		}
+	}
+
+	public async Task<ClientEventStoreChange> UpsertConfirmedAsync(Event ev, CancellationToken cancellationToken = default)
+	{
+		if (ev.StreamId == Guid.Empty)
+		{
+			throw new ArgumentException("A confirmed event requires a stream id.", nameof(ev));
+		}
+
+		await _gate.WaitAsync(cancellationToken);
+		try
+		{
+			var hiddenByPendingBatch = await PendingExistsAsync(ev.CommandId, cancellationToken);
+			var hasPendingTail = await HasPendingForStreamAsync(ev.StreamId, cancellationToken);
+			var existing = await TryReadConfirmedAsync(ev.EventId, cancellationToken);
+			var encoded = _codec.EncodeConfirmedRecord(ev);
+			if (existing is not null && existing.AsSpan().SequenceEqual(encoded))
+			{
+				return ClientEventStoreChange.None;
+			}
+			await _confirmedStorage.WriteBlobAsync(
+				ev.EventId,
+				encoded,
+				cancellationToken
+			);
+			if (hiddenByPendingBatch)
+			{
+				return ClientEventStoreChange.None;
+			}
+			if (hasPendingTail)
+			{
+				return ClientEventStoreChange.Rebuild;
+			}
+			return existing is null
+				? ClientEventStoreChange.Append
+				: ClientEventStoreChange.Rebuild;
+		}
+		finally
+		{
+			_gate.Release();
+		}
+	}
+
+	public async Task<ClientEventStoreChange> DeleteConfirmedAsync(Guid eventId, CancellationToken cancellationToken = default)
+	{
+		await _gate.WaitAsync(cancellationToken);
+		try
+		{
+			var record = await TryReadConfirmedAsync(eventId, cancellationToken);
+			if (record is null)
+			{
+				return ClientEventStoreChange.None;
+			}
+
+			var ev = _codec.DecodeConfirmedRecord(record);
+			var hiddenByPendingBatch = await PendingExistsAsync(ev.CommandId, cancellationToken);
+			await _confirmedStorage.DeleteBlobAsync(eventId, cancellationToken);
+			return hiddenByPendingBatch
+				? ClientEventStoreChange.None
+				: ClientEventStoreChange.Rebuild;
+		}
+		finally
+		{
+			_gate.Release();
+		}
+	}
+
+	public async Task<ClientEventStoreChange> AcknowledgeAsync(Guid commandId, CancellationToken cancellationToken = default)
+	{
+		await _gate.WaitAsync(cancellationToken);
+		try
+		{
+			var pending = await TryReadPendingAsync(commandId, cancellationToken);
+			if (pending is null)
+			{
+				return ClientEventStoreChange.None;
+			}
+			var confirmedMatches = true;
+			foreach (var optimisticEvent in pending.Events)
+			{
+				var confirmedRecord = await TryReadConfirmedAsync(
+					optimisticEvent.EventId,
+					cancellationToken
+				);
+				if (confirmedRecord is null
+					|| !_codec.SerializeEvent(optimisticEvent).AsSpan().SequenceEqual(
+						_codec.SerializeEvent(_codec.DecodeConfirmedRecord(confirmedRecord))
+					)
+				)
+				{
+					confirmedMatches = false;
+					break;
+				}
+			}
+			await _pendingStorage.DeleteBlobAsync(commandId, cancellationToken);
+			return confirmedMatches
+				? ClientEventStoreChange.None
+				: ClientEventStoreChange.Rebuild;
+		}
+		finally
+		{
+			_gate.Release();
+		}
+	}
+
+	public async Task AppendAsync(Event item, CancellationToken cancellationToken = default)
+	{
+		await UpsertConfirmedAsync(item, cancellationToken);
+	}
+
+	public async Task AppendBatchAsync(IEnumerable<Event> items, CancellationToken cancellationToken = default)
+	{
+		foreach (var item in items)
+		{
+			await UpsertConfirmedAsync(item, cancellationToken);
+		}
+	}
+
+	public async Task<Event> GetAsync(Guid key, CancellationToken cancellationToken = default)
+	{
+		await foreach (var ev in GetAllAsync(cancellationToken: cancellationToken))
+		{
+			if (ev.EventId == key)
+			{
+				return ev;
+			}
+		}
+		throw new KeyNotFoundException($"Event {key} was not found in confirmed or pending client storage.");
+	}
+
+	public async IAsyncEnumerable<Event> GetAllAsync(
+		  Guid from = default
+		, [EnumeratorCancellation] CancellationToken cancellationToken = default
+	)
+	{
+		var pending = await ReadPendingAsync(cancellationToken);
+		var pendingCommandIds = pending.Select(x => x.Command.CommandId).ToHashSet();
+		foreach (var record in await ReadConfirmedRecordsAsync(cancellationToken))
+		{
+			var ev = _codec.DecodeConfirmedRecord(record.Data);
+			if (!pendingCommandIds.Contains(ev.CommandId)
+				&& IsAtOrAfter(ev.EventId, from)
+			)
+			{
+				yield return ev;
+			}
+		}
+		foreach (var batch in pending)
+		{
+			foreach (var ev in batch.Events)
+			{
+				if (IsAtOrAfter(ev.EventId, from))
+				{
+					yield return ev;
+				}
+			}
+		}
+	}
+
+	public Task FlushAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+	public void Dispose()
+	{
+	}
+
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+	private async Task<List<PendingCommandBatch>> ReadPendingAsync(CancellationToken cancellationToken)
+	{
+		var result = new List<PendingCommandBatch>();
+		await foreach (var key in _pendingStorage.EnumerateKeysAsync(cancellationToken: cancellationToken))
+		{
+			var data = await _pendingStorage.ReadBlobAsync(key, cancellationToken);
+			result.Add(_codec.DecodePendingBatch(data));
+		}
+		return result;
+	}
+
+	private async Task<List<ConfirmedRecord>> ReadConfirmedRecordsAsync(CancellationToken cancellationToken)
+	{
+		var result = new List<ConfirmedRecord>();
+		await foreach (var key in _confirmedStorage.EnumerateKeysAsync(cancellationToken: cancellationToken))
+		{
+			result.Add(new ConfirmedRecord
+			{
+				EventId = key,
+				Data = (await _confirmedStorage.ReadBlobAsync(key, cancellationToken)).ToArray(),
+			});
+		}
+		return result;
+	}
+
+	private async Task<byte[]?> TryReadConfirmedAsync(Guid eventId, CancellationToken cancellationToken)
+	{
+		await foreach (var key in _confirmedStorage.EnumerateKeysAsync(cancellationToken: cancellationToken))
+		{
+			if (key == eventId)
+			{
+				return (await _confirmedStorage.ReadBlobAsync(key, cancellationToken)).ToArray();
+			}
+		}
+		return null;
+	}
+
+	private async Task<bool> PendingExistsAsync(Guid commandId, CancellationToken cancellationToken)
+	{
+		await foreach (var key in _pendingStorage.EnumerateKeysAsync(cancellationToken: cancellationToken))
+		{
+			if (key == commandId)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private async Task<bool> HasPendingForStreamAsync(
+		  Guid streamId
+		, CancellationToken cancellationToken
+	)
+	{
+		await foreach (var key in _pendingStorage.EnumerateKeysAsync(cancellationToken: cancellationToken))
+		{
+			var batch = _codec.DecodePendingBatch(
+				await _pendingStorage.ReadBlobAsync(key, cancellationToken)
+			);
+			if (batch.Command.StreamId == streamId)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private async Task<PendingCommandBatch?> TryReadPendingAsync(
+		  Guid commandId
+		, CancellationToken cancellationToken
+	)
+	{
+		await foreach (var key in _pendingStorage.EnumerateKeysAsync(cancellationToken: cancellationToken))
+		{
+			if (key == commandId)
+			{
+				return _codec.DecodePendingBatch(
+					await _pendingStorage.ReadBlobAsync(key, cancellationToken)
+				);
+			}
+		}
+		return null;
+	}
+
+	private static bool IsAtOrAfter(Guid eventId, Guid from)
+	{
+		return from == Guid.Empty
+			|| eventId.CompareTo(from) >= 0;
+	}
+
+	private sealed class ConfirmedRecord
+	{
+		public required Guid EventId { get; init; }
+		public required byte[] Data { get; init; }
+	}
+}

--- a/Synqra/EventReplicationConfig.cs
+++ b/Synqra/EventReplicationConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Net.WebSockets;
 
 namespace Synqra;
 
@@ -9,10 +10,22 @@ public class EventReplicationConfig
 
 	/// <summary>
 	/// Full WebSocket endpoint URI for the replication master. When set, overrides the default
-	/// <c>ws://localhost:{Port}/api/synqra/ws</c> construction so the WASM client can connect to
+	/// <c>ws://localhost:{Port}/api/synqra/ws</c> construction so a client can connect to
 	/// the correct remote host in deployed environments.
 	/// </summary>
 	public virtual string? Endpoint { get; set; }
+
+	/// <summary>
+	/// Configures a new WebSocket before each connection attempt. Return false when the client
+	/// is not currently eligible to connect, for example while it has no authenticated session.
+	/// </summary>
+	public Func<ClientWebSocket, CancellationToken, Task<bool>>? ConfigureWebSocketAsync { get; set; }
+
+	/// <summary>
+	/// Resolves the local stream whose confirmed records and pending commands should participate in
+	/// this connection. The server still derives the authoritative stream from authentication.
+	/// </summary>
+	public Func<CancellationToken, Task<Guid?>>? ResolveStreamIdAsync { get; set; }
 
 	internal Uri ResolveEndpointUri() =>
 		Endpoint is not null ? new Uri(Endpoint) : new Uri($"ws://localhost:{Port}/api/synqra/ws");

--- a/Synqra/EventReplicationService.cs
+++ b/Synqra/EventReplicationService.cs
@@ -1,320 +1,328 @@
-﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Synqra.AppendStorage;
-using System;
 using System.Buffers;
-using System.ComponentModel.DataAnnotations;
 using System.Net.WebSockets;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Synqra;
 
-/// <summary>
-/// Client-side service that connect to WS Master
-/// </summary>
-public class EventReplicationService : BackgroundService, IEventReplicationService
+public sealed class EventReplicationService : BackgroundService, IEventReplicationService
 {
 	public const int DefaultFrameSize = 8192;
 
-	private readonly IAppendStorage<Event, Guid> _storage;
-	private readonly EventReplicationState _eventReplicationState;
-	private readonly JsonSerializerContext? _jsonSerializerContext;
-	private readonly EventReplicationConfig _config;
-
+	private readonly IClientEventStore _storage;
 	private readonly INetworkSerializationService _networkSerializationService;
-
-	private SemaphoreSlim _autoResetEvent = new SemaphoreSlim(0, 1);
-	private CancellationTokenSource _cts = new CancellationTokenSource();
-
-	volatile bool _isOnline;
-	public bool IsOnline { get => _isOnline; private set => _isOnline = value; }
-
-	private Task? _readerTask;
-
-	/// <inheritdoc />
-	public event Action? EventsReceived;
+	private readonly ReplicationProtocol _protocol;
+	private readonly EventReplicationConfig _config;
+	private readonly SemaphoreSlim _pendingSignal = new(0, 1);
+	private readonly object _connectionLock = new();
+	private CancellationTokenSource? _connectionCts;
+	private volatile bool _isOnline;
 
 	public EventReplicationService(
 		  IOptions<EventReplicationConfig> options
-		, IAppendStorage<Event, Guid> storage
-		, EventReplicationState eventReplicationState
+		, IClientEventStore storage
 		, INetworkSerializationService networkSerializationService
-		, JsonSerializerContext? jsonSerializerContext = null
+		, ReplicationProtocol protocol
 		, EventReplicationConfig? config = null
-		)
+	)
 	{
 		_storage = storage;
-		_eventReplicationState = eventReplicationState;
 		_networkSerializationService = networkSerializationService;
-		_jsonSerializerContext = jsonSerializerContext;
+		_protocol = protocol;
 		_config = config ?? options.Value;
 	}
 
-	HashSet<Guid> _skipSet = new HashSet<Guid>();
-	LinkedList<Guid> _skipList = new LinkedList<Guid>();
+	public bool IsOnline => _isOnline;
 
-	static async Task<byte[]?> ReceiveFullMessageAsync(WebSocket ws, CancellationToken ct)
+	public event Action? EventsReceived;
+	public event Action? RebuildRequired;
+
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 	{
-		var rent = ArrayPool<byte>.Shared.Rent(DefaultFrameSize);
-		try
+		while (!stoppingToken.IsCancellationRequested)
 		{
-			using var ms = new MemoryStream(DefaultFrameSize);
-			while (!ct.IsCancellationRequested)
+			using var wsConnection = new ClientWebSocket();
+			using var connectionCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+			lock (_connectionLock)
 			{
-				var seg = new ArraySegment<byte>(rent);
-				var res = await ws.ReceiveAsync(seg, ct);
-				if (res.MessageType == WebSocketMessageType.Close)
-				{
-					return null;
-				}
-
-				if (res.Count > 0)
-				{
-					ms.Write(rent, 0, res.Count);
-				}
-
-				if (res.EndOfMessage)
-				{
-					break;
-				}
+				_connectionCts = connectionCts;
 			}
-			return ms.ToArray();
-		}
-		finally
-		{
-			ArrayPool<byte>.Shared.Return(rent);
-		}
-	}
 
-	protected async override Task ExecuteAsync(CancellationToken stoppingToken)
-	{
-		// Seed the by-EventId dedup (_skipSet/_skipList, otherwise only populated as events are
-		// received live) from whatever's already durably stored locally. Without this, the server's
-		// backlog replay on reconnect (see SynqraReplicationEndpointExtensions.cs) would be echoed
-		// straight back to it by the outgoing loop below. This service is transport-only: it never
-		// touches a projection — the projection owner brings its stream up to date via the keeper on
-		// the EventsReceived signal (and on first use through IProjectionProvider.GetAsync).
-		//
-		// A corrupt/undeserializable local record here means this client's local durable log can no
-		// longer be trusted at all — clear it and continue with an empty skip-set and a cold
-		// LastEventIdFromServer, which is a correct and safe "send me everything" signal, not a bug.
-		try
-		{
-			await foreach (var ev in _storage.GetAllAsync(from: default))
-			{
-				lock (_skipSet)
-				{
-					if (_skipSet.Add(ev.EventId))
-					{
-						_skipList.AddLast(ev.EventId);
-					}
-				}
-			}
-		}
-		catch (Exception ex)
-		{
-			EmergencyLog.Default.LogWarning(ex, "EventReplicationService: local durable log failed to replay — clearing it and resyncing fresh from the server.");
-			await ClearLocalStorageAsync();
-		}
-
-		ClientWebSocket wsConnection;
-		for (int i = 0; ; i++)
-		{
 			try
 			{
-				wsConnection = new ClientWebSocket();
-				await wsConnection.ConnectAsync(_config.ResolveEndpointUri(), _cts.Token);
-				_networkSerializationService.Reinitialize();
-				// Not online yet — that is declared only after the HELLO handshake completes,
-				// when the master is guaranteed to have registered this node for broadcasts.
-				break;
-			}
-			catch (Exception ex) when (i < 10)
-			{
-				EmergencyLog.Default.LogWarning(ex, $"EventReplicationService: connect attempt {i} failed: {ex.Message}");
-				await Task.Delay(1000);
-			}
-		}
-
-		async Task Reader()
-		{
-			#region HELLO
-			var magicBytes = await ReceiveFullMessageAsync(wsConnection, _cts.Token);
-			if (magicBytes == null || magicBytes.Length == 0)
-			{
-				IsOnline = false;
-				return;
-			}
-			if (magicBytes.Length != 8)
-			{
-				var sb = new System.Text.StringBuilder();
-				new HexDumpWriter().HexDump(magicBytes, s => sb.Append(s), c => sb.Append(c));
-				throw new Exception($"Protocol Negotiation Failed! Received {magicBytes.Length} bytes instead of 8. {Environment.NewLine}{sb}");
-			}
-			var magic = BitConverter.ToUInt64(magicBytes);
-			if (magic != _networkSerializationService.Magic)
-			{
-				throw new Exception($"Protocol Negotiation Failed! Received Magic {magic:X16} instead of {_networkSerializationService.Magic:X16}.");
-			}
-			IsOnline = true; // the master registers the socket before answering HELLO, so from here on broadcasts include this node
-			#endregion
-			while (!_cts.IsCancellationRequested)
-			{
-				var bytes = await ReceiveFullMessageAsync(wsConnection, _cts.Token);
-				if (bytes == null || bytes.Length == 0)
+				var streamId = await ResolveStreamIdAsync(connectionCts.Token);
+				if (streamId == Guid.Empty
+					|| _config.ConfigureWebSocketAsync is not null
+					&& !await _config.ConfigureWebSocketAsync(wsConnection, connectionCts.Token)
+				)
 				{
-					IsOnline = false;
-					break;
+					await Task.Delay(TimeSpan.FromSeconds(2), stoppingToken);
+					continue;
 				}
-				var operation = _networkSerializationService.Deserialize<TransportOperation>(bytes);
-				switch (operation)
-				{
-					case NewEvent1 ne1:
-						await _storage.AppendAsync(ne1.Event);
-						EmergencyLog.Default.LogInformation($"{GetHashCode():X4} <<< {ne1.Event}");
-						// Transport-only: dedup so the outgoing loop never echoes a server event back,
-						// then notify the projection owner to fold in the delta via the keeper. The
-						// event is already durably stored, so a missed/awaited-late notification is
-						// harmless — the owner also catches up on next use through the provider.
-						lock (_skipSet)
-						{
-							if (_skipSet.Add(ne1.Event.EventId))
-							{
-								_skipList.AddLast(ne1.Event.EventId);
-							}
-						}
-						// Tracks how far this client's backlog catch-up has progressed —
-						// applies to both a genuine live event and one the server resent as
-						// backlog (see the HELLO region above); mirrors LastEventIdFromMe's
-						// own bookkeeping for outgoing events.
-						_eventReplicationState.LastEventIdFromServer = ne1.Event.EventId;
-						EventsReceived?.Invoke();
-						break;
-					default:
-						throw new NotSupportedException();
-				}
-			}
-		}
-		_readerTask = Reader();
 
-		#region HELLO
-		{
-			// 8 bytes magic + 16 bytes LastEventIdFromServer — tells the server exactly
-			// where this client's backlog catch-up should resume from (Guid.Empty means
-			// "never synced, send me everything"). See SynqraReplicationEndpointExtensions.cs's
-			// own remarks on the server side of this handshake.
-			var buffer = ArrayPool<byte>.Shared.Rent(24);
-			try
+				await wsConnection.ConnectAsync(_config.ResolveEndpointUri(), connectionCts.Token);
+				await RepairConfirmedEventsAsync(wsConnection, streamId, connectionCts.Token);
+				_isOnline = true;
+
+				var readerTask = ReadAsync(wsConnection, streamId, connectionCts.Token);
+				var writerTask = WriteAsync(wsConnection, streamId, connectionCts.Token);
+				await Task.WhenAny(readerTask, writerTask);
+				await connectionCts.CancelAsync();
+				await Task.WhenAll(readerTask, writerTask);
+			}
+			catch (OperationCanceledException) when (connectionCts.IsCancellationRequested)
 			{
-				BitConverter.TryWriteBytes(buffer, _networkSerializationService.Magic);
-				_eventReplicationState.LastEventIdFromServer.TryWriteBytes(buffer.AsSpan(8, 16));
-				await wsConnection.SendAsync(new ArraySegment<byte>(buffer, 0, 24), WebSocketMessageType.Binary, endOfMessage: true, _cts.Token);
+			}
+			catch (Exception ex)
+			{
+				EmergencyLog.Default.LogWarning(ex, $"EventReplicationService: connection failed: {ex.Message}");
 			}
 			finally
 			{
-				ArrayPool<byte>.Shared.Return(buffer);
-			}
-		}
-		#endregion
-
-		var myEnumerable = _storage.GetAllAsync(from: _eventReplicationState.LastEventIdFromMe);
-		await using var myEnumerator = myEnumerable.GetAsyncEnumerator(_cts.Token);
-		while (true)
-		{
-			await _autoResetEvent.WaitAsync();
-			EmergencyLog.Default.LogInformation($"{GetHashCode():X4} >>> <TRIGGERED LOOP>");
-			if (_cts.IsCancellationRequested)
-			{
-				break;
-			}
-			// get new events from storage and send them to server
-			while (await myEnumerator.MoveNextAsync())
-			{
-				var ev = myEnumerator.Current;
-				lock (_skipSet)
+				_isOnline = false;
+				lock (_connectionLock)
 				{
-					if (_skipSet.Add(ev.EventId))
+					if (ReferenceEquals(_connectionCts, connectionCts))
 					{
-						_skipList.AddLast(ev.EventId);
+						_connectionCts = null;
 					}
 				}
-				// await _connection.InvokeAsync("NewEvent1", ev);
-
-				var inv = new NewEvent1() { Event = ev };
-
-				//var bytes = JsonSerializer.SerializeToUtf8Bytes<TransportOperation>(inv, AppJsonContext.Default.Options);
-
-				var pool = ArrayPool<byte>.Shared;
-				var bytes = pool.Rent(DefaultFrameSize);
-				// var span = new Span<byte>(bytes);
-				try
-				{
-					var serialized = _networkSerializationService.Serialize<TransportOperation>(inv, bytes);
-					EmergencyLog.Default.LogInformation($"{GetHashCode():X4} >>> {ev}");
-					await wsConnection.SendAsync(serialized, _networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, endOfMessage: true, _cts.Token);
-				}
-				finally
-				{
-					pool.Return(bytes);
-				}
-
-				_eventReplicationState.LastEventIdFromMe = ev.EventId;
 			}
-			EmergencyLog.Default.LogInformation($"{GetHashCode():X4} >>> </LOOP>");
 
-			// get events from server and apply them locally
+			if (!stoppingToken.IsCancellationRequested)
+			{
+				await Task.Delay(TimeSpan.FromSeconds(2), stoppingToken);
+			}
 		}
 	}
 
-	/*
-	public async Task StopAsync(CancellationToken cancellationToken)
+	public async Task StageAsync(
+		  Command command
+		, IReadOnlyList<Event> events
+		, CommandSubmissionOptions? options = null
+		, CancellationToken cancellationToken = default
+	)
 	{
-		await _cts.CancelAsync();
-		_autoResetEvent.Set();
-		// _ = _connection?.StopAsync();
-		if (_connection != null && _connection.State == WebSocketState.Open)
-		{
-			await _connection.CloseAsync(WebSocketCloseStatus.NormalClosure, null, cancellationToken);
-		}
-		if (_readerTask != null)
-		{
-			await _readerTask.WaitAsync(cancellationToken);
-		}
-		if (_writerTask != null)
-		{
-			await _writerTask.WaitAsync(cancellationToken);
-		}
-		// return Task.CompletedTask;
+		await _storage.StageAsync(command, events, options, cancellationToken);
+		SignalPending();
 	}
-	*/
 
-	public void Trigger(Command command, IReadOnlyList<Event> events)
+	public async Task ReconnectAsync()
+	{
+		CancellationTokenSource? connectionCts;
+		lock (_connectionLock)
+		{
+			connectionCts = _connectionCts;
+		}
+
+		if (connectionCts is not null)
+		{
+			await connectionCts.CancelAsync();
+		}
+	}
+
+	private async Task<Guid> ResolveStreamIdAsync(CancellationToken cancellationToken)
+	{
+		if (_config.ResolveStreamIdAsync is null)
+		{
+			throw new InvalidOperationException("EventReplicationConfig.ResolveStreamIdAsync is required for client replication.");
+		}
+		return await _config.ResolveStreamIdAsync(cancellationToken) ?? Guid.Empty;
+	}
+
+	private async Task RepairConfirmedEventsAsync(
+		  ClientWebSocket wsConnection
+		, Guid streamId
+		, CancellationToken cancellationToken
+	)
+	{
+		var digests = new List<ConfirmedEventDigest>();
+		await foreach (var digest in _storage.GetConfirmedDigestsAsync(streamId, cancellationToken))
+		{
+			digests.Add(digest);
+		}
+
+		await SendAsync(
+			wsConnection,
+			_protocol.CreateHello(_networkSerializationService.Magic, digests),
+			cancellationToken
+		);
+		var accepted = await ReceiveFullMessageAsync(wsConnection, cancellationToken)
+			?? throw new InvalidOperationException("Replication server closed before accepting the hello frame.");
+		_protocol.ValidateHelloAccepted(accepted, _networkSerializationService.Magic);
+
+		var changed = false;
+		while (true)
+		{
+			var frame = await ReceiveFullMessageAsync(wsConnection, cancellationToken)
+				?? throw new InvalidOperationException("Replication server closed during confirmed-record repair.");
+			switch (_protocol.ReadKind(frame))
+			{
+				case ReplicationFrameKind.ConfirmedEvent:
+					var ev = _protocol.ReadConfirmedEvent(frame);
+					ev.StreamId = streamId;
+					changed |= await _storage.UpsertConfirmedAsync(ev, cancellationToken)
+						!= ClientEventStoreChange.None;
+					break;
+				case ReplicationFrameKind.DeleteConfirmedEvent:
+					changed |= await _storage.DeleteConfirmedAsync(
+						_protocol.ReadEventId(frame, ReplicationFrameKind.DeleteConfirmedEvent),
+						cancellationToken
+					) != ClientEventStoreChange.None;
+					break;
+				case ReplicationFrameKind.RepairComplete:
+					if (changed)
+					{
+						RebuildRequired?.Invoke();
+					}
+					return;
+				default:
+					throw new InvalidDataException("Unexpected frame during confirmed-record repair.");
+			}
+		}
+	}
+
+	private async Task ReadAsync(
+		  ClientWebSocket wsConnection
+		, Guid streamId
+		, CancellationToken cancellationToken
+	)
+	{
+		while (!cancellationToken.IsCancellationRequested)
+		{
+			var frame = await ReceiveFullMessageAsync(wsConnection, cancellationToken);
+			if (frame is null)
+			{
+				return;
+			}
+
+			switch (_protocol.ReadKind(frame))
+			{
+				case ReplicationFrameKind.ConfirmedEvent:
+					var ev = _protocol.ReadConfirmedEvent(frame);
+					ev.StreamId = streamId;
+					var upsertChange = await _storage.UpsertConfirmedAsync(ev, cancellationToken);
+					if (upsertChange == ClientEventStoreChange.Append)
+					{
+						EventsReceived?.Invoke();
+					}
+					else if (upsertChange == ClientEventStoreChange.Rebuild)
+					{
+						RebuildRequired?.Invoke();
+					}
+					break;
+				case ReplicationFrameKind.DeleteConfirmedEvent:
+					if (await _storage.DeleteConfirmedAsync(
+							_protocol.ReadEventId(frame, ReplicationFrameKind.DeleteConfirmedEvent),
+							cancellationToken
+						) == ClientEventStoreChange.Rebuild)
+					{
+						RebuildRequired?.Invoke();
+					}
+					break;
+				case ReplicationFrameKind.CommandAcknowledged:
+					if (await _storage.AcknowledgeAsync(
+							_protocol.ReadEventId(frame, ReplicationFrameKind.CommandAcknowledged),
+							cancellationToken
+						) == ClientEventStoreChange.Rebuild)
+					{
+						RebuildRequired?.Invoke();
+					}
+					break;
+				case ReplicationFrameKind.CommandRejected:
+					var rejected = _protocol.ReadCommandRejected(frame);
+					EmergencyLog.Default.LogWarning(
+						$"EventReplicationService: command {rejected.CommandId} was rejected: {rejected.Message}"
+					);
+					break;
+				default:
+					throw new InvalidDataException("Unexpected replication frame after repair completed.");
+			}
+		}
+	}
+
+	private async Task WriteAsync(
+		  ClientWebSocket wsConnection
+		, Guid streamId
+		, CancellationToken cancellationToken
+	)
+	{
+		while (!cancellationToken.IsCancellationRequested)
+		{
+			await SendPendingAsync(wsConnection, streamId, cancellationToken);
+			await _pendingSignal.WaitAsync(cancellationToken);
+		}
+	}
+
+	private async Task SendPendingAsync(
+		  ClientWebSocket wsConnection
+		, Guid streamId
+		, CancellationToken cancellationToken
+	)
+	{
+		await foreach (var batch in _storage.GetPendingAsync(streamId, cancellationToken))
+		{
+			await SendAsync(
+				wsConnection,
+				_protocol.CreateSubmitCommand(batch),
+				cancellationToken
+			);
+		}
+	}
+
+	private void SignalPending()
 	{
 		try
 		{
-			_autoResetEvent.Release();
+			_pendingSignal.Release();
 		}
 		catch (SemaphoreFullException)
 		{
-			// already signaled - concurrent triggers coalesce into one loop iteration
 		}
 	}
 
-	/// <inheritdoc />
-	public async Task ClearLocalStorageAsync()
+	private async Task<byte[]?> ReceiveFullMessageAsync(WebSocket ws, CancellationToken cancellationToken)
 	{
-		lock (_skipSet)
+		var buffer = ArrayPool<byte>.Shared.Rent(DefaultFrameSize);
+		try
 		{
-			_skipSet.Clear();
-			_skipList.Clear();
+			using var stream = new MemoryStream(DefaultFrameSize);
+			while (!cancellationToken.IsCancellationRequested)
+			{
+				var result = await ws.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+				if (result.MessageType == WebSocketMessageType.Close)
+				{
+					return null;
+				}
+				if (result.Count > 0)
+				{
+					stream.Write(buffer, 0, result.Count);
+				}
+				if (result.EndOfMessage)
+				{
+					return stream.ToArray();
+				}
+			}
+			return null;
 		}
-		_eventReplicationState.LastEventIdFromServer = default;
-		if (_storage is IClearableAppendStorage clearable)
+		finally
 		{
-			await clearable.ClearAllAsync();
+			ArrayPool<byte>.Shared.Return(buffer);
 		}
+	}
+
+	private async Task SendAsync(
+		  WebSocket ws
+		, byte[] frame
+		, CancellationToken cancellationToken
+	)
+	{
+		await ws.SendAsync(
+			frame,
+			WebSocketMessageType.Binary,
+			endOfMessage: true,
+			cancellationToken
+		);
 	}
 }

--- a/Synqra/IClientEventStore.cs
+++ b/Synqra/IClientEventStore.cs
@@ -1,0 +1,50 @@
+using Synqra.AppendStorage;
+
+namespace Synqra;
+
+public sealed class PendingCommandBatch
+{
+	public required Command Command { get; init; }
+	public required IReadOnlyList<Event> Events { get; init; }
+	public CommandSubmissionOptions? Options { get; init; }
+}
+
+public readonly record struct ConfirmedEventDigest(Guid EventId, uint Hash);
+
+public enum ClientEventStoreChange
+{
+	None,
+	Append,
+	Rebuild,
+}
+
+/// <summary>
+/// Durable client-side event storage. Confirmed server records and optimistic command batches are
+/// physically separate; the inherited append-storage view reads confirmed records followed by the
+/// still-pending optimistic events.
+/// </summary>
+public interface IClientEventStore : IAppendStorage<Event, Guid>
+{
+	Task StageAsync(
+		  Command command
+		, IReadOnlyList<Event> events
+		, CommandSubmissionOptions? options = null
+		, CancellationToken cancellationToken = default
+	);
+
+	IAsyncEnumerable<PendingCommandBatch> GetPendingAsync(
+		  Guid streamId
+		, CancellationToken cancellationToken = default
+	);
+
+	IAsyncEnumerable<ConfirmedEventDigest> GetConfirmedDigestsAsync(
+		  Guid streamId
+		, CancellationToken cancellationToken = default
+	);
+
+	Task<ClientEventStoreChange> UpsertConfirmedAsync(Event ev, CancellationToken cancellationToken = default);
+
+	Task<ClientEventStoreChange> DeleteConfirmedAsync(Guid eventId, CancellationToken cancellationToken = default);
+
+	Task<ClientEventStoreChange> AcknowledgeAsync(Guid commandId, CancellationToken cancellationToken = default);
+}

--- a/Synqra/ReplicationProtocol.cs
+++ b/Synqra/ReplicationProtocol.cs
@@ -1,0 +1,276 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Synqra;
+
+public enum ReplicationFrameKind : byte
+{
+	Hello = 1,
+	HelloAccepted = 2,
+	ConfirmedEvent = 3,
+	DeleteConfirmedEvent = 4,
+	RepairComplete = 5,
+	SubmitCommand = 6,
+	CommandAcknowledged = 7,
+	CommandRejected = 8,
+}
+
+public sealed class ReplicationHello
+{
+	public required ulong Magic { get; init; }
+	public required IReadOnlyDictionary<Guid, uint> ConfirmedEvents { get; init; }
+}
+
+public sealed class SubmittedCommand
+{
+	public required Command Command { get; init; }
+	public CommandSubmissionOptions? Options { get; init; }
+}
+
+public sealed class RejectedCommand
+{
+	public required Guid CommandId { get; init; }
+	public required string Message { get; init; }
+}
+
+public sealed class ReplicationProtocol
+{
+	private readonly ReplicationRecordCodec _codec;
+
+	public ReplicationProtocol(ReplicationRecordCodec codec)
+	{
+		_codec = codec;
+	}
+
+	public byte[] CreateHello(ulong magic, IReadOnlyCollection<ConfirmedEventDigest> confirmedEvents)
+	{
+		var result = new byte[14 + confirmedEvents.Count * 20];
+		result[0] = (byte)ReplicationFrameKind.Hello;
+		result[1] = 1;
+		BinaryPrimitives.WriteUInt64LittleEndian(result.AsSpan(2, 8), magic);
+		BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(10, 4), confirmedEvents.Count);
+		var offset = 14;
+		foreach (var item in confirmedEvents)
+		{
+			item.EventId.TryWriteBytes(result.AsSpan(offset, 16));
+			offset += 16;
+			BinaryPrimitives.WriteUInt32LittleEndian(result.AsSpan(offset, 4), item.Hash);
+			offset += 4;
+		}
+		return result;
+	}
+
+	public ReplicationHello ReadHello(ReadOnlySpan<byte> frame)
+	{
+		ValidateHeader(frame, ReplicationFrameKind.Hello, minimumLength: 14);
+		if (frame[1] != 1)
+		{
+			throw new InvalidDataException($"Unsupported replication protocol version {frame[1]}.");
+		}
+
+		var count = BinaryPrimitives.ReadInt32LittleEndian(frame.Slice(10, 4));
+		if (count < 0
+			|| count > (frame.Length - 14) / 20
+			|| frame.Length != 14 + count * 20
+		)
+		{
+			throw new InvalidDataException("Replication hello contains an invalid digest count.");
+		}
+
+		var confirmedEvents = new Dictionary<Guid, uint>(count);
+		var offset = 14;
+		for (var i = 0; i < count; i++)
+		{
+			var eventId = new Guid(frame.Slice(offset, 16));
+			offset += 16;
+			var hash = BinaryPrimitives.ReadUInt32LittleEndian(frame.Slice(offset, 4));
+			offset += 4;
+			if (!confirmedEvents.TryAdd(eventId, hash))
+			{
+				throw new InvalidDataException($"Replication hello contains duplicate event id {eventId}.");
+			}
+		}
+
+		return new ReplicationHello
+		{
+			Magic = BinaryPrimitives.ReadUInt64LittleEndian(frame.Slice(2, 8)),
+			ConfirmedEvents = confirmedEvents,
+		};
+	}
+
+	public byte[] CreateHelloAccepted(ulong magic)
+	{
+		var result = new byte[10];
+		result[0] = (byte)ReplicationFrameKind.HelloAccepted;
+		result[1] = 1;
+		BinaryPrimitives.WriteUInt64LittleEndian(result.AsSpan(2, 8), magic);
+		return result;
+	}
+
+	public void ValidateHelloAccepted(ReadOnlySpan<byte> frame, ulong expectedMagic)
+	{
+		ValidateHeader(frame, ReplicationFrameKind.HelloAccepted, exactLength: 10);
+		if (frame[1] != 1)
+		{
+			throw new InvalidDataException($"Unsupported replication protocol version {frame[1]}.");
+		}
+		var magic = BinaryPrimitives.ReadUInt64LittleEndian(frame.Slice(2, 8));
+		if (magic != expectedMagic)
+		{
+			throw new InvalidDataException($"Replication magic {magic:X16} does not match {expectedMagic:X16}.");
+		}
+	}
+
+	public byte[] CreateConfirmedEvent(Event ev)
+	{
+		var payload = _codec.SerializeEvent(ev);
+		return CreatePayloadFrame(ReplicationFrameKind.ConfirmedEvent, payload);
+	}
+
+	public uint HashEvent(Event ev) => _codec.Hash(_codec.SerializeEvent(ev));
+
+	public Event ReadConfirmedEvent(ReadOnlySpan<byte> frame)
+	{
+		ValidateHeader(frame, ReplicationFrameKind.ConfirmedEvent, minimumLength: 2);
+		return _codec.DeserializeEvent(frame[1..]);
+	}
+
+	public byte[] CreateDeleteConfirmedEvent(Guid eventId)
+	{
+		var result = new byte[17];
+		result[0] = (byte)ReplicationFrameKind.DeleteConfirmedEvent;
+		eventId.TryWriteBytes(result.AsSpan(1, 16));
+		return result;
+	}
+
+	public Guid ReadEventId(ReadOnlySpan<byte> frame, ReplicationFrameKind expectedKind)
+	{
+		ValidateHeader(frame, expectedKind, exactLength: 17);
+		return new Guid(frame.Slice(1, 16));
+	}
+
+	public byte[] CreateRepairComplete() => [(byte)ReplicationFrameKind.RepairComplete];
+
+	public byte[] CreateSubmitCommand(PendingCommandBatch batch)
+	{
+		var payload = _codec.SerializeCommand(batch.Command);
+		var result = new byte[21 + batch.Events.Count * 16 + payload.Length];
+		result[0] = (byte)ReplicationFrameKind.SubmitCommand;
+		(batch.Options?.ExpectedLastEventId ?? Guid.Empty).TryWriteBytes(result.AsSpan(1, 16));
+		BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(17, 4), batch.Events.Count);
+		var offset = 21;
+		foreach (var ev in batch.Events)
+		{
+			ev.EventId.TryWriteBytes(result.AsSpan(offset, 16));
+			offset += 16;
+		}
+		payload.CopyTo(result.AsSpan(offset));
+		return result;
+	}
+
+	public SubmittedCommand ReadSubmittedCommand(ReadOnlySpan<byte> frame)
+	{
+		ValidateHeader(frame, ReplicationFrameKind.SubmitCommand, minimumLength: 22);
+		var expectedLastEventId = new Guid(frame.Slice(1, 16));
+		var eventCount = BinaryPrimitives.ReadInt32LittleEndian(frame.Slice(17, 4));
+		if (eventCount < 0
+			|| eventCount > (frame.Length - 22) / 16
+		)
+		{
+			throw new InvalidDataException("Submitted command contains an invalid event-id count.");
+		}
+		var allocatedEventIds = new Guid[eventCount];
+		var offset = 21;
+		for (var i = 0; i < eventCount; i++)
+		{
+			allocatedEventIds[i] = new Guid(frame.Slice(offset, 16));
+			offset += 16;
+		}
+		return new SubmittedCommand
+		{
+			Command = _codec.DeserializeCommand(frame[offset..]),
+			Options = new CommandSubmissionOptions
+			{
+				ExpectedLastEventId = expectedLastEventId,
+				AllocatedEventIds = allocatedEventIds,
+			},
+		};
+	}
+
+	public byte[] CreateCommandAcknowledged(Guid commandId)
+	{
+		var result = new byte[17];
+		result[0] = (byte)ReplicationFrameKind.CommandAcknowledged;
+		commandId.TryWriteBytes(result.AsSpan(1, 16));
+		return result;
+	}
+
+	public byte[] CreateCommandRejected(Guid commandId, string message)
+	{
+		var payload = Encoding.UTF8.GetBytes(message);
+		var result = new byte[17 + payload.Length];
+		result[0] = (byte)ReplicationFrameKind.CommandRejected;
+		commandId.TryWriteBytes(result.AsSpan(1, 16));
+		payload.CopyTo(result.AsSpan(17));
+		return result;
+	}
+
+	public RejectedCommand ReadCommandRejected(ReadOnlySpan<byte> frame)
+	{
+		ValidateHeader(frame, ReplicationFrameKind.CommandRejected, minimumLength: 17);
+		return new RejectedCommand
+		{
+			CommandId = new Guid(frame.Slice(1, 16)),
+			Message = Encoding.UTF8.GetString(frame[17..]),
+		};
+	}
+
+	public ReplicationFrameKind ReadKind(ReadOnlySpan<byte> frame)
+	{
+		if (frame.IsEmpty)
+		{
+			throw new InvalidDataException("Replication frame has an unknown or missing kind.");
+		}
+		return frame[0] switch
+		{
+			(byte)ReplicationFrameKind.Hello => ReplicationFrameKind.Hello,
+			(byte)ReplicationFrameKind.HelloAccepted => ReplicationFrameKind.HelloAccepted,
+			(byte)ReplicationFrameKind.ConfirmedEvent => ReplicationFrameKind.ConfirmedEvent,
+			(byte)ReplicationFrameKind.DeleteConfirmedEvent => ReplicationFrameKind.DeleteConfirmedEvent,
+			(byte)ReplicationFrameKind.RepairComplete => ReplicationFrameKind.RepairComplete,
+			(byte)ReplicationFrameKind.SubmitCommand => ReplicationFrameKind.SubmitCommand,
+			(byte)ReplicationFrameKind.CommandAcknowledged => ReplicationFrameKind.CommandAcknowledged,
+			(byte)ReplicationFrameKind.CommandRejected => ReplicationFrameKind.CommandRejected,
+			_ => throw new InvalidDataException("Replication frame has an unknown or missing kind."),
+		};
+	}
+
+	private static byte[] CreatePayloadFrame(ReplicationFrameKind kind, ReadOnlySpan<byte> payload)
+	{
+		var result = new byte[1 + payload.Length];
+		result[0] = (byte)kind;
+		payload.CopyTo(result.AsSpan(1));
+		return result;
+	}
+
+	private static void ValidateHeader(
+		  ReadOnlySpan<byte> frame
+		, ReplicationFrameKind expectedKind
+		, int? exactLength = null
+		, int? minimumLength = null
+	)
+	{
+		if (frame.IsEmpty || frame[0] != (byte)expectedKind)
+		{
+			throw new InvalidDataException($"Expected {expectedKind} replication frame.");
+		}
+		if (exactLength is int exact && frame.Length != exact)
+		{
+			throw new InvalidDataException($"{expectedKind} frame has length {frame.Length}; expected {exact}.");
+		}
+		if (minimumLength is int minimum && frame.Length < minimum)
+		{
+			throw new InvalidDataException($"{expectedKind} frame has length {frame.Length}; expected at least {minimum}.");
+		}
+	}
+}

--- a/Synqra/ReplicationRecordCodec.cs
+++ b/Synqra/ReplicationRecordCodec.cs
@@ -1,0 +1,188 @@
+using System.Buffers.Binary;
+using Synqra.BinarySerializer;
+
+namespace Synqra;
+
+public sealed class ReplicationRecordCodec
+{
+	private readonly ISbxSerializerFactory _serializerFactory;
+
+	public ReplicationRecordCodec(ISbxSerializerFactory serializerFactory)
+	{
+		_serializerFactory = serializerFactory;
+	}
+
+	public byte[] SerializeEvent(Event ev) => Serialize(ev);
+	public byte[] SerializeCommand(Command command) => Serialize(command);
+
+	public Event DeserializeEvent(ReadOnlySpan<byte> data) => Deserialize<Event>(data);
+	public Command DeserializeCommand(ReadOnlySpan<byte> data) => Deserialize<Command>(data);
+
+	public uint Hash(ReadOnlySpan<byte> data)
+	{
+		var hash = 2166136261u;
+		foreach (var value in data)
+		{
+			hash = unchecked((hash ^ value) * 16777619u);
+		}
+		return hash;
+	}
+
+	public byte[] EncodeConfirmedRecord(Event ev)
+	{
+		var payload = SerializeEvent(ev);
+		var result = new byte[17 + payload.Length];
+		result[0] = 1;
+		ev.StreamId.TryWriteBytes(result.AsSpan(1, 16));
+		payload.CopyTo(result.AsSpan(17));
+		return result;
+	}
+
+	public Event DecodeConfirmedRecord(ReadOnlySpan<byte> data)
+	{
+		if (data.Length < 18 || data[0] != 1)
+		{
+			throw new InvalidDataException("Unsupported confirmed-event record format.");
+		}
+
+		var streamId = new Guid(data.Slice(1, 16));
+		var ev = DeserializeEvent(data[17..]);
+		ev.StreamId = streamId;
+		return ev;
+	}
+
+	public uint HashConfirmedRecord(ReadOnlySpan<byte> data)
+	{
+		if (data.Length < 18 || data[0] != 1)
+		{
+			throw new InvalidDataException("Unsupported confirmed-event record format.");
+		}
+		return Hash(data[17..]);
+	}
+
+	public byte[] EncodePendingBatch(PendingCommandBatch batch)
+	{
+		var commandData = SerializeCommand(batch.Command);
+		var eventData = batch.Events.Select(SerializeEvent).ToArray();
+		var length = 1 + 16 + 16 + 4 + commandData.Length + 4
+			+ eventData.Sum(x => 4 + x.Length);
+		var result = new byte[length];
+		var offset = 0;
+		result[offset++] = 1;
+		batch.Command.StreamId.TryWriteBytes(result.AsSpan(offset, 16));
+		offset += 16;
+		(batch.Options?.ExpectedLastEventId ?? Guid.Empty).TryWriteBytes(result.AsSpan(offset, 16));
+		offset += 16;
+		BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(offset, 4), commandData.Length);
+		offset += 4;
+		commandData.CopyTo(result.AsSpan(offset));
+		offset += commandData.Length;
+		BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(offset, 4), eventData.Length);
+		offset += 4;
+		foreach (var data in eventData)
+		{
+			BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(offset, 4), data.Length);
+			offset += 4;
+			data.CopyTo(result.AsSpan(offset));
+			offset += data.Length;
+		}
+		return result;
+	}
+
+	public PendingCommandBatch DecodePendingBatch(ReadOnlySpan<byte> data)
+	{
+		if (data.Length < 41 || data[0] != 1)
+		{
+			throw new InvalidDataException("Unsupported pending-command record format.");
+		}
+
+		var offset = 1;
+		var streamId = new Guid(data.Slice(offset, 16));
+		offset += 16;
+		var expectedLastEventId = new Guid(data.Slice(offset, 16));
+		offset += 16;
+		var commandLength = ReadLength(data, ref offset);
+		var command = DeserializeCommand(data.Slice(offset, commandLength));
+		offset += commandLength;
+		command.StreamId = streamId;
+		var eventCount = ReadLength(data, ref offset);
+		if (eventCount > (data.Length - offset) / 4)
+		{
+			throw new InvalidDataException("Pending-command record contains an invalid event count.");
+		}
+		var events = new List<Event>(eventCount);
+		for (var i = 0; i < eventCount; i++)
+		{
+			var eventLength = ReadLength(data, ref offset);
+			var ev = DeserializeEvent(data.Slice(offset, eventLength));
+			offset += eventLength;
+			ev.StreamId = streamId;
+			events.Add(ev);
+		}
+
+		if (offset != data.Length)
+		{
+			throw new InvalidDataException("Pending-command record contains trailing data.");
+		}
+
+		return new PendingCommandBatch
+		{
+			Command = command,
+			Events = events,
+			Options = expectedLastEventId == Guid.Empty
+				? null
+				: new CommandSubmissionOptions { ExpectedLastEventId = expectedLastEventId },
+		};
+	}
+
+	private byte[] Serialize<T>(T value)
+	{
+		var serializer = _serializerFactory.CreateSerializer();
+		var buffer = new byte[16 * 1024];
+		while (true)
+		{
+			try
+			{
+				var offset = 0;
+				serializer.Reset();
+				serializer.Serialize(buffer, value, ref offset);
+				return buffer.AsSpan(0, offset).ToArray();
+			}
+			catch (Exception ex) when (IsCapacityException(ex))
+			{
+				buffer = new byte[buffer.Length * 2];
+			}
+		}
+	}
+
+	private T Deserialize<T>(ReadOnlySpan<byte> data)
+	{
+		var serializer = _serializerFactory.CreateSerializer();
+		var offset = 0;
+		return serializer.Deserialize<T>(data, ref offset);
+	}
+
+	private static int ReadLength(ReadOnlySpan<byte> data, ref int offset)
+	{
+		if (offset > data.Length - 4)
+		{
+			throw new InvalidDataException("Replication record ended before its next length prefix.");
+		}
+
+		var length = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(offset, 4));
+		offset += 4;
+		if (length < 0 || length > data.Length - offset)
+		{
+			throw new InvalidDataException("Replication record contains an invalid length prefix.");
+		}
+		return length;
+	}
+
+	private static bool IsCapacityException(Exception ex)
+	{
+		return false
+			|| ex is IndexOutOfRangeException
+			|| ex is ArgumentOutOfRangeException
+			|| ex is OverflowException;
+	}
+}

--- a/Synqra/Synqra.csproj
+++ b/Synqra/Synqra.csproj
@@ -21,15 +21,17 @@
  -->
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+	<PackageReference Include="System.Text.Json" />
+	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+	<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <InternalsVisibleTo Include="Synqra.Tests.MiniModel" /><!-- THIS IS SERIOUS LIMITATION THAT NEEDS TO BE LIFTED -->
     <InternalsVisibleTo Include="Synqra.Tests" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Synqra.AppendStorage.Abstractions\Synqra.AppendStorage.Abstractions.csproj" />
-    <ProjectReference Include="..\Synqra.BinarySerializer\Synqra.BinarySerializer.csproj" />
+	<ProjectReference Include="..\Synqra.BinarySerializer\Synqra.BinarySerializer.csproj" />
+	<ProjectReference Include="..\Synqra.BlobStorage.Abstractions\Synqra.BlobStorage.Abstractions.csproj" />
     <ProjectReference Include="..\Synqra.Model\Synqra.Model.csproj" />
     <ProjectReference Include="..\Synqra.Projection.Abstractions\Synqra.Projection.Abstractions.csproj" />
     <ProjectReference Include="..\Synqra.Utils\Synqra.Utils.csproj" />

--- a/Synqra/_DI.cs
+++ b/Synqra/_DI.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Synqra.AppendStorage;
+using Synqra.BlobStorage;
+
+namespace Synqra;
+
+public static class ClientReplicationServiceCollectionExtensions
+{
+	public static IServiceCollection AddReplicationProtocol(this IServiceCollection services)
+	{
+		services.TryAddSingleton<ReplicationRecordCodec>();
+		services.TryAddSingleton<ReplicationProtocol>();
+		return services;
+	}
+
+	public static IServiceCollection AddClientEventStoreBlob(
+		  this IServiceCollection services
+		, string confirmedStoreName
+		, string pendingStoreName
+	)
+	{
+		services.AddReplicationProtocol();
+		services.TryAddSingleton(sp => new BlobClientEventStore(
+			  sp.GetRequiredKeyedService<IBlobStorage<Guid>>(confirmedStoreName)
+			, sp.GetRequiredKeyedService<IBlobStorage<Guid>>(pendingStoreName)
+			, sp.GetRequiredService<ReplicationRecordCodec>()
+		));
+		services.TryAddSingleton<IClientEventStore>(sp => sp.GetRequiredService<BlobClientEventStore>());
+		services.TryAddSingleton<IAppendStorage<Event, Guid>>(sp => sp.GetRequiredService<BlobClientEventStore>());
+		return services;
+	}
+}

--- a/Tests/Synqra.Tests/ClientEventStoreTests.cs
+++ b/Tests/Synqra.Tests/ClientEventStoreTests.cs
@@ -1,0 +1,231 @@
+using Microsoft.Extensions.DependencyInjection;
+using Synqra.BinarySerializer;
+using Synqra.BlobStorage.Sqlite;
+using Synqra.Tests.TestHelpers;
+
+namespace Synqra.Tests;
+
+[NotInParallel]
+public class ClientEventStoreTests : BaseTest
+{
+	private ServiceProvider _services = null!;
+	private string _databasePath = null!;
+	private BlobClientEventStore _store = null!;
+
+	[Before(Test)]
+	public void Setup()
+	{
+		var services = new ServiceCollection();
+		services.AddLogging();
+		services.AddSbxSerializer();
+		_services = services.BuildServiceProvider();
+		_databasePath = CreateTestFileName("client_replica.db");
+		_store = CreateStore();
+	}
+
+	[After(Test)]
+	public async Task Cleanup()
+	{
+		await _store.DisposeAsync();
+		await _services.DisposeAsync();
+	}
+
+	[Test]
+	public async Task Pending_batch_survives_reopen_with_command_options_and_events()
+	{
+		var streamId = GuidExtensions.CreateVersion7();
+		var command = CreateCommand(streamId);
+		var optimisticEvent = CreateEvent(streamId, command.CommandId);
+		var expectedLastEventId = GuidExtensions.CreateVersion7();
+		await _store.StageAsync(
+			command,
+			[optimisticEvent],
+			new CommandSubmissionOptions { ExpectedLastEventId = expectedLastEventId }
+		);
+
+		_store = CreateStore();
+		var pending = await ToListAsync(_store.GetPendingAsync(streamId));
+		var visibleEvents = await ToListAsync(_store.GetAllAsync());
+
+		await Assert.That(pending).HasCount(1);
+		await Assert.That(pending[0].Command.CommandId).IsEqualTo(command.CommandId);
+		await Assert.That(pending[0].Options?.ExpectedLastEventId).IsEqualTo(expectedLastEventId);
+		await Assert.That(pending[0].Events).HasCount(1);
+		await Assert.That(visibleEvents.Select(x => x.EventId)).IsEquivalentTo([optimisticEvent.EventId]);
+	}
+
+	[Test]
+	public async Task Confirmed_events_for_pending_command_stay_hidden_until_acknowledgement()
+	{
+		var streamId = GuidExtensions.CreateVersion7();
+		var command = CreateCommand(streamId);
+		var optimisticEvent = CreateEvent(streamId, command.CommandId, "optimistic");
+		var authoritativeEvent = CreateEvent(streamId, command.CommandId, "authoritative");
+		await _store.StageAsync(command, [optimisticEvent]);
+
+		var changedBeforeAcknowledgement = await _store.UpsertConfirmedAsync(authoritativeEvent);
+		var beforeAcknowledgement = await ToListAsync(_store.GetAllAsync());
+		var acknowledged = await _store.AcknowledgeAsync(command.CommandId);
+		var afterAcknowledgement = await ToListAsync(_store.GetAllAsync());
+
+		await Assert.That(changedBeforeAcknowledgement).IsEqualTo(ClientEventStoreChange.None);
+		await Assert.That(beforeAcknowledgement.Select(x => x.EventId)).IsEquivalentTo([optimisticEvent.EventId]);
+		await Assert.That(acknowledged).IsEqualTo(ClientEventStoreChange.Rebuild);
+		await Assert.That(afterAcknowledgement.Select(x => x.EventId)).IsEquivalentTo([authoritativeEvent.EventId]);
+	}
+
+	[Test]
+	public async Task Matching_authoritative_events_replace_pending_batch_without_rebuild()
+	{
+		var streamId = GuidExtensions.CreateVersion7();
+		var command = CreateCommand(streamId);
+		var optimisticEvent = CreateEvent(streamId, command.CommandId);
+		await _store.StageAsync(command, [optimisticEvent]);
+
+		var upsert = await _store.UpsertConfirmedAsync(optimisticEvent);
+		var acknowledgement = await _store.AcknowledgeAsync(command.CommandId);
+
+		await Assert.That(upsert).IsEqualTo(ClientEventStoreChange.None);
+		await Assert.That(acknowledgement).IsEqualTo(ClientEventStoreChange.None);
+	}
+
+	[Test]
+	public async Task Remote_confirmed_event_requires_rebuild_when_stream_has_pending_tail()
+	{
+		var streamId = GuidExtensions.CreateVersion7();
+		var pendingCommand = CreateCommand(streamId);
+		await _store.StageAsync(
+			pendingCommand,
+			[CreateEvent(streamId, pendingCommand.CommandId)]
+		);
+		var remoteEvent = CreateEvent(streamId, GuidExtensions.CreateVersion7());
+
+		var change = await _store.UpsertConfirmedAsync(remoteEvent);
+
+		await Assert.That(change).IsEqualTo(ClientEventStoreChange.Rebuild);
+	}
+
+	[Test]
+	public async Task Repairing_confirmed_records_does_not_remove_pending_batches()
+	{
+		var streamId = GuidExtensions.CreateVersion7();
+		var confirmedCommand = CreateCommand(streamId);
+		var confirmedEvent = CreateEvent(streamId, confirmedCommand.CommandId);
+		await _store.UpsertConfirmedAsync(confirmedEvent);
+		var pendingCommand = CreateCommand(streamId);
+		var pendingEvent = CreateEvent(streamId, pendingCommand.CommandId);
+		await _store.StageAsync(pendingCommand, [pendingEvent]);
+
+		await _store.DeleteConfirmedAsync(confirmedEvent.EventId);
+		var pending = await ToListAsync(_store.GetPendingAsync(streamId));
+		var visibleEvents = await ToListAsync(_store.GetAllAsync());
+
+		await Assert.That(pending.Select(x => x.Command.CommandId)).IsEquivalentTo([pendingCommand.CommandId]);
+		await Assert.That(visibleEvents.Select(x => x.EventId)).IsEquivalentTo([pendingEvent.EventId]);
+	}
+
+	[Test]
+	public async Task Confirmed_digest_changes_when_record_content_is_repaired()
+	{
+		var streamId = GuidExtensions.CreateVersion7();
+		var eventId = GuidExtensions.CreateVersion7();
+		var first = CreateEvent(streamId, GuidExtensions.CreateVersion7(), "first", eventId);
+		await _store.UpsertConfirmedAsync(first);
+		var firstDigest = (await ToListAsync(_store.GetConfirmedDigestsAsync(streamId))).Single();
+
+		var repaired = CreateEvent(streamId, first.CommandId, "repaired", eventId);
+		await _store.UpsertConfirmedAsync(repaired);
+		var repairedDigest = (await ToListAsync(_store.GetConfirmedDigestsAsync(streamId))).Single();
+
+		await Assert.That(repairedDigest.EventId).IsEqualTo(eventId);
+		await Assert.That(repairedDigest.Hash).IsNotEqualTo(firstDigest.Hash);
+	}
+
+	[Test]
+	public async Task Protocol_round_trips_hash_inventory_and_command_submission()
+	{
+		var codec = new ReplicationRecordCodec(_services.GetRequiredService<ISbxSerializerFactory>());
+		var protocol = new ReplicationProtocol(codec);
+		var streamId = GuidExtensions.CreateVersion7();
+		var command = CreateCommand(streamId);
+		var optimisticEvent = CreateEvent(streamId, command.CommandId);
+		var batch = new PendingCommandBatch
+		{
+			Command = command,
+			Events = [optimisticEvent],
+			Options = new CommandSubmissionOptions { ExpectedLastEventId = GuidExtensions.CreateVersion7() },
+		};
+		var digest = new ConfirmedEventDigest(GuidExtensions.CreateVersion7(), 123u);
+
+		var hello = protocol.ReadHello(protocol.CreateHello(456ul, [digest]));
+		var submitted = protocol.ReadSubmittedCommand(protocol.CreateSubmitCommand(batch));
+
+		await Assert.That(hello.Magic).IsEqualTo(456ul);
+		await Assert.That(hello.ConfirmedEvents[digest.EventId]).IsEqualTo(digest.Hash);
+		await Assert.That(submitted.Command.CommandId).IsEqualTo(command.CommandId);
+		await Assert.That(submitted.Command.StreamId).IsEqualTo(streamId);
+		await Assert.That(submitted.Options?.ExpectedLastEventId).IsEqualTo(batch.Options.ExpectedLastEventId);
+		await Assert.That(submitted.Options?.AllocatedEventIds).IsEquivalentTo([optimisticEvent.EventId]);
+		await Assert.That(protocol.HashEvent(optimisticEvent))
+			.IsEqualTo(codec.HashConfirmedRecord(codec.EncodeConfirmedRecord(optimisticEvent)));
+	}
+
+	private BlobClientEventStore CreateStore()
+	{
+		var options = new SqliteBlobStorageOptions
+		{
+			ConnectionString = $"Data Source={_databasePath}",
+		};
+		return new BlobClientEventStore(
+			  new SqliteBlobStorage<Guid>(options, "confirmed-events")
+			, new SqliteBlobStorage<Guid>(options, "pending-command-batches")
+			, new ReplicationRecordCodec(_services.GetRequiredService<ISbxSerializerFactory>())
+		);
+	}
+
+	private ChangeObjectPropertyCommand CreateCommand(Guid streamId)
+	{
+		return new ChangeObjectPropertyCommand
+		{
+			CommandId = GuidExtensions.CreateVersion7(),
+			StreamId = streamId,
+			TargetId = GuidExtensions.CreateVersion7(),
+			TargetTypeId = GuidExtensions.CreateVersion7(),
+			CollectionId = GuidExtensions.CreateVersion7(),
+			PropertyName = "Subject",
+			OldValue = "old",
+			NewValue = "new",
+		};
+	}
+
+	private ObjectPropertyChangedEvent CreateEvent(
+		  Guid streamId
+		, Guid commandId
+		, string value = "value"
+		, Guid? eventId = null
+	)
+	{
+		return new ObjectPropertyChangedEvent
+		{
+			EventId = eventId ?? GuidExtensions.CreateVersion7(),
+			CommandId = commandId,
+			StreamId = streamId,
+			TargetId = GuidExtensions.CreateVersion7(),
+			TargetTypeId = GuidExtensions.CreateVersion7(),
+			CollectionId = GuidExtensions.CreateVersion7(),
+			PropertyName = "Subject",
+			OldValue = "old",
+			NewValue = value,
+		};
+	}
+
+	private async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+	{
+		var result = new List<T>();
+		await foreach (var item in source)
+		{
+			result.Add(item);
+		}
+		return result;
+	}
+}

--- a/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
+++ b/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
@@ -1,590 +1,414 @@
-﻿#if NETFRAMEWORK
-#else
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
-#endif
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using MongoDB.Driver;
-using Synqra.Tests.SampleModels;
-using Synqra.Tests.Helpers;
-using Synqra.Tests.TestHelpers;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-// using System.Text.Json;
-// using System.Text.Json.Serialization;
-using System.Threading.Tasks;
-using System.Text.Json.Serialization.Metadata;
-using System.Net.WebSockets;
-using System.Buffers;
-using System.Collections.Concurrent;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Data.Common;
-using Synqra.BinarySerializer;
-using Synqra.Tests.SampleModels.Syncronization;
-using Synqra.Projection.InMemory;
-using Synqra.AppendStorage.JsonLines;
 using Synqra.AppendStorage;
 using Synqra.AppendStorage.InMemory;
+using Synqra.AppendStorage.JsonLines;
+using Synqra.BinarySerializer;
+using Synqra.BlobStorage.Sqlite;
+using Synqra.Projection.InMemory;
+using Synqra.Tests.SampleModels;
+using Synqra.Tests.SampleModels.Syncronization;
+using Synqra.Tests.TestHelpers;
 #if NET10_0_OR_GREATER
-using Synqra.Projection.Sqlite;
 using Synqra.Replication.AspNetCore;
 #endif
 
 namespace Synqra.Tests.Simulator;
 
-internal class SynqraTestNode
+internal sealed class SynqraTestNode
 {
-	[ThreadStatic]
-	static int _fceRecursionGuard;
-
-	static SynqraTestNode()
-	{
-		// Log all first-chance exceptions (for diagnostics, not errors)
-		AppDomain.CurrentDomain.FirstChanceException += (s, e) =>
-		{
-			if (_fceRecursionGuard > 2)
-			{
-				return;
-			}
-			var pre = _fceRecursionGuard;
-			_fceRecursionGuard = pre + 1;
-			try
-			{
-				if (_fceRecursionGuard > 1)
-				{
-					EmergencyLog.Default.Message("[Warning] First Chance Exception StackOverflow prevention happened!!");
-				}
-				Exception? exceptionToStringException = null;
-				try
-				{
-					e.Exception.ToString();
-				}
-				catch (Exception ex)
-				{
-					exceptionToStringException = ex;
-				}
-				if (exceptionToStringException != null)
-				{
-					EmergencyLog.Default.Message("[Warning] First Chance Exception (Exception.ToString Exception!): " + exceptionToStringException);
-				}
-				else
-				{
-					EmergencyLog.Default.Message("[Warning] First Chance Exception: " + e.Exception);
-				}
-			}
-			catch
-			{
-			}
-			finally
-			{
-				_fceRecursionGuard = pre;
-			}
-		};
-	}
-
-#if NETFRAMEWORK
-	public IHost Host { get; private set; }
-#else
-	public Microsoft.AspNetCore.Builder.WebApplication Host { get; private set; }
-#endif
-
-	/// <summary>
-	/// The stream this node projects/replicates. All nodes in one test (master + clients) share the
-	/// same stream id — it is passed in at construction, never pinned into a DI registration. The
-	/// node OWNS its projection for this stream (obtained at startup from <see cref="IProjectionProvider"/>),
-	/// which is why there is no DI-resolvable projection singleton anymore.
-	/// </summary>
-	public Guid StreamId { get; }
-
-	// The node's own projection for StreamId, resolved once at startup via the provider (cached, so
-	// every consumer here — StoreContext, the master WS apply loop, the client EventsReceived
-	// catch-up — shares the one instance).
+	private readonly SemaphoreSlim _transportGate = new(1, 1);
 	private IReplayProjection? _projection;
 
-	public IObjectStore StoreContext =>
-#if NETFRAMEWORK
-		throw new NotImplementedException();
-#else
-		_projection ?? throw new InvalidOperationException("Projection not initialized yet — await node.Started first.");
-#endif
-
-	public IAppendStorage<Event, Guid> Events
+	public SynqraTestNode(
+		  Guid streamId
+		, Action<IHostApplicationBuilder>? configureHost = null
+		, bool masterHost = false
+		, bool useRealEndpoint = false
+	)
 	{
-		get =>
-#if NETFRAMEWORK
-			throw new NotImplementedException();
-#else
-			field ??= Host.Services.GetRequiredService<IAppendStorage<Event, Guid>>(); private set;
-#endif
-	}
-
-	public ushort Port { get; set; }
-
-	/// <summary>
-	/// Completes when the node's web host is listening. For the master node this is also
-	/// the moment <see cref="Port"/> carries the real OS-assigned port — await it before
-	/// constructing client nodes that target the master.
-	/// </summary>
-	public Task Started { get; private set; } = Task.CompletedTask;
-
-	SemaphoreSlim _semaphoreSlim = new(1, 1);
-	long _masterSeq = 0;
-
-	/// <param name="useRealEndpoint">
-	/// Master only (net10). When true the host wires the real production endpoint
-	/// (<see cref="SynqraReplicationEndpointExtensions.MapSynqraReplicationEndpoint"/>) behind
-	/// middleware that scopes each connection to the <c>?stream=</c> it connected with — the
-	/// test's stand-in for Quotaly's auth middleware — instead of the hand-rolled single-stream
-	/// simulator below. This is what the stream-isolation e2e exercises. The event log is then
-	/// InMemory (it keeps <see cref="Event.StreamId"/> on the in-memory object; the JSON-lines log
-	/// drops it, since StreamId is [JsonIgnore] and only the Mongo log re-maps it to _sid).
-	/// </param>
-	public SynqraTestNode(Guid streamId, Action<IHostApplicationBuilder>? configureHost = null, bool masterHost = false, bool useRealEndpoint = false)
-	{
-		if (streamId == default)
+		if (streamId == Guid.Empty)
 		{
-			throw new ArgumentException("A non-default stream id is required — all nodes in a test share one explicit stream.", nameof(streamId));
+			throw new ArgumentException("A non-default stream id is required.", nameof(streamId));
 		}
+
 		StreamId = streamId;
-		#region Folder
+		var workingDirectory = new TestUtils().CreateTestFolder();
+		Directory.CreateDirectory(workingDirectory);
 
-		var utils = new TestUtils();
-		var synqraTestsCurrentPath = utils.CreateTestFolder();
-		Directory.CreateDirectory(synqraTestsCurrentPath);
-
-		#endregion
-
-#if NETFRAMEWORK
-		throw new NotImplementedException();
-
-		var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
-		{
-			ContentRootPath	= synqraTestsCurrentPath,
-			EnvironmentName = Environments.Development,
-		});
-		builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
-		{
-			["Storage:JsonLinesStorage:FileName"] = Path.Combine(synqraTestsCurrentPath, "[TypeName].jsonl"),
-		});
-		builder.AddSynqraStoreContext();
-		builder.AddJsonLinesStorage<Event, Guid>();
-		builder.Services.AddSingleton<JsonSerializerContext>(TestJsonSerializerContext.Default);
-		builder.Services.AddSingleton(TestJsonSerializerContext.Default.Options);
-		// builder.Services.AddSignalR();
-		builder.Services.AddLazyServiceResolution();
-		if (masterHost)
-		{
-		}
-		else
-		{
-			builder.Services.AddHostedService<EventReplicationService>(x => x.GetRequiredService<EventReplicationService>());
-			builder.Services.AddSingleton<EventReplicationService>(); // x => x.GetServices<IHostedService>().OfType<EventReplicationService>().Single());
-			// builder.Services.AddSingleton<EventReplicationService>(x => x.GetServices<IHostedService>().OfType<EventReplicationService>().Single());
-			builder.Services.AddSingleton<EventReplicationState>();
-			// services.Configure<EventReplicationConfig>(hostContext.Configuration.GetSection(nameof(EventReplicationConfig)));
-			var port = Port = GetNextAvailablePort();
-			builder.Services.Configure<EventReplicationConfig>(x =>
-			{
-				x.Port = port;
-			});
-		}
-		Host = builder.Build();
-#else
-		var builder = Microsoft.AspNetCore.Builder.WebApplication.CreateSlimBuilder(new Microsoft.AspNetCore.Builder.WebApplicationOptions
+		var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
 		{
 			Args = Array.Empty<string>(),
 			EnvironmentName = Environments.Development,
-			ContentRootPath = synqraTestsCurrentPath,
+			ContentRootPath = workingDirectory,
 		});
 		builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
 		{
-			["Storage:JsonLinesStorage:FileName"] = Path.Combine(synqraTestsCurrentPath, "[TypeName].jsonl"),
-			// Port 0: Kestrel asks the OS for a free port at bind time. Reserving a port
-			// up front (listen, read, release, rebind) raced with parallel tests — the
-			// released port could be taken again before Kestrel bound it.
+			["Storage:JsonLinesStorage:FileName"] = Path.Combine(workingDirectory, "[TypeName].jsonl"),
+			["Storage:BlobStorage:Sqlite:ConnectionString"] = $"Data Source={Path.Combine(workingDirectory, "client.db")}",
 			["URLS"] = "http://127.0.0.1:0",
 		});
 
 		builder.Services.AddInMemorySynqraStore();
+		if (masterHost)
+		{
 #if NET10_0_OR_GREATER
-		if (masterHost && useRealEndpoint)
-		{
-			// The real endpoint reads events back from its own log to replay a stream's backlog and
-			// filters by Event.StreamId — so the log must preserve it. InMemory does (it holds the
-			// object); JSON-lines does not ([JsonIgnore]). See the useRealEndpoint remarks above.
-			builder.Services.AddAppendStorageInMemory<Event, Guid>(x => x.EventId);
-		}
-		else
+			if (useRealEndpoint)
+			{
+				builder.Services.AddAppendStorageInMemory<Event, Guid>(x => x.EventId);
+			}
+			else
 #endif
-		{
+			{
 			builder.AddAppendStorageJsonLines<Event>("EventId", x => x.EventId);
-		}
-
-		// builder.Services.AddSingleton<INetworkSerializationService, JsonNetworkSerializationService>();
-		builder.Services.AddSingleton<INetworkSerializationService, SbxNetworkSerializationService>();
-
-		// builder.Services.AddSingleton<JsonSerializerContext>(SampleJsonSerializerContext.Default);
-		builder.Services.AddSingleton(SampleJsonSerializerContext.DefaultOptions);
-
-		var options = new JsonSerializerOptions(SampleJsonSerializerContext.DefaultOptions);
-		/*
-		if (options.Converters.Count == 0)
-		{
-			Type[] extra = [
-				typeof(SamplePublicModel),
-				typeof(SampleTaskModel),
-			];
-			options.Converters.Add(new ObjectConverter(extra));
-			// options.Converters.Add(new BindableModelConverter(extra));
-			options.TypeInfoResolver = new SynqraJsonTypeInfoResolver(extra);
+			}
+			builder.Services.AddReplicationProtocol();
+			builder.Services.AddControllers();
 		}
 		else
 		{
-			throw new Exception("Double check why we are here now");
+			builder.AddBlobStorageSqlite<Guid>("confirmed-events");
+			builder.AddBlobStorageSqlite<Guid>("pending-command-batches");
+			builder.Services.AddClientEventStoreBlob("confirmed-events", "pending-command-batches");
+			builder.Services.AddSingleton<EventReplicationService>();
+			builder.Services.AddSingleton<IEventReplicationService>(services =>
+				services.GetRequiredService<EventReplicationService>());
+			builder.Services.AddHostedService(services =>
+				services.GetRequiredService<EventReplicationService>());
+			builder.Services.AddSingleton<EventReplicationConfig>(new TestNodeReplicationConfig(this));
 		}
-		*/
-		/*
-		var typeInfo = options.GetTypeInfo(typeof(IBindableModel));
-		typeInfo.PolymorphismOptions ??= new JsonPolymorphismOptions
-		{
-			IgnoreUnrecognizedTypeDiscriminators = false,
-			UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization,
-			TypeDiscriminatorPropertyName = "_t",
-		};
-		typeInfo.PolymorphismOptions.DerivedTypes.Add(new JsonDerivedType(typeof(SamplePublicModel), "SamplePublicModel"));
-		typeInfo.PolymorphismOptions.DerivedTypes.Add(new JsonDerivedType(typeof(SampleTaskModel), "SampleTaskModel"));
-		*/
-		builder.Services.AddSingleton(options);
 
+		builder.Services.AddSingleton<INetworkSerializationService, SbxNetworkSerializationService>();
+		builder.Services.AddSingleton(SampleJsonSerializerContext.DefaultOptions);
+		builder.Services.AddSingleton(new JsonSerializerOptions(SampleJsonSerializerContext.DefaultOptions));
 		builder.Services.AddTypeMetadataProvider([
 			typeof(DemoModel),
 			typeof(MyPocoTask),
 			typeof(SampleTaskModel),
 		]);
 		builder.Services.AddEmergencyLogger();
-
-		builder.Services.AddSbxSerializer(ser =>
+		builder.Services.AddSbxSerializer(serializer =>
 		{
-			ser.Map(100, typeof(SamplePublicModel));
-			ser.Map(101, typeof(SampleTaskModel));
+			serializer.Map(100, typeof(SamplePublicModel));
+			serializer.Map(101, typeof(SampleTaskModel));
 		});
-
-		builder.Services.ConfigureHttpJsonOptions(o =>
+		builder.Services.ConfigureHttpJsonOptions(options =>
 		{
-			o.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonContext.Default);
-			o.SerializerOptions.Converters.Add(new ObjectConverter());
+			options.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonContext.Default);
+			options.SerializerOptions.Converters.Add(new ObjectConverter());
 		});
-
-		/*
-		builder.Services.AddSignalR(o => o.EnableDetailedErrors = true)
-			.AddJsonProtocol(o =>
-			 {
-				 // o.PayloadSerializerOptions = AppJsonContext.Default.Options;
-				 // o.PayloadSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-				 o.PayloadSerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonContext.Default);
-				 // Make the source-generated resolver first so it wins.
-				 // o.PayloadSerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonContext.Default);
-				 o.PayloadSerializerOptions.Converters.Add(new ObjectConverter());
-				 // (Optional) tune other STJ options here if you really need to.
-			 })
-			;
-		*/
-
 		builder.Services.AddLazyServiceResolution();
 
+		configureHost?.Invoke(builder);
+		Host = builder.Build();
 		if (masterHost)
 		{
-			builder.Services.AddControllers();
 #if NET10_0_OR_GREATER
 			if (useRealEndpoint)
 			{
-				// The real endpoint resolves IProjection from DI and Accepts every inbound event.
-				// This test only asserts socket-level routing, so a do-nothing projection suffices.
-				builder.Services.AddSingleton<IProjection, FakeProjection>();
-			}
-#endif
-		}
-		else
-		{
-			builder.Services.AddSingleton<EventReplicationService>();
-			builder.Services.AddSingleton<IEventReplicationService>(x => x.GetRequiredService<EventReplicationService>());
-			builder.Services.AddHostedService(x => x.GetRequiredService<EventReplicationService>());
-
-			builder.Services.AddSingleton<EventReplicationState>();
-			// builder.Services.Configure<EventReplicationConfig>(builder.Configuration.GetSection(nameof(EventReplicationConfig)));
-			// The client tells the master which stream it is on via the ?stream= query — the real
-			// endpoint's scoping middleware reads it (the hand-rolled single-stream master below just
-			// ignores it, matching on path only). Port is assigned after construction, so resolve both
-			// lazily at connect time.
-			builder.Services.AddSingleton<EventReplicationConfig>(new TestNodeReplicationConfig(this));
-
-		}
-
-		configureHost?.Invoke(builder);
-		var app = builder.Build();
-		Host = app;
-
-#if NET10_0_OR_GREATER
-		if (masterHost && useRealEndpoint)
-		{
-			app.MapControllers();
-			// Stand-in for Quotaly's auth middleware: scope each connection to the stream it
-			// connected with (?stream=<guid>). The real endpoint reads this ambient scope via
-			// SynqraStreamContext.CurrentOrNull and never trusts anything the client sends on the wire.
-			app.Use(next => async ctx =>
-			{
-				if (Guid.TryParse(ctx.Request.Query["stream"], out var connStream) && connStream != default)
+				Host.MapControllers();
+				Host.Use(next => async context =>
 				{
-					using (SynqraStreamContext.Enter(connStream))
+					if (Guid.TryParse(context.Request.Query["stream"], out var streamId)
+						&& streamId != Guid.Empty
+					)
 					{
-						await next(ctx);
+						using (SynqraStreamContext.Enter(streamId))
+						{
+							await next(context);
+						}
+						return;
 					}
-				}
-				else
-				{
-					await next(ctx);
-				}
-			});
-			app.MapSynqraReplicationEndpoint();
-		}
-		else
+					await next(context);
+				});
+				Host.MapSynqraReplicationEndpoint();
+			}
+			else
 #endif
-		if (masterHost)
-		{
-			var knownEvents = new ConcurrentDictionary<Guid, object?>();
-
-			app.MapControllers();
-			app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(20) });
-			ConcurrentBag<WebSocket> _sockets = new ConcurrentBag<WebSocket>();
-			app.Map("/api/synqra/ws", async ctx =>
 			{
-				var networkSerializationService = app.Services.GetRequiredService<INetworkSerializationService>();
-				if (!ctx.WebSockets.IsWebSocketRequest) { ctx.Response.StatusCode = 400; return; }
-				using var socket = await ctx.WebSockets.AcceptWebSocketAsync();
+			MapReplicationEndpoint(Host);
+			}
+		}
+		Started = StartHostAsync(Host, masterHost);
+	}
 
-				// Hand-rolled duplicate of SynqraReplicationEndpointExtensions.cs's HELLO/
-				// broadcast protocol, kept in sync by hand — Synqra.Replication.AspNetCore
-				// (the real production endpoint) is net10.0-only, but this test project also
-				// builds for net8.0/net9.0, so it can't just call the real thing on every TFM.
-				//
-				// One intentional difference: the production endpoint additionally scopes backlog
-				// replay and broadcast to each connection's own stream (ReplicationStreamScope).
-				// This simulator is single-stream by construction (every node in a test shares one
-				// StreamId, and there is no per-connection stream scope here), so that filter would
-				// be a no-op — it is deliberately omitted rather than duplicated as dead code.
+	public WebApplication Host { get; }
+	public Guid StreamId { get; }
+	public ushort Port { get; set; }
+	public Task Started { get; }
 
-				#region HELLO - from client
-				// 8 bytes magic + 16 bytes the client's own "last event id it already
-				// received from a server" cursor — see EventReplicationService's HELLO send
-				// and EventReplicationState.LastEventIdFromServer's own remarks.
-				var helloBytes = await ReceiveFullMessageAsync(socket, ctx.RequestAborted);
-				if (helloBytes is null)
+	public IObjectStore StoreContext => _projection
+		?? throw new InvalidOperationException("Projection not initialized; await Started first.");
+
+	public IAppendStorage<Event, Guid> Events =>
+		Host.Services.GetRequiredService<IAppendStorage<Event, Guid>>();
+
+	private void MapReplicationEndpoint(WebApplication app)
+	{
+		var sockets = new ConcurrentDictionary<WebSocket, byte>();
+		app.MapControllers();
+		app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(20) });
+		app.Map("/api/synqra/ws", async context =>
+		{
+			if (!context.WebSockets.IsWebSocketRequest)
+			{
+				context.Response.StatusCode = 400;
+				return;
+			}
+
+			var protocol = context.RequestServices.GetRequiredService<ReplicationProtocol>();
+			var serializer = context.RequestServices.GetRequiredService<INetworkSerializationService>();
+			using var socket = await context.WebSockets.AcceptWebSocketAsync();
+			try
+			{
+				var helloFrame = await ReceiveFullMessageAsync(socket, context.RequestAborted)
+					?? throw new InvalidOperationException("Client closed before sending replication hello.");
+				var hello = protocol.ReadHello(helloFrame);
+				if (hello.Magic != serializer.Magic)
 				{
-					return;
+					throw new InvalidDataException("Replication serializer does not match the server.");
 				}
-				if (helloBytes.Length != 24)
-				{
-					throw new Exception($"Protocol Negotiation Failed! Received {helloBytes.Length} bytes instead of 24.");
-				}
-				var magic = BitConverter.ToUInt64(helloBytes, 0);
-				if (magic != networkSerializationService.Magic)
-				{
-					throw new Exception($"Protocol Negotiation Failed! Received Magic {magic:X16} instead of {networkSerializationService.Magic:X16}.");
-				}
-				var clientCursor = new Guid(helloBytes.AsSpan(8, 16));
-				#endregion
-				#region HELLO - to client, then replay this stream's backlog since clientCursor
-				// Register for broadcasts BEFORE answering HELLO, and do both — plus the
-				// backlog replay below — under the broadcast semaphore: the moment a client
-				// observes the HELLO reply (and reports IsOnline), every subsequent broadcast
-				// is guaranteed to reach it, and none of this can interleave with a concurrent
-				// broadcast SendAsync on the same socket.
-				var magicBytes = BitConverter.GetBytes(networkSerializationService.Magic);
-				await _semaphoreSlim.WaitAsync(ctx.RequestAborted);
+
+				await _transportGate.WaitAsync(context.RequestAborted);
 				try
 				{
-					_sockets.Add(socket);
-					await socket.SendAsync(magicBytes, WebSocketMessageType.Binary, endOfMessage: true, ctx.RequestAborted);
-
-					var backlogStorage = app.Services.GetRequiredService<IAppendStorage<Event, Guid>>();
-					var backlogBuffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
-					try
-					{
-						await foreach (var ev in backlogStorage.GetAllAsync(from: clientCursor, ctx.RequestAborted))
-						{
-							knownEvents.TryAdd(ev.EventId, null);
-							var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, backlogBuffer);
-							await socket.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
-						}
-					}
-					finally
-					{
-						ArrayPool<byte>.Shared.Return(backlogBuffer);
-					}
+					sockets[socket] = 0;
+					await SendAsync(socket, protocol.CreateHelloAccepted(serializer.Magic), context.RequestAborted);
+					await RepairConfirmedEventsAsync(
+						socket,
+						hello.ConfirmedEvents,
+						protocol,
+						context.RequestAborted);
 				}
 				finally
 				{
-					_semaphoreSlim.Release();
+					_transportGate.Release();
 				}
-				#endregion
 
-				try
+				while (!context.RequestAborted.IsCancellationRequested
+					&& socket.State == WebSocketState.Open)
 				{
-					while (!ctx.RequestAborted.IsCancellationRequested && socket.State == WebSocketState.Open)
+					var frame = await ReceiveFullMessageAsync(socket, context.RequestAborted);
+					if (frame is null)
 					{
-						var messageBytes = await ReceiveFullMessageAsync(socket, ctx.RequestAborted);
-						if (messageBytes is null)
-						{
-							break;
-						}
-						var operation = networkSerializationService.Deserialize<TransportOperation>(messageBytes);
-
-						var storeCtx = _projection ?? throw new InvalidOperationException("Master projection not initialized.");
-						if (operation is NewEvent1 newEvent1)
-						{
-							if (!knownEvents.TryAdd(newEvent1.Event.EventId, null))
-							{
-								// already known, ignore
-								continue;
-							}
-							EmergencyLog.Default.Message($"Master Received: {newEvent1.Event}{Environment.NewLine}{JsonSerializer.Serialize(newEvent1.Event, AppJsonContext.Default.Options)}");
-							await _semaphoreSlim.WaitAsync(ctx.RequestAborted);
-							try
-							{
-								var ev = newEvent1.Event;
-								// ev.MasterSeq
-								await ev.AcceptAsync(storeCtx, null);
-								var storage = app.Services.GetRequiredService<IAppendStorage<Event, Guid>>();
-								await storage.AppendAsync(ev);
-								var buffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
-								try
-								{
-									var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, buffer);
-									foreach (var item in _sockets)
-									{
-										if (item != socket)
-										{
-											try
-											{
-												await item.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
-											}
-											catch
-											{
-												// ignore
-											}
-										}
-									}
-								}
-								finally
-								{
-									ArrayPool<byte>.Shared.Return(buffer);
-								}
-							}
-							finally
-							{
-								_semaphoreSlim.Release();
-							}
-						}
-						else
-						{
-							throw new NotSupportedException();
-						}
+						break;
 					}
+					if (protocol.ReadKind(frame) != ReplicationFrameKind.SubmitCommand)
+					{
+						throw new InvalidDataException("The test server accepts only command submissions after repair.");
+					}
+					await ProcessCommandAsync(
+						socket,
+						sockets,
+						protocol.ReadSubmittedCommand(frame),
+						protocol,
+						context.RequestAborted);
 				}
-				catch (Exception ex)
-				{
-					EmergencyLog.Default.Error("Master Loop Error", ex);
-				}
-			});
-		}
-
-		Started = StartHostAsync(app, masterHost);
-#endif
+			}
+			finally
+			{
+				sockets.TryRemove(socket, out _);
+			}
+		});
 	}
 
-#if !NETFRAMEWORK
-	async Task StartHostAsync(Microsoft.AspNetCore.Builder.WebApplication app, bool masterHost)
+	private async Task RepairConfirmedEventsAsync(
+		  WebSocket socket
+		, IReadOnlyDictionary<Guid, uint> clientDigests
+		, ReplicationProtocol protocol
+		, CancellationToken cancellationToken
+	)
+	{
+		var unmatched = clientDigests.ToDictionary();
+		await foreach (var ev in Events.GetAllAsync(cancellationToken: cancellationToken))
+		{
+			if (ev.StreamId != Guid.Empty && ev.StreamId != StreamId)
+			{
+				continue;
+			}
+			if (!unmatched.Remove(ev.EventId, out var clientHash)
+				|| clientHash != protocol.HashEvent(ev))
+			{
+				await SendAsync(socket, protocol.CreateConfirmedEvent(ev), cancellationToken);
+			}
+		}
+		foreach (var eventId in unmatched.Keys)
+		{
+			await SendAsync(socket, protocol.CreateDeleteConfirmedEvent(eventId), cancellationToken);
+		}
+		await SendAsync(socket, protocol.CreateRepairComplete(), cancellationToken);
+	}
+
+	private async Task ProcessCommandAsync(
+		  WebSocket origin
+		, ConcurrentDictionary<WebSocket, byte> sockets
+		, SubmittedCommand submitted
+		, ReplicationProtocol protocol
+		, CancellationToken cancellationToken
+	)
+	{
+		submitted.Command.StreamId = StreamId;
+		await _transportGate.WaitAsync(cancellationToken);
+		try
+		{
+			var events = await ReadCommandEventsAsync(submitted.Command.CommandId, cancellationToken);
+			var wasAlreadyProcessed = events.Count > 0;
+			if (!wasAlreadyProcessed)
+			{
+				var provider = Host.Services.GetRequiredService<IProjectionProvider>();
+				var objectStore = (IObjectStore)await provider.GetAsync(StreamId, cancellationToken);
+				await objectStore.SubmitCommandAsync(submitted.Command, submitted.Options);
+				events = await ReadCommandEventsAsync(submitted.Command.CommandId, cancellationToken);
+			}
+
+			foreach (var ev in events)
+			{
+				ev.StreamId = StreamId;
+				var eventFrame = protocol.CreateConfirmedEvent(ev);
+				foreach (var peer in sockets.Keys)
+				{
+					if (peer.State != WebSocketState.Open
+						|| wasAlreadyProcessed && peer != origin)
+					{
+						continue;
+					}
+					try
+					{
+						await SendAsync(peer, eventFrame, cancellationToken);
+					}
+					catch (WebSocketException)
+					{
+						sockets.TryRemove(peer, out _);
+					}
+				}
+			}
+			await SendAsync(
+				origin,
+				protocol.CreateCommandAcknowledged(submitted.Command.CommandId),
+				cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			if (origin.State == WebSocketState.Open)
+			{
+				await SendAsync(
+					origin,
+					protocol.CreateCommandRejected(submitted.Command.CommandId, ex.Message),
+					cancellationToken);
+			}
+		}
+		finally
+		{
+			_transportGate.Release();
+		}
+	}
+
+	private async Task<List<Event>> ReadCommandEventsAsync(
+		  Guid commandId
+		, CancellationToken cancellationToken
+	)
+	{
+		var result = new List<Event>();
+		await foreach (var ev in Events.GetAllAsync(cancellationToken: cancellationToken))
+		{
+			if (ev.CommandId == commandId
+				&& (ev.StreamId == Guid.Empty || ev.StreamId == StreamId))
+			{
+				result.Add(ev);
+			}
+		}
+		return result;
+	}
+
+	private async Task StartHostAsync(WebApplication app, bool masterHost)
 	{
 		await app.StartAsync();
 		if (masterHost)
 		{
-			// Kestrel bound to 127.0.0.1:0 — publish the OS-assigned port so clients can
-			// target it. Client nodes keep the master port assigned by the test instead.
 			Port = checked((ushort)new Uri(app.Urls.First()).Port);
 		}
 
-		// Own the projection for this node's stream. The provider caches per stream and brings it to
-		// head via the keeper, so this single instance is what StoreContext, the master apply loop,
-		// and the client catch-up below all share — no DI-registered projection singleton.
 		var provider = app.Services.GetRequiredService<IProjectionProvider>();
-		_projection = await provider.GetAsync(StreamId);
-
 		if (!masterHost)
 		{
-			// Transport-only replication service: when it appends incoming server events to local
-			// durable storage it raises EventsReceived; fold them into this node's projection via the
-			// keeper (cheap no-op if nothing new for this stream). Tests poll for the result, so a
-			// fire-and-forget catch-up is fine; the provider serializes concurrent catch-ups.
-			var ers = app.Services.GetRequiredService<IEventReplicationService>();
-			ers.EventsReceived += () => _ = provider.GetAsync(StreamId);
+			var replication = app.Services.GetRequiredService<IEventReplicationService>();
+			replication.EventsReceived += () => _ = MaintainProjectionAsync(provider);
+			replication.RebuildRequired += () => _ = RebuildProjectionAsync(provider);
 		}
+		_projection = await provider.GetAsync(StreamId);
 	}
-#endif
 
-	static async Task<byte[]?> ReceiveFullMessageAsync(WebSocket ws, CancellationToken ct)
+	private async Task MaintainProjectionAsync(IProjectionProvider provider)
 	{
-		var rent = ArrayPool<byte>.Shared.Rent(64 * 1024);
+		_projection = await provider.GetAsync(StreamId);
+	}
+
+	private async Task RebuildProjectionAsync(IProjectionProvider provider)
+	{
+		_projection = await provider.RebuildAsync(StreamId);
+	}
+
+	private static async Task<byte[]?> ReceiveFullMessageAsync(
+		  WebSocket socket
+		, CancellationToken cancellationToken
+	)
+	{
+		var buffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
 		try
 		{
-			using var ms = new MemoryStream();
-			while (true)
+			using var stream = new MemoryStream(EventReplicationService.DefaultFrameSize);
+			while (!cancellationToken.IsCancellationRequested)
 			{
-				var seg = new ArraySegment<byte>(rent);
-				var res = await ws.ReceiveAsync(seg, ct);
-				if (res.MessageType == WebSocketMessageType.Close) return null;
-
-				ms.Write(rent, 0, res.Count);
-				if (res.EndOfMessage) break;
+				var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+				if (result.MessageType == WebSocketMessageType.Close)
+				{
+					return null;
+				}
+				stream.Write(buffer, 0, result.Count);
+				if (result.EndOfMessage)
+				{
+					return stream.ToArray();
+				}
 			}
-			return ms.ToArray();
+			return null;
 		}
 		finally
 		{
-			ArrayPool<byte>.Shared.Return(rent);
+			ArrayPool<byte>.Shared.Return(buffer);
 		}
 	}
 
-	private static ushort GetNextAvailablePort()
+	private static Task SendAsync(
+		  WebSocket socket
+		, byte[] frame
+		, CancellationToken cancellationToken
+	)
 	{
-		var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-		listener.Start();
-		var port = checked((ushort)((System.Net.IPEndPoint)listener.LocalEndpoint).Port);
-		listener.Stop();
-		return port;
+		return socket.SendAsync(
+			frame,
+			WebSocketMessageType.Binary,
+			endOfMessage: true,
+			cancellationToken);
 	}
 
-	/// <summary>
-	/// Replication config for a client test node. The master's port is only known after this node is
-	/// constructed (the test assigns <see cref="Port"/> via an object initializer), so both the port
-	/// and the full endpoint are resolved lazily at connect time. The endpoint carries this node's
-	/// own <see cref="StreamId"/> as <c>?stream=</c> so a real-endpoint master can scope the
-	/// connection; the hand-rolled single-stream master ignores it (it matches on path only).
-	/// </summary>
 	private sealed class TestNodeReplicationConfig : EventReplicationConfig
 	{
 		private readonly SynqraTestNode _node;
-		public TestNodeReplicationConfig(SynqraTestNode node) => _node = node;
-		public override ushort Port => _node.Port;
-		public override string? Endpoint => $"ws://localhost:{_node.Port}/api/synqra/ws?stream={_node.StreamId:D}";
-	}
 
+		public TestNodeReplicationConfig(SynqraTestNode node)
+		{
+			_node = node;
+			ResolveStreamIdAsync = _ => Task.FromResult<Guid?>(_node.StreamId);
+		}
+
+		public override ushort Port => _node.Port;
+		public override string? Endpoint =>
+			$"ws://localhost:{_node.Port}/api/synqra/ws?stream={_node.StreamId:D}";
+	}
 }

--- a/Tests/Synqra.Tests/SqliteStorageTests.cs
+++ b/Tests/Synqra.Tests/SqliteStorageTests.cs
@@ -262,12 +262,14 @@ public class SqliteStorageTests : BaseTest
 	}
 
 	[Test]
-	public async Task Should_reject_duplicate_key()
+	public async Task Should_replace_existing_key()
 	{
 		var id = GuidExtensions.CreateVersion7();
 		await _storage!.AppendAsync(new SqliteTestItem { Id = id, Name = "First" });
+		await _storage.AppendAsync(new SqliteTestItem { Id = id, Name = "Replacement" });
 
-		var ex = await Assert.ThrowsAsync(() =>
-			_storage.AppendAsync(new SqliteTestItem { Id = id, Name = "Duplicate" }));
+		var item = await _storage.GetAsync(id);
+
+		await Assert.That(item.Name).IsEqualTo("Replacement");
 	}
 }


### PR DESCRIPTION
## Summary

- store server-confirmed events and pending local command batches in separate durable stores; resync never clears confirmed history or pending work
- synchronize by sending commands plus client-allocated event IDs, while the server remains authoritative for event payloads
- exchange FNV-1a hashes for confirmed records and repair only missing, changed, or deleted records
- rebuild divergent projections off to the side, then switch the active projection reference after replaying confirmed events and rebased pending events
- use per-operation SQLite connections and keep reconnect/authentication configuration in the replication client

## Why

The previous version treated the client event store as a disposable server replica and uploaded locally produced event bodies. That model could throw away valid confirmed history during resync and did not distinguish authoritative records from optimistic local work.

The client now keeps both categories durably but separately. Confirmed records are repaired in place from a hash inventory. Pending commands survive restart and resync, remain visible through their optimistic events, and are removed only after the authoritative result is received and acknowledged.

## Impact

Mobile and browser clients can edit offline, retain pending work across process restarts, reconnect under an authenticated stream, and repair local state without redownloading or clearing an otherwise valid confirmed history. When authoritative results diverge from optimistic state, projection replay occurs in a hidden instance before the active reference changes.

## Validation

- full `Synqra.Tests` suite passed on `net10.0`
- focused SQLite durability, client event-store, initial synchronization, and backlog replay tests passed
- Quotaly Web/WASM build passed
- clean Android Release publish passed for `android-x64`
- Android emulator launched the release APK, enforced sign-in, handled the demo-account failure, and handed Google authentication to Chrome
