### PR TITLE
feat(guids): migrate SynqraTypeNamespaceId to v8 C0DE object-type namespace

### DIFF
--- a/Synqra.Model/SynqraGuids.cs
+++ b/Synqra.Model/SynqraGuids.cs
@@ -38,13 +38,21 @@ public static class SynqraGuids
 	 * Reserved UUIDs:
 	 *   - C0DE0000-0000-8000-8000-000000000000 is a reserved UUID to identify principles behind custom UUIDs (vendor-neutral)
 	 *   - C0DEADD0-1032-8000-8000-000000000000 is a reserved synqra-zero UUID to identify "the Synqra UUID reservations table and principles document". Sha256('synqra')[..4] = ADD01032
+	 *   - C0DEADD0-1032-8000-8000-000000000001 is the Synqra object-type namespace (class 000, node 1) — the fixed salt for derived (v5) type ids. See SynqraTypeNamespaceId.
 	 *   - C0DEADD0-1032-8000-800C-000000000000 is a reserved synqra GUID for root/default stream id (before stream id is fully supported in a system, it is a reserved field and requires reserved value to avoid zeros validation)
 	 *
 	 * For Synqra: SHA256("synqra") → first 4 bytes → ADD01032
 	 * To compute: pwsh -c "$h=[Security.Cryptography.SHA256]::Create().ComputeHash([Text.Encoding]::UTF8.GetBytes('synqra'));($h[0..3]|%{$_.ToString('X2')})-join''"
 	 */
 
-	public static Guid SynqraTypeNamespaceId = new("BAD8F923-FA74-4CA0-9AA3-70BB874ACC76"); // NEVER CHANGE THAT! Object type namespace. It does not matter, what pattern it follows, it is just a random but fixed input to sha256 v8 guids it produces from type names.
+	// The Synqra object-type namespace: the fixed salt fed to CreateVersion5(namespace, type.FullName)
+	// to derive a type id for any [SynqraModel] type that does not carry an explicit id
+	// (see TypeMetadataProvider). Follows the v8 C0DE convention — C0DE + sha256("synqra")[..4]=ADD01032
+	// + version 8 + class 000 (object-type namespace) + node 1 (…0000 is the reserved synqra-zero doc).
+	// This value is a persisted contract: derived type ids are written into stored events, so once data
+	// exists this MUST NOT change. (It was migrated once, from the legacy random BAD8F923… salt, to the
+	// self-documenting C0DE form; affected types carry [SynqraLegacyTypeId] aliases for the old ids.)
+	public static Guid SynqraTypeNamespaceId = new("C0DEADD0-1032-8000-8000-000000000001");
 
 	// There is no default/root stream. A stream id is a first-class, mandatory value (a security
 	// boundary): multitenant stores read the ambient SynqraStreamContext.Current (entered per

--- a/Synqra.Model/SynqraModelAttribute.cs
+++ b/Synqra.Model/SynqraModelAttribute.cs
@@ -37,10 +37,20 @@ public sealed class SynqraModelAttribute : Attribute
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
 public sealed class SynqraLegacyTypeIdAttribute : Attribute
 {
-	public SynqraLegacyTypeIdAttribute(string synqraTypeId)
+	public SynqraLegacyTypeIdAttribute(string synqraTypeId, string when, string why)
 	{
 		SynqraTypeId = Guid.Parse(synqraTypeId ?? throw new ArgumentNullException(nameof(synqraTypeId)));
+		When = DateTime.Parse(when ?? throw new ArgumentNullException(nameof(when)), CultureInfo.InvariantCulture, DateTimeStyles.None).Date;
+		Why = !string.IsNullOrWhiteSpace(why)
+			? why
+			: throw new ArgumentException("A reason is required so the motivation for the id change is preserved in the source.", nameof(why));
 	}
 
 	public Guid SynqraTypeId { get; }
+
+	/// <summary>ISO-8601 date (yyyy-MM-dd) the id was superseded — a historic record of when the migration happened.</summary>
+	public DateTime When { get; }
+
+	/// <summary>Why the type id was changed — a historic record of the reason, kept in the source next to the type.</summary>
+	public string Why { get; }
 }

--- a/Tests/Synqra.Tests/SynqraModelAttributeTests.cs
+++ b/Tests/Synqra.Tests/SynqraModelAttributeTests.cs
@@ -31,7 +31,7 @@ public class SynqraModelAttributeTests : BaseTest
 	}
 
 	[SynqraModel("C0DE0000-0000-8000-9041-000000000000")] // 9041 where 9 means test, 41 means exact this test model class (unique per class and above any potential 640 production type codes from 8 space)
-	[SynqraLegacyTypeId("C0DE0000-0000-8000-9040-000000000000")] // a former id (e.g. 9040 before the change to 9041) — still resolves
+	[SynqraLegacyTypeId("C0DE0000-0000-8000-9040-000000000000", "2026-07-19", "test: former id (9040) must still resolve after change to 9041")] // a former id (e.g. 9040 before the change to 9041) — still resolves
 	private sealed class ExplicitTypeIdModel
 	{
 	}

--- a/docs/model.md
+++ b/docs/model.md
@@ -195,6 +195,13 @@ that is the only form that marries with real-time world-hashing (see Historical 
 - **Retired:** the default/root **stream** reservation — a stream id is mandatory and has no default.
   The **MasterId** scheme (term/sequence/collection ordering) is not used — there is no master
   election or monotonic cluster clock.
+- **`SynqraTypeNamespaceId`** — the object-type namespace (class `000`, node `1`):
+  `C0DEADD0-1032-8000-8000-000000000001`. It is the fixed salt fed to `CreateVersion5(namespace,
+  type.FullName)` for any `[SynqraModel]` type that has no explicit id. It is a persisted contract
+  (derived type ids are written into stored events), so once data exists it must not change. It was
+  migrated once from the legacy random salt `BAD8F923-FA74-4CA0-9AA3-70BB874ACC76`; consumer types
+  that were persisted under the old salt carry `[SynqraLegacyTypeId(oldId, when, why)]` aliases so
+  their existing events still resolve.
 
 ### Reserved built-in type ids (registry)
 


### PR DESCRIPTION
Migrates the object-type namespace salt from the legacy random `BAD8F923-FA74-4CA0-9AA3-70BB874ACC76` to the self-documenting v8 C0DE form `C0DEADD0-1032-8000-8000-000000000001` (sha256('synqra')[..4]=ADD01032, class `000` object-type namespace, node `1`; `…0000` stays the reserved synqra-zero doc).

Derived (v5) type ids for attribute-less `[SynqraModel]` types are written into stored events, so this is a persisted contract. To make the migration **graceful** instead of requiring a data drop, `SynqraLegacyTypeIdAttribute` now records the former id as a resolvable alias. As its first users we make provenance mandatory: the ctor gains `(when, why)` so every id change carries a dated reason in source.

- `SynqraGuids`: new namespace value + reserved-list entry + rationale
- `SynqraLegacyTypeIdAttribute`: required `When` (DateTime) + `Why` (string)
- `docs/model.md`: document the namespace reservation and one-time migration

Consumer-side (Quotaly) counterpart stamps `[SynqraLegacyTypeId]` on the 15 durably-persisted Scene models and bumps the submodule pin.

`SynqraModelAttributeTests` pass on net8/9/10.