### PR TITLE
feat(replication): per-stream outbound filter + socket config hook

### DIFF
--- a/Synqra/EventReplicationConfig.cs
+++ b/Synqra/EventReplicationConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+using System.Net.WebSockets;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Synqra;
@@ -13,6 +14,32 @@ public class EventReplicationConfig
 	/// the correct remote host in deployed environments.
 	/// </summary>
 	public virtual string? Endpoint { get; set; }
+
+	/// <summary>
+	/// When set, this client only <i>sends</i> locally-authored events whose
+	/// <see cref="Event.StreamId"/> matches — every other stream's events in the shared multitenant
+	/// local store are skipped (their outbound cursor still advances). Lets a process replicate one
+	/// specific stream (e.g. a per-user "/tracking" sub-stream) over its own connection without
+	/// leaking, or mis-filing, events from another stream that happens to share the same local store.
+	/// <c>null</c> (the default) replicates every stream, exactly as before.
+	/// <para>
+	/// Deliberately mutable: the stream is often per-user and only known after sign-in, so a host can
+	/// set it just before the service starts (see the auth-gated starter pattern) rather than at DI
+	/// registration time.
+	/// </para>
+	/// </summary>
+	public Guid? StreamId { get; set; }
+
+	/// <summary>
+	/// Hook to configure the outgoing <see cref="ClientWebSocket"/> before it connects — the only
+	/// seam a host has to attach auth to the replication socket. A native client (MAUI/desktop) sets
+	/// <see cref="ClientWebSocketOptions.Cookies"/> to the same <see cref="System.Net.CookieContainer"/>
+	/// its authenticated <c>HttpClient</c> uses, so the cookie-auth'd server endpoint accepts the
+	/// upgrade. A WASM/browser client leaves this <c>null</c>: the browser attaches its origin cookies
+	/// to the WS handshake automatically, and <see cref="ClientWebSocketOptions.Cookies"/> throws
+	/// <see cref="PlatformNotSupportedException"/> there anyway.
+	/// </summary>
+	public Action<ClientWebSocketOptions>? ConfigureSocket { get; set; }
 
 	internal Uri ResolveEndpointUri() =>
 		Endpoint is not null ? new Uri(Endpoint) : new Uri($"ws://localhost:{Port}/api/synqra/ws");

--- a/Synqra/EventReplicationService.cs
+++ b/Synqra/EventReplicationService.cs
@@ -126,6 +126,7 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 			try
 			{
 				wsConnection = new ClientWebSocket();
+				_config.ConfigureSocket?.Invoke(wsConnection.Options);
 				await wsConnection.ConnectAsync(_config.ResolveEndpointUri(), _cts.Token);
 				_networkSerializationService.Reinitialize();
 				// Not online yet — that is declared only after the HELLO handshake completes,
@@ -234,6 +235,16 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 			while (await myEnumerator.MoveNextAsync())
 			{
 				var ev = myEnumerator.Current;
+				// Single-stream connection: skip events belonging to any other stream that shares this
+				// local multitenant store (e.g. the primary stream's events when this connection only
+				// replicates a "/tracking" sub-stream). The outbound cursor still advances past them so
+				// they are never re-examined, and they are never sent to — and mis-stamped by — the
+				// stream-scoped master endpoint. StreamId is set locally even though it is off the wire.
+				if (_config.StreamId is Guid onlyStream && ev.StreamId != onlyStream)
+				{
+					_eventReplicationState.LastEventIdFromMe = ev.EventId;
+					continue;
+				}
 				lock (_skipSet)
 				{
 					if (_skipSet.Add(ev.EventId))


### PR DESCRIPTION
Adds two client-replication seams so a native (MAUI) head can replicate a single per-user sub-stream over an authenticated WebSocket:

- `EventReplicationConfig.ConfigureSocket` — configure the outgoing ClientWebSocket (attach a CookieContainer for cookie auth) before connect. WASM leaves it null.
- `EventReplicationConfig.StreamId` — when set, only locally-authored events with a matching `Event.StreamId` are sent; other streams in the shared multitenant local store are skipped (outbound cursor still advances).

Consumed by Quotaly's activity `/tracking` stream replication.