### PR TITLE
docs: consolidate branches to `main`

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,14 +1,14 @@
 name: Dependency Graph
 
 # Overrides GitHub's dynamically-generated "Automatic Dependency Submission" workflow, which
-# fails repo-wide (every branch, including master) with NETSDK1147 because it never installs the
+# fails repo-wide (every branch, including main) with NETSDK1147 because it never installs the
 # wasm-tools workload that Contoso.Wasm.csproj requires to restore. Defining a workflow here that
 # performs the submission ourselves makes GitHub stop auto-generating its own.
 
 on:
   # GitHub's dynamic version ran on push to every branch, not just the default ones (observed
   # failing on arbitrary feature branches) — match that breadth so it actually supersedes it
-  # everywhere, not just on master/master-quotaly.
+  # everywhere, not just on main.
   push:
   workflow_dispatch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,9 @@ This repository is also used as a **submodule of Quotaly**.
 
 ## Branch Workflow
 
-- Active development for the Quotaly-integrated flow happens on `master-quotaly`.
-- Treat `master-quotaly` as the working branch for new changes unless explicitly told otherwise.
-- `master` remains the upstream/mainline branch that changes will eventually be merged into.
-- Be careful when discussing or preparing merges: in this repo, branch choice is part of the intended workflow, not an incidental local preference.
+- `main` is the single mainline branch for this repo (also the branch Quotaly pins its submodule to).
+- Treat `main` as the working branch for new changes unless explicitly told otherwise.
+- No direct/force push to `main`: land changes via a feature branch + PR against `main`.
 
 ### PR push + CI tracking
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 Synqra
 
-[![Build Status](https://dev.azure.com/xkit/Synqra/_apis/build/status%2FBuild?branchName=master)](https://dev.azure.com/xkit/Synqra/_build/latest?definitionId=103&branchName=master)
+[![Build Status](https://dev.azure.com/xkit/Synqra/_apis/build/status%2FBuild?branchName=main)](https://dev.azure.com/xkit/Synqra/_build/latest?definitionId=103&branchName=main)
 
 1) State management framework. It brings abstractions and mechanisms to provide you a data model, events and commands
 


### PR DESCRIPTION
Follow-up to renaming `master-quotaly` -> `main` and deleting `master`.

Updates stale branch references in docs/CI:
- `AGENTS.md` Branch Workflow section: single `main` branch.
- `readme.md`: Azure build badge `branchName=main`.
- `.github/workflows/dependency-graph.yml`: comment wording.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>