### PR TITLE
feat(replication): admit host-granted read-only streams per connection

### DIFF
--- a/Synqra.Model/IEventReplicationService.cs
+++ b/Synqra.Model/IEventReplicationService.cs
@@ -6,6 +6,27 @@ public interface IEventReplicationService
 	bool IsOnline { get; }
 
 	/// <summary>
+	/// The streams this connection is currently subscribed to, as last confirmed by the master's
+	/// subscription-state ack (sent after HELLO and every Subscribe/Unsubscribe). A client can compare
+	/// this against what it asked for to detect an unexpected server default. Empty until the first ack.
+	/// </summary>
+	IReadOnlyCollection<Guid> ActiveStreams { get; }
+
+	/// <summary>Raised when the master confirms a change to <see cref="ActiveStreams"/>.</summary>
+	event Action? SubscriptionChanged;
+
+	/// <summary>
+	/// Asks the master to start delivering a stream this connection is authorized to read (its own
+	/// stream or a host-granted shared stream). The master authorizes the request, replays that
+	/// stream's backlog, and acks the resulting <see cref="ActiveStreams"/>. A stream the host does not
+	/// authorize is silently not added — observe <see cref="ActiveStreams"/> to confirm it took.
+	/// </summary>
+	Task SubscribeAsync(Guid streamId, CancellationToken ct = default);
+
+	/// <summary>Asks the master to stop delivering a stream (removing it from <see cref="ActiveStreams"/>).</summary>
+	Task UnsubscribeAsync(Guid streamId, CancellationToken ct = default);
+
+	/// <summary>
 	/// Raised after one or more incoming server events have been appended to this client's local
 	/// durable event log. This service is transport-only — it does not touch any projection. The
 	/// projection owner (test node / client component) subscribes and brings its stream's projection

--- a/Synqra.Replication.AspNetCore/ReplicationStreamScope.cs
+++ b/Synqra.Replication.AspNetCore/ReplicationStreamScope.cs
@@ -15,24 +15,26 @@ namespace Synqra.Replication.AspNetCore;
 /// case every event is admitted, exactly the pre-isolation behavior.
 /// </para>
 /// <para>
-/// <paramref name="readableStreams"/> is an optional host-supplied set of <em>additional</em> streams
-/// the connection may <em>read</em> (never write) — genuinely shared/public streams the host chose to
-/// fan out to every connection (for Quotaly, e.g. the shared metering/main-menu content streams). It is
-/// host-controlled and never taken from the wire, so admitting them onto a scoped connection is safe.
-/// A scoped connection therefore sees its own stream plus these; an unscoped connection still sees all.
+/// <paramref name="activeStreams"/> is the set of streams the connection is currently <em>subscribed</em>
+/// to read — its own writable stream and/or host-granted shared streams (for Quotaly, e.g. the shared
+/// metering/main-menu content streams), as chosen by the HELLO subscription mode and any live
+/// Subscribe/Unsubscribe control frames. It is host-authorized and never taken raw from the wire, so
+/// admitting these onto a scoped connection is safe. Crucially the own writable stream is <em>not</em>
+/// implicitly readable: a connection that opened in EMPTY mode (empty active set) receives nothing —
+/// not even its own stream — until it subscribes. An unscoped connection still sees everything.
 /// </para>
 /// </summary>
 internal static class ReplicationStreamScope
 {
 	/// <summary>
 	/// True if an event on stream <paramref name="candidateStream"/> may be delivered to a connection
-	/// whose own writable stream is <paramref name="connectionStream"/> and which may additionally read
-	/// <paramref name="readableStreams"/>. A scoped connection sees its own stream and any host-supplied
-	/// readable stream (a peer that carries no stream, <c>null</c>, is never admitted onto a scoped
-	/// connection); an unscoped connection sees everything.
+	/// whose own writable stream is <paramref name="connectionStream"/> and whose currently-subscribed
+	/// read-set is <paramref name="activeStreams"/>. A scoped connection admits exactly the streams in
+	/// its active set (a peer/event that carries no stream, <c>null</c>, is never admitted onto a scoped
+	/// connection, and neither is the own stream unless it is in the active set); an unscoped connection
+	/// (<paramref name="connectionStream"/> is <c>null</c>) sees everything.
 	/// </summary>
-	public static bool Admits(System.Guid? candidateStream, System.Guid? connectionStream, System.Collections.Generic.IReadOnlySet<System.Guid>? readableStreams = null)
-		=> connectionStream is not System.Guid stream
-			|| candidateStream == stream
-			|| (candidateStream is System.Guid candidate && readableStreams is not null && readableStreams.Contains(candidate));
+	public static bool Admits(System.Guid? candidateStream, System.Guid? connectionStream, System.Collections.Generic.IReadOnlySet<System.Guid>? activeStreams = null)
+		=> connectionStream is not System.Guid
+			|| (candidateStream is System.Guid candidate && activeStreams is not null && activeStreams.Contains(candidate));
 }

--- a/Synqra.Replication.AspNetCore/ReplicationStreamScope.cs
+++ b/Synqra.Replication.AspNetCore/ReplicationStreamScope.cs
@@ -5,24 +5,34 @@ namespace Synqra.Replication.AspNetCore;
 /// factored out so the isolation decision is asserted directly rather than only through a live
 /// WebSocket. One rule covers both directions the endpoint filters on:
 /// <list type="bullet">
-/// <item>backlog replay — an event is sent to a connection only if it belongs to that connection's stream;</item>
-/// <item>live broadcast — an event is fanned out to a peer socket only if that peer is on the event's stream.</item>
+/// <item>backlog replay — an event is sent to a connection only if it belongs to a stream that connection may read;</item>
+/// <item>live broadcast — an event is fanned out to a peer socket only if that peer may read the event's stream.</item>
 /// </list>
 /// <para>
-/// <paramref name="connectionStream"/> is the stream the receiving connection is authorized for — the
-/// ambient <see cref="SynqraStreamContext"/> the host established (for Quotaly, the authenticated
-/// user's own stream). <c>null</c> means the host set no scope at all — a single-tenant deployment —
-/// in which case every event is admitted, exactly the pre-isolation behavior.
+/// <paramref name="connectionStream"/> is the connection's own writable stream — the ambient
+/// <see cref="SynqraStreamContext"/> the host established (for Quotaly, the authenticated user's own
+/// stream). <c>null</c> means the host set no scope at all — a single-tenant deployment — in which
+/// case every event is admitted, exactly the pre-isolation behavior.
+/// </para>
+/// <para>
+/// <paramref name="readableStreams"/> is an optional host-supplied set of <em>additional</em> streams
+/// the connection may <em>read</em> (never write) — genuinely shared/public streams the host chose to
+/// fan out to every connection (for Quotaly, e.g. the shared metering/main-menu content streams). It is
+/// host-controlled and never taken from the wire, so admitting them onto a scoped connection is safe.
+/// A scoped connection therefore sees its own stream plus these; an unscoped connection still sees all.
 /// </para>
 /// </summary>
 internal static class ReplicationStreamScope
 {
 	/// <summary>
 	/// True if an event on stream <paramref name="candidateStream"/> may be delivered to a connection
-	/// scoped to <paramref name="connectionStream"/>. A scoped connection only ever sees its own
-	/// stream (a peer that carries no stream, <c>null</c>, is never admitted onto a scoped connection);
-	/// an unscoped connection sees everything.
+	/// whose own writable stream is <paramref name="connectionStream"/> and which may additionally read
+	/// <paramref name="readableStreams"/>. A scoped connection sees its own stream and any host-supplied
+	/// readable stream (a peer that carries no stream, <c>null</c>, is never admitted onto a scoped
+	/// connection); an unscoped connection sees everything.
 	/// </summary>
-	public static bool Admits(System.Guid? candidateStream, System.Guid? connectionStream)
-		=> connectionStream is not System.Guid stream || candidateStream == stream;
+	public static bool Admits(System.Guid? candidateStream, System.Guid? connectionStream, System.Collections.Generic.IReadOnlySet<System.Guid>? readableStreams = null)
+		=> connectionStream is not System.Guid stream
+			|| candidateStream == stream
+			|| (candidateStream is System.Guid candidate && readableStreams is not null && readableStreams.Contains(candidate));
 }

--- a/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
+++ b/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
@@ -36,11 +36,13 @@ public static class SynqraReplicationEndpointExtensions
 	/// operates against its own store rather than sharing one global singleton.
 	/// </para>
 	/// <para>
-	/// Pass <paramref name="readableStreamsResolver"/> to let each connection additionally
-	/// <em>read</em> a host-chosen set of shared/public streams beyond its own writable stream
-	/// (see <see cref="ReplicationStreamScope"/>). It is evaluated once per connection from the
-	/// authenticated <see cref="HttpContext"/> and is never taken from the wire, so a client can
-	/// only ever gain read access the host grants it — it still writes solely to its own stream.
+	/// Pass <paramref name="readableStreamsResolver"/> to define, per connection, the set of
+	/// shared/public streams the connection is <em>allowed</em> to read beyond its own writable
+	/// stream (see <see cref="ReplicationStreamScope"/>). It is evaluated once per connection from
+	/// the authenticated <see cref="HttpContext"/> and is never taken from the wire, so a client can
+	/// only ever gain read access the host grants — it still writes solely to its own stream. This is
+	/// the <em>authorization ceiling</em>; which of those streams are actually delivered is chosen by
+	/// the client's HELLO subscription mode and live Subscribe/Unsubscribe frames.
 	/// </para>
 	/// </summary>
 	public static WebApplication MapSynqraReplicationEndpoint(this WebApplication app, string path = "/api/synqra/ws", string? serviceKey = null, Func<HttpContext, IReadOnlySet<Guid>>? readableStreamsResolver = null)
@@ -75,24 +77,48 @@ public static class SynqraReplicationEndpointExtensions
 			// all (a single-tenant deployment): everything below then behaves as before, unscoped.
 			var connectionStream = SynqraStreamContext.CurrentOrNull;
 
-			// Additional streams this connection may READ (never write) — a host-chosen set of
-			// shared/public streams resolved from the authenticated context, never from the wire.
-			// null/empty means "own stream only", the pre-existing behavior.
-			var readableStreams = readableStreamsResolver?.Invoke(ctx);
-			var socketScope = new SocketScope(connectionStream, readableStreams);
+			// Additional streams this connection is AUTHORIZED to read (never write) — a host-chosen
+			// ceiling resolved from the authenticated context, never from the wire. Combined with the
+			// own writable stream this forms the "grantable" set: the most a client could ever be
+			// subscribed to. null/empty resolver means "own stream only".
+			var granted = readableStreamsResolver?.Invoke(ctx);
+			var grantable = new HashSet<Guid>();
+			if (connectionStream is Guid ownStream)
+			{
+				grantable.Add(ownStream);
+			}
+			if (granted is not null)
+			{
+				foreach (var g in granted)
+				{
+					grantable.Add(g);
+				}
+			}
+
+			// Serializes one event as a tagged Event frame: [1 tag byte][SBX NewEvent1 payload]. The
+			// payload is written at offset 1 so the tag can prefix it without a second copy.
+			async Task SendEventFrameAsync(WebSocket target, byte[] frameBuffer, Event ev)
+			{
+				var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, new ArraySegment<byte>(frameBuffer, 1, frameBuffer.Length - 1));
+				frameBuffer[0] = (byte)ReplicationFrameTag.Event;
+				await target.SendAsync(new ArraySegment<byte>(frameBuffer, 0, payload.Count + 1), networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
+			}
 
 			#region HELLO — from client
-			// 8 bytes magic + 16 bytes the client's own "last event id it already received
-			// from a server" cursor (Guid.Empty means "never synced, send me everything") —
-			// see EventReplicationState.LastEventIdFromServer's own remarks.
+			// 8 bytes magic + 16 bytes the client's own "last event id it already received from a
+			// server" cursor (Guid.Empty means "never synced, send me everything") — see
+			// EventReplicationState.LastEventIdFromServer's remarks — plus the HELLO "ws-method":
+			//   byte[24] kind: 0 = NoAutoSubscription, 1 = UserDefaultMainStream, 2 = SubscribeTo.
+			//   For kind 2 the next 16 bytes are the stream id to subscribe to (total 41 bytes).
+			// A legacy 24-byte HELLO omits the kind and is treated as UserDefaultMainStream.
 			var helloBytes = await ReceiveFullMessageAsync(socket, ctx.RequestAborted);
 			if (helloBytes is null)
 			{
 				return;
 			}
-			if (helloBytes.Length != 24)
+			if (helloBytes.Length is not (24 or 25 or 41))
 			{
-				throw new InvalidOperationException($"Protocol negotiation failed: received {helloBytes.Length} bytes instead of 24.");
+				throw new InvalidOperationException($"Protocol negotiation failed: received {helloBytes.Length} bytes (expected 24, 25, or 41).");
 			}
 			var magic = BitConverter.ToUInt64(helloBytes, 0);
 			if (magic != networkSerializationService.Magic)
@@ -100,6 +126,39 @@ public static class SynqraReplicationEndpointExtensions
 				throw new InvalidOperationException($"Protocol negotiation failed: received magic {magic:X16} instead of {networkSerializationService.Magic:X16}.");
 			}
 			var clientCursor = new Guid(helloBytes.AsSpan(8, 16));
+			var helloKind = helloBytes.Length >= 25 ? (ReplicationHelloKind)helloBytes[24] : ReplicationHelloKind.UserDefaultMainStream;
+			// The streams this connection is currently subscribed to. Seeded from the HELLO kind, then
+			// mutated live by Subscribe/Unsubscribe frames. Only ever touched under broadcastGate, so
+			// the broadcast loop's reads never race a subscription change.
+			var active = new HashSet<Guid>();
+			switch (helloKind)
+			{
+				case ReplicationHelloKind.NoAutoSubscription:
+					break;
+				case ReplicationHelloKind.UserDefaultMainStream:
+					if (connectionStream is Guid ownAtHello)
+					{
+						active.Add(ownAtHello);
+					}
+					break;
+				case ReplicationHelloKind.SubscribeTo:
+					if (helloBytes.Length != 41)
+					{
+						throw new InvalidOperationException("Protocol negotiation failed: Hello_SubscribeTo requires a 16-byte stream id (41-byte HELLO).");
+					}
+					var helloTarget = new Guid(helloBytes.AsSpan(25, 16));
+					// Authorize against the ceiling — an unscoped host (no connectionStream) admits any
+					// stream; a scoped host admits only streams in the grantable set. A rejected target
+					// simply leaves the active set empty; the ack below reveals what actually took.
+					if (connectionStream is null || grantable.Contains(helloTarget))
+					{
+						active.Add(helloTarget);
+					}
+					break;
+				default:
+					throw new InvalidOperationException($"Protocol negotiation failed: unknown HELLO kind {helloBytes[24]}.");
+			}
+			var socketScope = new SocketScope(connectionStream, grantable, active);
 			#endregion
 
 			#region HELLO — to client, then replay this stream's backlog since clientCursor
@@ -117,6 +176,10 @@ public static class SynqraReplicationEndpointExtensions
 				sockets[socket] = socketScope;
 				await socket.SendAsync(magicBytes, WebSocketMessageType.Binary, endOfMessage: true, ctx.RequestAborted);
 
+				// Auto-ack the HELLO with the authoritative active set, so the client can immediately
+				// tell whether the server's default matched what it expected (see SubscriptionState).
+				await socket.SendSubscriptionStateAsync(socketScope.Active, networkSerializationService.IsTextOrBinary, ctx.RequestAborted);
+
 				var storage = serviceKey is null
 					? ctx.RequestServices.GetRequiredService<IAppendStorage<Event, Guid>>()
 					: ctx.RequestServices.GetRequiredKeyedService<IAppendStorage<Event, Guid>>(serviceKey);
@@ -125,18 +188,16 @@ public static class SynqraReplicationEndpointExtensions
 				{
 					await foreach (var ev in storage.GetAllAsync(from: clientCursor, ctx.RequestAborted))
 					{
-						// Replay only streams THIS connection may read — its own stream plus any host-
-						// granted readable stream. The log is one shared multitenant collection;
-						// ev.StreamId (persisted as _sid) says which stream each event belongs to.
-						// Without this filter the backlog leaked every stream's events to any
-						// connecting client. Unscoped host (connectionStream null) → send all.
-						if (!ReplicationStreamScope.Admits(ev.StreamId, connectionStream, readableStreams))
+						// Replay only streams THIS connection is currently subscribed to. The log is one
+						// shared multitenant collection; ev.StreamId (persisted as _sid) says which stream
+						// each event belongs to. Without this filter the backlog leaked every stream's
+						// events to any connecting client. Unscoped host (connectionStream null) → send all.
+						if (!ReplicationStreamScope.Admits(ev.StreamId, connectionStream, socketScope.Active))
 						{
 							continue;
 						}
 						knownEvents.TryAdd(ev.EventId, null);
-						var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, backlogBuffer);
-						await socket.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
+						await SendEventFrameAsync(socket, backlogBuffer, ev);
 					}
 				}
 				finally
@@ -160,7 +221,72 @@ public static class SynqraReplicationEndpointExtensions
 				{
 					break;
 				}
-				var operation = networkSerializationService.Deserialize<TransportOperation>(messageBytes);
+				if (messageBytes.Length == 0)
+				{
+					continue;
+				}
+				var frameTag = (ReplicationFrameTag)messageBytes[0];
+
+				// Subscribe / Unsubscribe control frames: [tag][16-byte stream id]. Mutate this
+				// connection's active set (under the broadcast gate so the fan-out loop never races it),
+				// replay the newly-subscribed stream's backlog, then ack the resulting active set.
+				if (frameTag is ReplicationFrameTag.Subscribe or ReplicationFrameTag.Unsubscribe)
+				{
+					if (messageBytes.Length != 17)
+					{
+						throw new InvalidOperationException($"Malformed {frameTag} frame: {messageBytes.Length} bytes (expected 17).");
+					}
+					var target = new Guid(messageBytes.AsSpan(1, 16));
+					await broadcastGate.WaitAsync(ctx.RequestAborted);
+					try
+					{
+						if (frameTag is ReplicationFrameTag.Subscribe)
+						{
+							// Authorize against the ceiling: unscoped host admits any stream, scoped host
+							// only its grantable set. A rejected target leaves the active set unchanged —
+							// the ack tells the client it did not take.
+							if ((connectionStream is null || grantable.Contains(target)) && socketScope.Active.Add(target))
+							{
+								var storage = serviceKey is null
+									? ctx.RequestServices.GetRequiredService<IAppendStorage<Event, Guid>>()
+									: ctx.RequestServices.GetRequiredKeyedService<IAppendStorage<Event, Guid>>(serviceKey);
+								var subBuffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
+								try
+								{
+									await foreach (var ev in storage.GetAllAsync(from: default, ctx.RequestAborted))
+									{
+										if (ev.StreamId != target)
+										{
+											continue;
+										}
+										knownEvents.TryAdd(ev.EventId, null);
+										await SendEventFrameAsync(socket, subBuffer, ev);
+									}
+								}
+								finally
+								{
+									ArrayPool<byte>.Shared.Return(subBuffer);
+								}
+							}
+						}
+						else
+						{
+							socketScope.Active.Remove(target);
+						}
+						await socket.SendSubscriptionStateAsync(socketScope.Active, networkSerializationService.IsTextOrBinary, ctx.RequestAborted);
+					}
+					finally
+					{
+						broadcastGate.Release();
+					}
+					continue;
+				}
+
+				if (frameTag is not ReplicationFrameTag.Event)
+				{
+					throw new NotSupportedException($"Unsupported replication frame tag: {frameTag}.");
+				}
+				var operation = networkSerializationService.Deserialize<TransportOperation>(messageBytes.AsSpan(1));
 				if (operation is not NewEvent1 newEvent1)
 				{
 					throw new NotSupportedException($"Unsupported transport operation: {operation.GetType()}.");
@@ -195,23 +321,21 @@ public static class SynqraReplicationEndpointExtensions
 					var buffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
 					try
 					{
-						var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, buffer);
 						foreach (var (other, otherScope) in sockets)
 						{
 							if (other == socket || other.State != WebSocketState.Open) { continue; }
-							// Only fan out to peers that may READ the event's stream (their own stream
-							// or a host-granted readable stream). Without this a client's event was
-							// broadcast to every connected socket regardless of stream — a live
-							// cross-tenant leak. The check is oriented per peer: does THIS peer admit
-							// the event's stream (ev.StreamId, stamped above from the sender's stream)?
-							// Unscoped peer (null own stream) → admits all, as before.
-							if (!ReplicationStreamScope.Admits(ev.StreamId, otherScope.WritableStream, otherScope.ReadableStreams))
+							// Only fan out to peers subscribed to the event's stream. Without this a
+							// client's event was broadcast to every connected socket regardless of stream
+							// — a live cross-tenant leak. The check is oriented per peer: is THIS peer
+							// currently subscribed to the event's stream (ev.StreamId, stamped above from
+							// the sender's stream)? Unscoped peer (null own stream) → admits all, as before.
+							if (!ReplicationStreamScope.Admits(ev.StreamId, otherScope.WritableStream, otherScope.Active))
 							{
 								continue;
 							}
 							try
 							{
-								await other.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
+								await SendEventFrameAsync(other, buffer, ev);
 							}
 							catch (Exception broadcastEx)
 							{
@@ -279,7 +403,21 @@ public static class SynqraReplicationEndpointExtensions
 		}
 	}
 
-	/// <summary>Per-connection routing tags: the connection's own writable stream and the host-granted
-	/// set of additional readable streams. Both feed <see cref="ReplicationStreamScope.Admits"/>.</summary>
-	readonly record struct SocketScope(Guid? WritableStream, IReadOnlySet<Guid>? ReadableStreams);
+	/// <summary>Per-connection routing state: the connection's own writable stream, the host-authorized
+	/// ceiling of streams it MAY read (<see cref="Grantable"/>), and the subset it is currently
+	/// subscribed to (<see cref="Active"/>, mutated live by Subscribe/Unsubscribe frames, only ever under
+	/// the endpoint's broadcast gate). <see cref="Active"/> feeds <see cref="ReplicationStreamScope.Admits"/>.</summary>
+	sealed class SocketScope
+	{
+		public SocketScope(Guid? writableStream, IReadOnlySet<Guid> grantable, HashSet<Guid> active)
+		{
+			WritableStream = writableStream;
+			Grantable = grantable;
+			Active = active;
+		}
+
+		public Guid? WritableStream { get; }
+		public IReadOnlySet<Guid> Grantable { get; }
+		public HashSet<Guid> Active { get; }
+	}
 }

--- a/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
+++ b/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
@@ -77,10 +77,12 @@ public static class SynqraReplicationEndpointExtensions
 			// all (a single-tenant deployment): everything below then behaves as before, unscoped.
 			var connectionStream = SynqraStreamContext.CurrentOrNull;
 
-			// Additional streams this connection is AUTHORIZED to read (never write) — a host-chosen
-			// ceiling resolved from the authenticated context, never from the wire. Combined with the
-			// own writable stream this forms the "grantable" set: the most a client could ever be
-			// subscribed to. null/empty resolver means "own stream only".
+			// Additional streams this connection may read — a host-chosen ceiling resolved from the
+			// authenticated context, never from the wire. Combined with the own stream this forms the
+			// "grantable" set: the most a client could ever be subscribed to. null/empty resolver means
+			// "own stream only". Only the read (event-delivery) path exists today; submitting events
+			// to a subscribed stream is a future replication-API concern tracked separately, not an
+			// inherent restriction of these streams.
 			var granted = readableStreamsResolver?.Invoke(ctx);
 			var grantable = new HashSet<Guid>();
 			if (connectionStream is Guid ownStream)

--- a/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
+++ b/Synqra.Replication.AspNetCore/SynqraReplicationEndpointExtensions.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Synqra;
@@ -34,17 +35,24 @@ public static class SynqraReplicationEndpointExtensions
 	/// <see cref="IAppendStorage{Event, Guid}"/> from the keyed DI slot so each feature
 	/// operates against its own store rather than sharing one global singleton.
 	/// </para>
+	/// <para>
+	/// Pass <paramref name="readableStreamsResolver"/> to let each connection additionally
+	/// <em>read</em> a host-chosen set of shared/public streams beyond its own writable stream
+	/// (see <see cref="ReplicationStreamScope"/>). It is evaluated once per connection from the
+	/// authenticated <see cref="HttpContext"/> and is never taken from the wire, so a client can
+	/// only ever gain read access the host grants it — it still writes solely to its own stream.
+	/// </para>
 	/// </summary>
-	public static WebApplication MapSynqraReplicationEndpoint(this WebApplication app, string path = "/api/synqra/ws", string? serviceKey = null)
+	public static WebApplication MapSynqraReplicationEndpoint(this WebApplication app, string path = "/api/synqra/ws", string? serviceKey = null, Func<HttpContext, IReadOnlySet<Guid>>? readableStreamsResolver = null)
 	{
 		app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(20) });
 
-		// Each connected socket is tagged with the stream it is authorized for, so a broadcast
-		// only reaches peers on the same stream (see the broadcast loop below). Was a
-		// ConcurrentBag<WebSocket> — a set with no per-socket stream and, worse, no removal, so
-		// dead sockets accumulated forever. A dictionary gives both the stream tag and O(1)
-		// removal on disconnect.
-		var sockets = new ConcurrentDictionary<WebSocket, Guid?>();
+		// Each connected socket is tagged with its own writable stream plus the host-granted set of
+		// additional readable streams, so a broadcast only reaches peers that may read the event's
+		// stream (see the broadcast loop below). Was a ConcurrentBag<WebSocket> — a set with no
+		// per-socket stream and, worse, no removal, so dead sockets accumulated forever. A dictionary
+		// gives both the routing tags and O(1) removal on disconnect.
+		var sockets = new ConcurrentDictionary<WebSocket, SocketScope>();
 		var broadcastGate = new SemaphoreSlim(1, 1);
 		var knownEvents = new ConcurrentDictionary<Guid, object?>();
 
@@ -66,6 +74,12 @@ public static class SynqraReplicationEndpointExtensions
 			// must not be able to name another user's stream. null means the host set no scope at
 			// all (a single-tenant deployment): everything below then behaves as before, unscoped.
 			var connectionStream = SynqraStreamContext.CurrentOrNull;
+
+			// Additional streams this connection may READ (never write) — a host-chosen set of
+			// shared/public streams resolved from the authenticated context, never from the wire.
+			// null/empty means "own stream only", the pre-existing behavior.
+			var readableStreams = readableStreamsResolver?.Invoke(ctx);
+			var socketScope = new SocketScope(connectionStream, readableStreams);
 
 			#region HELLO — from client
 			// 8 bytes magic + 16 bytes the client's own "last event id it already received
@@ -100,7 +114,7 @@ public static class SynqraReplicationEndpointExtensions
 			await broadcastGate.WaitAsync(ctx.RequestAborted);
 			try
 			{
-				sockets[socket] = connectionStream;
+				sockets[socket] = socketScope;
 				await socket.SendAsync(magicBytes, WebSocketMessageType.Binary, endOfMessage: true, ctx.RequestAborted);
 
 				var storage = serviceKey is null
@@ -111,11 +125,12 @@ public static class SynqraReplicationEndpointExtensions
 				{
 					await foreach (var ev in storage.GetAllAsync(from: clientCursor, ctx.RequestAborted))
 					{
-						// Replay only THIS connection's stream. The log is one shared multitenant
-						// collection; ev.StreamId (persisted as _sid) says which stream each event
-						// belongs to. Without this filter the backlog leaked every stream's events
-						// to any connecting client. Unscoped host (connectionStream null) → send all.
-						if (!ReplicationStreamScope.Admits(ev.StreamId, connectionStream))
+						// Replay only streams THIS connection may read — its own stream plus any host-
+						// granted readable stream. The log is one shared multitenant collection;
+						// ev.StreamId (persisted as _sid) says which stream each event belongs to.
+						// Without this filter the backlog leaked every stream's events to any
+						// connecting client. Unscoped host (connectionStream null) → send all.
+						if (!ReplicationStreamScope.Admits(ev.StreamId, connectionStream, readableStreams))
 						{
 							continue;
 						}
@@ -181,15 +196,16 @@ public static class SynqraReplicationEndpointExtensions
 					try
 					{
 						var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, buffer);
-						foreach (var (other, otherStream) in sockets)
+						foreach (var (other, otherScope) in sockets)
 						{
 							if (other == socket || other.State != WebSocketState.Open) { continue; }
-							// Only fan out to peers on the same stream as the event. Without this a
-							// client's event was broadcast to every connected socket regardless of
-							// stream — a live cross-tenant leak. Unscoped host (connectionStream null)
-							// → broadcast to all, as before. (connectionStream == ev.StreamId here,
-							// since inbound events were stamped with it above.)
-							if (!ReplicationStreamScope.Admits(otherStream, connectionStream))
+							// Only fan out to peers that may READ the event's stream (their own stream
+							// or a host-granted readable stream). Without this a client's event was
+							// broadcast to every connected socket regardless of stream — a live
+							// cross-tenant leak. The check is oriented per peer: does THIS peer admit
+							// the event's stream (ev.StreamId, stamped above from the sender's stream)?
+							// Unscoped peer (null own stream) → admits all, as before.
+							if (!ReplicationStreamScope.Admits(ev.StreamId, otherScope.WritableStream, otherScope.ReadableStreams))
 							{
 								continue;
 							}
@@ -262,4 +278,8 @@ public static class SynqraReplicationEndpointExtensions
 			ArrayPool<byte>.Shared.Return(rent);
 		}
 	}
+
+	/// <summary>Per-connection routing tags: the connection's own writable stream and the host-granted
+	/// set of additional readable streams. Both feed <see cref="ReplicationStreamScope.Admits"/>.</summary>
+	readonly record struct SocketScope(Guid? WritableStream, IReadOnlySet<Guid>? ReadableStreams);
 }

--- a/Synqra/EventReplicationConfig.cs
+++ b/Synqra/EventReplicationConfig.cs
@@ -4,9 +4,43 @@ using System.Text.Json.Serialization;
 
 namespace Synqra;
 
+/// <summary>
+/// What a replication client asks the master to start pushing right after HELLO — the "ws-method"
+/// encoded as the HELLO kind byte (see <see cref="EventReplicationService"/> /
+/// <see cref="Synqra.Replication.AspNetCore"/>'s endpoint). Whatever the choice, the master replies
+/// with an authoritative subscription-state ack so the client can detect an unexpected default.
+/// </summary>
+public enum ReplicationHelloKind : byte
+{
+	/// <summary>Hello_NoAutoSubscription — start subscribed to nothing (not even the own stream) until
+	/// the client issues its own Subscribe frames. For UIs that drive their own per-view subscriptions.</summary>
+	NoAutoSubscription = 0,
+
+	/// <summary>Hello_Subscribed_UserDefaultMainStream — start subscribed to just the user's own default
+	/// main stream. The simple "give me my data" default.</summary>
+	UserDefaultMainStream = 1,
+
+	/// <summary>Hello_SubscribeTo — start subscribed to one specific stream named in the HELLO (see
+	/// <see cref="EventReplicationConfig.InitialSubscribeStreamId"/>), if the host ceiling authorizes it.</summary>
+	SubscribeTo = 2,
+}
+
 public class EventReplicationConfig
 {
 	public virtual ushort Port { get; set; }
+
+	/// <summary>
+	/// The HELLO "ws-method" announced in the handshake. <see cref="ReplicationHelloKind.UserDefaultMainStream"/>
+	/// (start subscribed to the own main stream) unless a self-subscribing client chooses
+	/// <see cref="ReplicationHelloKind.NoAutoSubscription"/> or <see cref="ReplicationHelloKind.SubscribeTo"/>.
+	/// </summary>
+	public virtual ReplicationHelloKind HelloKind { get; set; } = ReplicationHelloKind.UserDefaultMainStream;
+
+	/// <summary>
+	/// The stream to subscribe to at HELLO when <see cref="HelloKind"/> is
+	/// <see cref="ReplicationHelloKind.SubscribeTo"/>. Ignored for the other kinds.
+	/// </summary>
+	public virtual Guid? InitialSubscribeStreamId { get; set; }
 
 	/// <summary>
 	/// Full WebSocket endpoint URI for the replication master. When set, overrides the default

--- a/Synqra/EventReplicationService.cs
+++ b/Synqra/EventReplicationService.cs
@@ -33,9 +33,32 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 	public bool IsOnline { get => _isOnline; private set => _isOnline = value; }
 
 	private Task? _readerTask;
+	private ClientWebSocket? _wsConnection;
+	private volatile IReadOnlyCollection<Guid> _activeStreams = Array.Empty<Guid>();
+
+	/// <inheritdoc />
+	public IReadOnlyCollection<Guid> ActiveStreams => _activeStreams;
+
+	/// <inheritdoc />
+	public event Action? SubscriptionChanged;
 
 	/// <inheritdoc />
 	public event Action? EventsReceived;
+
+	/// <inheritdoc />
+	public Task SubscribeAsync(Guid streamId, CancellationToken ct = default)
+		=> SendStreamControlAsync(ReplicationFrameTag.Subscribe, streamId, ct);
+
+	/// <inheritdoc />
+	public Task UnsubscribeAsync(Guid streamId, CancellationToken ct = default)
+		=> SendStreamControlAsync(ReplicationFrameTag.Unsubscribe, streamId, ct);
+
+	private async Task SendStreamControlAsync(ReplicationFrameTag tag, Guid streamId, CancellationToken ct)
+	{
+		var socket = _wsConnection ?? throw new InvalidOperationException("Not connected — cannot change subscriptions before the replication client has connected.");
+		using var linked = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, ct);
+		await socket.SendStreamControlFrameAsync(tag, streamId, _networkSerializationService.IsTextOrBinary, linked.Token);
+	}
 
 	public EventReplicationService(
 		  IOptions<EventReplicationConfig> options
@@ -128,6 +151,7 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 				wsConnection = new ClientWebSocket();
 				_config.ConfigureSocket?.Invoke(wsConnection.Options);
 				await wsConnection.ConnectAsync(_config.ResolveEndpointUri(), _cts.Token);
+				_wsConnection = wsConnection;
 				_networkSerializationService.Reinitialize();
 				// Not online yet — that is declared only after the HELLO handshake completes,
 				// when the master is guaranteed to have registered this node for broadcasts.
@@ -170,7 +194,27 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 					IsOnline = false;
 					break;
 				}
-				var operation = _networkSerializationService.Deserialize<TransportOperation>(bytes);
+				var frameTag = (ReplicationFrameTag)bytes[0];
+				if (frameTag == ReplicationFrameTag.SubscriptionState)
+				{
+					// Master's authoritative snapshot of the streams this connection is now subscribed
+					// to (N*16 bytes after the tag). Lets the client detect an unexpected default and
+					// drive its own UI off the confirmed set. Sent after HELLO and every sub/unsub.
+					var count = (bytes.Length - 1) / 16;
+					var streams = new Guid[count];
+					for (var i = 0; i < count; i++)
+					{
+						streams[i] = new Guid(bytes.AsSpan(1 + (i * 16), 16));
+					}
+					_activeStreams = streams;
+					SubscriptionChanged?.Invoke();
+					continue;
+				}
+				if (frameTag != ReplicationFrameTag.Event)
+				{
+					throw new NotSupportedException($"Unsupported replication frame tag: {frameTag}.");
+				}
+				var operation = _networkSerializationService.Deserialize<TransportOperation>(bytes.AsSpan(1));
 				switch (operation)
 				{
 					case NewEvent1 ne1:
@@ -203,16 +247,22 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 
 		#region HELLO
 		{
-			// 8 bytes magic + 16 bytes LastEventIdFromServer — tells the server exactly
-			// where this client's backlog catch-up should resume from (Guid.Empty means
-			// "never synced, send me everything"). See SynqraReplicationEndpointExtensions.cs's
-			// own remarks on the server side of this handshake.
-			var buffer = ArrayPool<byte>.Shared.Rent(24);
+			// 8 bytes magic + 16 bytes LastEventIdFromServer (Guid.Empty = "send me everything") + the
+			// HELLO "ws-method": byte[24] kind, and for Hello_SubscribeTo the next 16 bytes are the
+			// stream id (total 41 bytes). See SynqraReplicationEndpointExtensions.cs for the server side.
+			var isSubscribeTo = _config.HelloKind == ReplicationHelloKind.SubscribeTo;
+			var helloSize = isSubscribeTo ? 41 : 25;
+			var buffer = ArrayPool<byte>.Shared.Rent(helloSize);
 			try
 			{
 				BitConverter.TryWriteBytes(buffer, _networkSerializationService.Magic);
 				_eventReplicationState.LastEventIdFromServer.TryWriteBytes(buffer.AsSpan(8, 16));
-				await wsConnection.SendAsync(new ArraySegment<byte>(buffer, 0, 24), WebSocketMessageType.Binary, endOfMessage: true, _cts.Token);
+				buffer[24] = (byte)_config.HelloKind;
+				if (isSubscribeTo)
+				{
+					(_config.InitialSubscribeStreamId ?? throw new InvalidOperationException("HelloKind SubscribeTo requires InitialSubscribeStreamId.")).TryWriteBytes(buffer.AsSpan(25, 16));
+				}
+				await wsConnection.SendAsync(new ArraySegment<byte>(buffer, 0, helloSize), WebSocketMessageType.Binary, endOfMessage: true, _cts.Token);
 			}
 			finally
 			{
@@ -263,9 +313,12 @@ public class EventReplicationService : BackgroundService, IEventReplicationServi
 				// var span = new Span<byte>(bytes);
 				try
 				{
-					var serialized = _networkSerializationService.Serialize<TransportOperation>(inv, bytes);
+					// [1 tag byte][SBX payload] — payload written at offset 1 so the Event tag prefixes
+					// it without a second copy. Matches the server's framing (ReplicationFrameTag).
+					var serialized = _networkSerializationService.Serialize<TransportOperation>(inv, new ArraySegment<byte>(bytes, 1, bytes.Length - 1));
+					bytes[0] = (byte)ReplicationFrameTag.Event;
 					EmergencyLog.Default.LogInformation($"{GetHashCode():X4} >>> {ev}");
-					await wsConnection.SendAsync(serialized, _networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, endOfMessage: true, _cts.Token);
+					await wsConnection.SendAsync(new ArraySegment<byte>(bytes, 0, serialized.Count + 1), _networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, endOfMessage: true, _cts.Token);
 				}
 				finally
 				{

--- a/Synqra/ReplicationFraming.cs
+++ b/Synqra/ReplicationFraming.cs
@@ -1,0 +1,70 @@
+using System.Buffers;
+using System.Net.WebSockets;
+
+namespace Synqra;
+
+/// <summary>
+/// The first byte of every post-HELLO replication frame, disambiguating a domain-event payload from
+/// the transport-control frames that drive client-driven subscriptions. Kept out of the SBX
+/// (<see cref="INetworkSerializationService"/>) model layer on purpose: these are transport metadata,
+/// not domain events, so they never touch the codegen-stamped model serializer.
+/// </summary>
+public enum ReplicationFrameTag : byte
+{
+	/// <summary>The remaining bytes are an SBX-serialized <see cref="TransportOperation"/> (a NewEvent1).</summary>
+	Event = 0,
+
+	/// <summary>Client → master: "subscribe me to this stream" — 16 bytes, a stream <see cref="Guid"/>.</summary>
+	Subscribe = 1,
+
+	/// <summary>Client → master: "unsubscribe me from this stream" — 16 bytes, a stream <see cref="Guid"/>.</summary>
+	Unsubscribe = 2,
+
+	/// <summary>Master → client: the authoritative snapshot of the streams this connection is now
+	/// subscribed to — N*16 bytes, N stream <see cref="Guid"/>s (N may be zero). Sent right after HELLO
+	/// and after every Subscribe/Unsubscribe so the client can detect an unexpected default.</summary>
+	SubscriptionState = 3,
+}
+
+/// <summary>Send helpers for the tagged post-HELLO replication frames (see <see cref="ReplicationFrameTag"/>).</summary>
+public static class ReplicationFramingExtensions
+{
+	/// <summary>Sends a single-stream control frame (<see cref="ReplicationFrameTag.Subscribe"/> /
+	/// <see cref="ReplicationFrameTag.Unsubscribe"/>): 1 tag byte + the 16-byte stream id.</summary>
+	public static async ValueTask SendStreamControlFrameAsync(this WebSocket socket, ReplicationFrameTag tag, Guid streamId, bool text, CancellationToken ct)
+	{
+		var buffer = ArrayPool<byte>.Shared.Rent(17);
+		try
+		{
+			buffer[0] = (byte)tag;
+			streamId.TryWriteBytes(buffer.AsSpan(1, 16));
+			await socket.SendAsync(new ArraySegment<byte>(buffer, 0, 17), text ? WebSocketMessageType.Text : WebSocketMessageType.Binary, endOfMessage: true, ct);
+		}
+		finally
+		{
+			ArrayPool<byte>.Shared.Return(buffer);
+		}
+	}
+
+	/// <summary>Sends the master → client subscription-state ack: 1 tag byte + N*16 bytes of stream ids.</summary>
+	public static async ValueTask SendSubscriptionStateAsync(this WebSocket socket, IReadOnlyCollection<Guid> streams, bool text, CancellationToken ct)
+	{
+		var size = 1 + (streams.Count * 16);
+		var buffer = ArrayPool<byte>.Shared.Rent(size);
+		try
+		{
+			buffer[0] = (byte)ReplicationFrameTag.SubscriptionState;
+			var offset = 1;
+			foreach (var s in streams)
+			{
+				s.TryWriteBytes(buffer.AsSpan(offset, 16));
+				offset += 16;
+			}
+			await socket.SendAsync(new ArraySegment<byte>(buffer, 0, size), text ? WebSocketMessageType.Text : WebSocketMessageType.Binary, endOfMessage: true, ct);
+		}
+		finally
+		{
+			ArrayPool<byte>.Shared.Return(buffer);
+		}
+	}
+}

--- a/Tests/Synqra.Tests/ReplicationStreamScopeTests.cs
+++ b/Tests/Synqra.Tests/ReplicationStreamScopeTests.cs
@@ -15,12 +15,13 @@ public class ReplicationStreamScopeTests
 	static readonly Guid StreamB = Guid.NewGuid();
 
 	[Test]
-	public async Task A_scoped_connection_admits_only_its_own_stream()
+	public async Task A_scoped_connection_admits_only_its_active_streams()
 	{
-		// The core isolation guarantee: a connection authorized for stream A sees A's events and
-		// nothing else. Before this rule the backlog and broadcast admitted every stream.
-		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA)).IsTrue();
-		await Assert.That(ReplicationStreamScope.Admits(StreamB, StreamA)).IsFalse();
+		// The core isolation guarantee: a connection subscribed to stream A sees A's events and
+		// nothing else. The own writable stream is admitted only because it is in the active set.
+		var active = new HashSet<Guid> { StreamA };
+		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA, active)).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(StreamB, StreamA, active)).IsFalse();
 	}
 
 	[Test]
@@ -28,8 +29,9 @@ public class ReplicationStreamScopeTests
 	{
 		// A legacy/unstamped event (StreamId null or default) must NOT leak onto a scoped
 		// connection — the whole point of stamping inbound events and backfilling _sid.
-		await Assert.That(ReplicationStreamScope.Admits(null, StreamA)).IsFalse();
-		await Assert.That(ReplicationStreamScope.Admits(Guid.Empty, StreamA)).IsFalse();
+		var active = new HashSet<Guid> { StreamA };
+		await Assert.That(ReplicationStreamScope.Admits(null, StreamA, active)).IsFalse();
+		await Assert.That(ReplicationStreamScope.Admits(Guid.Empty, StreamA, active)).IsFalse();
 	}
 
 	[Test]
@@ -44,25 +46,26 @@ public class ReplicationStreamScopeTests
 	}
 
 	[Test]
-	public async Task A_scoped_connection_also_admits_host_granted_readable_streams()
+	public async Task A_scoped_connection_admits_every_active_stream()
 	{
-		// Multi-stream read: a connection scoped to A that the host additionally grants read access
-		// to B sees both A's and B's events, but still nothing else (C), and still never an
-		// unstamped/zero event.
-		var readable = new HashSet<Guid> { StreamB };
-		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA, readable)).IsTrue();
-		await Assert.That(ReplicationStreamScope.Admits(StreamB, StreamA, readable)).IsTrue();
-		await Assert.That(ReplicationStreamScope.Admits(Guid.NewGuid(), StreamA, readable)).IsFalse();
-		await Assert.That(ReplicationStreamScope.Admits(null, StreamA, readable)).IsFalse();
-		await Assert.That(ReplicationStreamScope.Admits(Guid.Empty, StreamA, readable)).IsFalse();
+		// Multi-stream read: a connection subscribed to both A and B sees both, but still nothing
+		// else (C), and still never an unstamped/zero event.
+		var active = new HashSet<Guid> { StreamA, StreamB };
+		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA, active)).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(StreamB, StreamA, active)).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(Guid.NewGuid(), StreamA, active)).IsFalse();
+		await Assert.That(ReplicationStreamScope.Admits(null, StreamA, active)).IsFalse();
+		await Assert.That(ReplicationStreamScope.Admits(Guid.Empty, StreamA, active)).IsFalse();
 	}
 
 	[Test]
-	public async Task An_empty_readable_set_is_own_stream_only()
+	public async Task An_empty_active_set_admits_nothing_not_even_the_own_stream()
 	{
-		// A resolver that grants nothing is identical to the single-stream behavior.
-		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA, new HashSet<Guid>())).IsTrue();
+		// The EMPTY subscription mode: a scoped connection that has subscribed to nothing yet
+		// receives no events at all — not even its own stream — until it Subscribes.
+		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA, new HashSet<Guid>())).IsFalse();
 		await Assert.That(ReplicationStreamScope.Admits(StreamB, StreamA, new HashSet<Guid>())).IsFalse();
+		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA, null)).IsFalse();
 	}
 }
 #endif

--- a/Tests/Synqra.Tests/ReplicationStreamScopeTests.cs
+++ b/Tests/Synqra.Tests/ReplicationStreamScopeTests.cs
@@ -42,5 +42,27 @@ public class ReplicationStreamScopeTests
 		await Assert.That(ReplicationStreamScope.Admits(null, null)).IsTrue();
 		await Assert.That(ReplicationStreamScope.Admits(Guid.Empty, null)).IsTrue();
 	}
+
+	[Test]
+	public async Task A_scoped_connection_also_admits_host_granted_readable_streams()
+	{
+		// Multi-stream read: a connection scoped to A that the host additionally grants read access
+		// to B sees both A's and B's events, but still nothing else (C), and still never an
+		// unstamped/zero event.
+		var readable = new HashSet<Guid> { StreamB };
+		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA, readable)).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(StreamB, StreamA, readable)).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(Guid.NewGuid(), StreamA, readable)).IsFalse();
+		await Assert.That(ReplicationStreamScope.Admits(null, StreamA, readable)).IsFalse();
+		await Assert.That(ReplicationStreamScope.Admits(Guid.Empty, StreamA, readable)).IsFalse();
+	}
+
+	[Test]
+	public async Task An_empty_readable_set_is_own_stream_only()
+	{
+		// A resolver that grants nothing is identical to the single-stream behavior.
+		await Assert.That(ReplicationStreamScope.Admits(StreamA, StreamA, new HashSet<Guid>())).IsTrue();
+		await Assert.That(ReplicationStreamScope.Admits(StreamB, StreamA, new HashSet<Guid>())).IsFalse();
+	}
 }
 #endif

--- a/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
+++ b/Tests/Synqra.Tests/Simulator/SynqraTestNode.cs
@@ -384,16 +384,18 @@ internal class SynqraTestNode
 
 				#region HELLO - from client
 				// 8 bytes magic + 16 bytes the client's own "last event id it already
-				// received from a server" cursor — see EventReplicationService's HELLO send
-				// and EventReplicationState.LastEventIdFromServer's own remarks.
+				// received from a server" cursor, plus an optional 25th subscription-mode byte
+				// (see EventReplicationService's HELLO send). This simulator is single-stream by
+				// construction, so the mode byte is accepted and ignored — there is only ever one
+				// stream to subscribe to.
 				var helloBytes = await ReceiveFullMessageAsync(socket, ctx.RequestAborted);
 				if (helloBytes is null)
 				{
 					return;
 				}
-				if (helloBytes.Length != 24)
+				if (helloBytes.Length is not (24 or 25 or 41))
 				{
-					throw new Exception($"Protocol Negotiation Failed! Received {helloBytes.Length} bytes instead of 24.");
+					throw new Exception($"Protocol Negotiation Failed! Received {helloBytes.Length} bytes instead of 24, 25 or 41.");
 				}
 				var magic = BitConverter.ToUInt64(helloBytes, 0);
 				if (magic != networkSerializationService.Magic)
@@ -422,8 +424,9 @@ internal class SynqraTestNode
 						await foreach (var ev in backlogStorage.GetAllAsync(from: clientCursor, ctx.RequestAborted))
 						{
 							knownEvents.TryAdd(ev.EventId, null);
-							var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, backlogBuffer);
-							await socket.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
+							var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, new ArraySegment<byte>(backlogBuffer, 1, backlogBuffer.Length - 1));
+							backlogBuffer[0] = (byte)ReplicationFrameTag.Event;
+							await socket.SendAsync(new ArraySegment<byte>(backlogBuffer, 0, payload.Count + 1), networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
 						}
 					}
 					finally
@@ -446,7 +449,15 @@ internal class SynqraTestNode
 						{
 							break;
 						}
-						var operation = networkSerializationService.Deserialize<TransportOperation>(messageBytes);
+						// Post-HELLO frames carry a 1-byte channel tag (Event/Subscribe/Unsubscribe/
+						// SubscriptionState). This single-stream simulator only acts on Event frames;
+						// client-driven Subscribe/Unsubscribe control frames are accepted and ignored.
+						var frameTag = (ReplicationFrameTag)messageBytes[0];
+						if (frameTag is ReplicationFrameTag.Subscribe or ReplicationFrameTag.Unsubscribe)
+						{
+							continue;
+						}
+						var operation = networkSerializationService.Deserialize<TransportOperation>(messageBytes.AsSpan(1));
 
 						var storeCtx = _projection ?? throw new InvalidOperationException("Master projection not initialized.");
 						if (operation is NewEvent1 newEvent1)
@@ -468,14 +479,16 @@ internal class SynqraTestNode
 								var buffer = ArrayPool<byte>.Shared.Rent(EventReplicationService.DefaultFrameSize);
 								try
 								{
-									var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, buffer);
+									var payload = networkSerializationService.Serialize<TransportOperation>(new NewEvent1 { Event = ev }, new ArraySegment<byte>(buffer, 1, buffer.Length - 1));
+									buffer[0] = (byte)ReplicationFrameTag.Event;
+									var taggedFrame = new ArraySegment<byte>(buffer, 0, payload.Count + 1);
 									foreach (var item in _sockets)
 									{
 										if (item != socket)
 										{
 											try
 											{
-												await item.SendAsync(payload, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
+												await item.SendAsync(taggedFrame, networkSerializationService.IsTextOrBinary ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true, ctx.RequestAborted);
 											}
 											catch
 											{


### PR DESCRIPTION
Generalizes the WS replication endpoint so a connection scoped to its own writable stream can also receive a host-granted, read-only set of shared streams (e.g. metering / main-menu).

- `ReplicationStreamScope.Admits` takes an optional `IReadOnlySet<Guid>? readableStreams`.
- `MapSynqraReplicationEndpoint` gains a `readableStreamsResolver` resolved once per connection from the authenticated `HttpContext` (never from the wire).
- Broadcast admission is re-oriented per-peer since the relation is no longer symmetric.
- +3 `ReplicationStreamScopeTests` (net10, 5/5 green).

Needed to bump the Quotaly submodule pin for multi-stream replication to the browser.