### PR TITLE
test: de-flake WS replication sync tests (widen propagation budget to 30s)

### DIFF
--- a/Tests/Synqra.Tests/Syncronization/BacklogReplaySyncronizationTests.cs
+++ b/Tests/Synqra.Tests/Syncronization/BacklogReplaySyncronizationTests.cs
@@ -17,7 +17,11 @@ namespace Synqra.Tests.Syncronization;
 [NotInParallel]
 internal class BacklogReplaySyncronizationTests : BaseTest
 {
-	const int PropagationTimeoutMs = 10_000;
+	// Matches the 30s online-wait budget (see WaitForOnlineAsync): under docker CPU contention a
+	// node can spend most of that budget just connecting, so a tighter propagation window
+	// occasionally lapses under load even though no event is dropped. Polling exits on first
+	// success, so the happy path never waits the full budget.
+	const int PropagationTimeoutMs = 30_000;
 
 	[Test]
 	public async Task Should_replay_existing_history_to_a_client_that_connects_after_the_data_already_exists()

--- a/Tests/Synqra.Tests/Syncronization/BasicModelSyncronizationTests.cs
+++ b/Tests/Synqra.Tests/Syncronization/BasicModelSyncronizationTests.cs
@@ -127,9 +127,13 @@ internal class BasicModelSyncronizationTests : BaseTest
 		await Assert.That(taskB.Subject).IsEqualTo("Task 1 - updated");
 	}
 
-	// Generous because CI runs these targets in parallel inside docker; the polling
-	// loops above exit as soon as the condition is met, so the happy path never waits.
-	const int PropagationTimeoutMs = 10_000;
+	// Matches the 30s online-wait budget below: CI runs the net8 and net10 targets in parallel
+	// inside docker, each spinning up several Kestrel+WebSocket hosts, so under CPU contention a
+	// node can take most of that budget just to come online — leaving a tighter 10s propagation
+	// window that occasionally lapses (a peer at count 0), even though the events never drop. The
+	// polling loops exit the instant the condition is met, so the happy path never waits the full
+	// budget; this only widens the ceiling before a genuinely stuck sync is declared a failure.
+	const int PropagationTimeoutMs = 30_000;
 
 	async Task WaitForOnlineAsync()
 	{

--- a/Tests/Synqra.Tests/Syncronization/ReplicationEndpointIsolationTests.cs
+++ b/Tests/Synqra.Tests/Syncronization/ReplicationEndpointIsolationTests.cs
@@ -22,7 +22,11 @@ namespace Synqra.Tests.Syncronization;
 [NotInParallel]
 internal class ReplicationEndpointIsolationTests : BaseTest
 {
-	const int PropagationTimeoutMs = 10_000;
+	// Matches the 30s online-wait budget (see WaitForOnlineAsync): under docker CPU contention a
+	// node can spend most of that budget just connecting, so a tighter propagation window
+	// occasionally lapses under load even though no event is dropped. Polling exits on first
+	// success, so the happy path never waits the full budget.
+	const int PropagationTimeoutMs = 30_000;
 	// After the same-stream peer has demonstrably received an event, a cross-stream peer either
 	// already has it (a leak) or never will — the endpoint fans a single event out to all sockets in
 	// one guarded pass. This grace just lets any erroneous delivery land before we assert its absence.


### PR DESCRIPTION
## Why
PR validation for the Quotaly submodule bump went red on a single intermittent test, `Should_20_synchronize_simple_models` (`BasicModelSyncronizationTests`), failing with *expected count 1, has count 0* after ~11s. The same Synqra bits passed on the immediately preceding and following CI runs, so this is a **flake, not a regression** — no event is dropped, the peer simply hasn't converged inside the window under load.

## Root cause
The three WS-replication sync test classes each poll for *eventual* convergence but cap it at **10s** (`PropagationTimeoutMs`), while allowing **30s** just to come online (`WaitForOnlineAsync`). On CI the net8 and net10 targets run in parallel inside docker, each spinning up several Kestrel + WebSocket hosts; under that CPU contention a node can spend most of the online budget merely connecting, leaving a propagation window too tight to converge — an inverted budget (30s to connect, 10s to then sync).

## Fix
Raise `PropagationTimeoutMs` to **30s** in all three sync test classes so the propagation budget matches the online-wait budget. The polling loops exit the instant the condition is met, so the happy path never waits longer — this only widens the ceiling before a genuinely stuck sync is declared a failure.

- `BasicModelSyncronizationTests`
- `BacklogReplaySyncronizationTests`
- `ReplicationEndpointIsolationTests` (positive waits only; the cross-stream leak assertion still uses the unchanged 750ms `LeakGraceMs`)

## Verification
Built `Synqra.Tests` (net10, Release) clean and ran all three classes — 7/7 passing.