### PR TITLE
feat(ecs): deterministic event ids derived from CommandId

### DIFF
--- a/Synqra.Projection.File/_DI.cs
+++ b/Synqra.Projection.File/_DI.cs
@@ -634,7 +634,7 @@ public static class FileSynqraExtensions
 		{
 			var created = new CommandCreatedEvent
 			{
-				EventId = GuidExtensions.CreateVersion7(),
+				EventId = GuidExtensions.Derive(cmd.CommandId, 0),
 				Data = cmd,
 				CommandId = cmd.CommandId,
 				StreamId = cmd.StreamId,
@@ -680,7 +680,7 @@ public static class FileSynqraExtensions
 			var ev = new ObjectPropertyChangedEvent
 			{
 				StreamId = cmd.StreamId,
-				EventId = GuidExtensions.CreateVersion7(),
+				EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 				CollectionId = cmd.CollectionId,
 				CommandId = cmd.CommandId,
 				TargetTypeId = cmd.TargetTypeId,
@@ -702,7 +702,7 @@ public static class FileSynqraExtensions
 			ctx.Events.Add(new ComponentAddedEvent
 			{
 				StreamId = cmd.StreamId,
-				EventId = GuidExtensions.CreateVersion7(),
+				EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 				CollectionId = cmd.CollectionId,
 				CommandId = cmd.CommandId,
 				TargetTypeId = cmd.TargetTypeId,
@@ -718,7 +718,7 @@ public static class FileSynqraExtensions
 			ctx.Events.Add(new ComponentPropertyChangedEvent
 			{
 				StreamId = cmd.StreamId,
-				EventId = GuidExtensions.CreateVersion7(),
+				EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 				CollectionId = cmd.CollectionId,
 				CommandId = cmd.CommandId,
 				TargetTypeId = cmd.TargetTypeId,
@@ -736,7 +736,7 @@ public static class FileSynqraExtensions
 			ctx.Events.Add(new ComponentDeletedEvent
 			{
 				StreamId = cmd.StreamId,
-				EventId = GuidExtensions.CreateVersion7(),
+				EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 				CollectionId = cmd.CollectionId,
 				CommandId = cmd.CommandId,
 				TargetTypeId = cmd.TargetTypeId,

--- a/Synqra.Projection.InMemory/InMemoryProjection.cs
+++ b/Synqra.Projection.InMemory/InMemoryProjection.cs
@@ -567,7 +567,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 	{
 		var created = new CommandCreatedEvent
 		{
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 0),
 			Data = cmd,
 			CommandId = cmd.CommandId,
 			StreamId = cmd.StreamId,
@@ -605,7 +605,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			CommandId = cmd.CommandId,
 			CollectionId = cmd.CollectionId,
 
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
 
@@ -632,7 +632,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
 			CollectionId = cmd.CollectionId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
 
@@ -650,7 +650,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
 			CollectionId = cmd.CollectionId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
 
@@ -670,7 +670,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
 			CollectionId = cmd.CollectionId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
 
@@ -688,7 +688,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		{
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			LinkTypeId = cmd.LinkTypeId,
 			LinkId = cmd.LinkId,
 			SourceId = cmd.SourceId,
@@ -704,7 +704,7 @@ public class InMemoryProjection : IObjectStore, IProjection, ICommandVisitor<Com
 		{
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			LinkId = cmd.LinkId,
 		});
 		return Task.CompletedTask;

--- a/Synqra.Projection.MongoDb/MongoProjection.cs
+++ b/Synqra.Projection.MongoDb/MongoProjection.cs
@@ -396,7 +396,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
 			CollectionId = cmd.CollectionId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
 			PropertyName = cmd.PropertyName,
@@ -417,7 +417,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
 			CollectionId = cmd.CollectionId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
 			ComponentTypeId = cmd.ComponentTypeId,
@@ -434,7 +434,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
 			CollectionId = cmd.CollectionId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
 			ComponentTypeId = cmd.ComponentTypeId,
@@ -453,7 +453,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
 			CollectionId = cmd.CollectionId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			TargetTypeId = cmd.TargetTypeId,
 			TargetId = cmd.TargetId,
 			ComponentTypeId = cmd.ComponentTypeId,
@@ -471,7 +471,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		{
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			LinkTypeId = cmd.LinkTypeId,
 			LinkId = cmd.LinkId,
 			SourceId = cmd.SourceId,
@@ -487,7 +487,7 @@ public sealed class MongoProjection : IObjectStore, IProjection, ILinkIndex
 		{
 			StreamId = cmd.StreamId,
 			CommandId = cmd.CommandId,
-			EventId = GuidExtensions.CreateVersion7(),
+			EventId = GuidExtensions.Derive(cmd.CommandId, 1),
 			LinkId = cmd.LinkId,
 		});
 		return Task.CompletedTask;

--- a/Synqra.Utils.Tests/DeterministicEventIds.cs
+++ b/Synqra.Utils.Tests/DeterministicEventIds.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Synqra.Utils.Tests;
+
+internal class DeterministicEventIds
+{
+	[Test]
+	public async Task Should_be_deterministic()
+	{
+		var cmd = GuidExtensions.CreateVersion7();
+		await Assert.That(GuidExtensions.Derive(cmd, 1)).IsEqualTo(GuidExtensions.Derive(cmd, 1));
+		await Assert.That(GuidExtensions.Derive(cmd, 2)).IsEqualTo(GuidExtensions.Derive(cmd, 2));
+	}
+
+	[Test]
+	public async Task Should_not_mutate_the_command_id()
+	{
+		var cmd = GuidExtensions.CreateVersion7();
+		var copy = cmd;
+		GuidExtensions.Derive(cmd, 5);
+		await Assert.That(cmd).IsEqualTo(copy);
+	}
+
+	[Test]
+	public async Task Should_stay_a_valid_v7_and_keep_the_command_timestamp()
+	{
+		var cmd = GuidExtensions.CreateVersion7();
+		var ev = GuidExtensions.Derive(cmd, 1);
+		await Assert.That(ev.GetVersion()).IsEqualTo(7);
+		await Assert.That(ev.GetVariant()).IsEqualTo(1);
+		await Assert.That(ev.GetTimestamp()).IsEqualTo(cmd.GetTimestamp());
+	}
+
+	[Test]
+	public async Task Should_sort_after_the_command_and_in_ordinal_order()
+	{
+		var cmd = GuidExtensions.CreateVersion7();
+		var e0 = GuidExtensions.Derive(cmd, 0);
+		var e1 = GuidExtensions.Derive(cmd, 1);
+		var e2 = GuidExtensions.Derive(cmd, 2);
+		await Assert.That(e0).IsEqualTo(cmd); // ordinal 0 == the command id itself
+		await Assert.That(e1.CompareTo(e0)).IsEqualTo(1);
+		await Assert.That(e2.CompareTo(e1)).IsEqualTo(1);
+	}
+
+	[Test]
+	public async Task Should_reject_a_negative_ordinal()
+	{
+		var cmd = GuidExtensions.CreateVersion7();
+		await Assert.That(() => { _ = GuidExtensions.Derive(cmd, -1); }).Throws<ArgumentOutOfRangeException>();
+	}
+}

--- a/Synqra.Utils/GuidExtensions.cs
+++ b/Synqra.Utils/GuidExtensions.cs
@@ -683,6 +683,39 @@ public static class GuidExtensions
 #endif
 	}
 
+	/// <summary>
+	/// Deterministically derives the id of the <paramref name="ordinal"/>-th event a command expands
+	/// to, from the command's own client-generated v7 id. This makes the whole command→event
+	/// expansion reproducible across nodes and replays (core.md §8: same command ⇒ same events) with
+	/// no clock or shared counter. Modelled on the Todo predecessor's id layout (a reserved low-bytes
+	/// counter region + increment): here the low 56 random bits are incremented by <paramref name="ordinal"/>
+	/// while the timestamp, version and variant bytes are preserved, so the result stays a valid,
+	/// time-ordered v7 that sorts adjacent to its command (model.md §8: v7 monotonic for all data).
+	/// </summary>
+	public static unsafe Guid Derive(Guid commandId, int ordinal)
+	{
+		if (ordinal < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(ordinal));
+		}
+		byte* b = (byte*)&commandId;
+		// Increment the trailing 56 random bits (bytes 9..15, big-endian). Bytes 0..8 (timestamp +
+		// version nibble + variant) are untouched, so the derived id is still a valid v7 sharing the
+		// command's time position; ordinals stay far below the 56-bit space for any real command.
+		ulong low = 0;
+		for (int i = 9; i < 16; i++)
+		{
+			low = (low << 8) | b[i];
+		}
+		low += (ulong)ordinal;
+		for (int i = 15; i >= 9; i--)
+		{
+			b[i] = (byte)low;
+			low >>= 8;
+		}
+		return commandId;
+	}
+
 	public static Guid Create(int version)
 	{
 		switch (version)

--- a/docs/model.md
+++ b/docs/model.md
@@ -130,6 +130,13 @@ that is the only form that marries with real-time world-hashing (see Historical 
 
 - **v7 GUIDs** for all data (entities, components, links) — monotonic, totally ordered (undirected
   `min` folding relies on this order).
+- **Event ids are derived, not random.** Each event a command expands to gets `Derive(CommandId,
+  ordinal)` — the command's client-generated v7 id with its low random bits incremented by a small
+  per-command ordinal (the wrapper `CommandCreatedEvent` = ordinal 0, domain events start at 1).
+  This makes the command→event expansion reproducible across nodes and replays (core.md §8) with no
+  clock or shared counter, and the derived id stays a time-ordered v7 that sorts adjacent to its
+  command. (Modelled on the Todo predecessor's id layout: a reserved low-bytes counter region +
+  increment.)
 - **v8 `C0DE…` GUIDs** for well-known/system ids (RFC 9562, application-defined layout). The
   version nibble structurally marks "system/well-known" vs v7 data. Well-known classes carry a
   `CCC` class field; the root entity is a new class here.


### PR DESCRIPTION
Stacked on #124.

## Problem
Every projection stamped event ids with random `GuidExtensions.CreateVersion7()`, so two replicas processing the same command — or a replay — produced **different** `EventId`s. That violates core.md §8 ("same initial state + same commands → the same emitted Events") and breaks cross-node dedup/idempotency under virtual synchrony. Commands are already deterministic (client-generated ids); only the event-id derivation wasn't.

## Approach (per Todo predecessor)
`Todo.Common/Id` used a Mongo-ObjectId layout with a reserved low-bytes **counter** region + `operator ++`. Synqra's v7 has no dedicated counter field, so the faithful port is `GuidExtensions.Derive(commandId, ordinal)`: increment the command id's low 56 random bits by a small per-command ordinal, preserving timestamp/version/variant. The result stays a valid, time-ordered v7 that sorts adjacent to its command (model.md §8: v7 monotonic for all data).

- `CommandCreatedEvent` (wrapper) = ordinal 0 (⇒ EventId == CommandId)
- domain events = ordinal 1, across InMemory / Mongo / File
- documented in model.md §8

## Verified
- 5 new `Derive` unit tests (determinism, no-mutation, valid-v7 + timestamp preserved, ordinal ordering, negative-ordinal guard)
- Synqra.Tests 185/185, Utils.Tests green locally