### PR TITLE
refactor(sbx): put `ref int pos` right after the span in every Serialize overload

### DIFF
--- a/Synqra.AppendStorage.BlobStorage/BlobAppendStorage.cs
+++ b/Synqra.AppendStorage.BlobStorage/BlobAppendStorage.cs
@@ -207,7 +207,7 @@ public class BlobAppendStorage<T, TKey> : IAppendStorage<T, TKey>, IClearableApp
 		{
 			bytesWritten = 0;
 			_serializer.Reset();
-			_serializer.Serialize(destination, item, ref bytesWritten);
+			_serializer.Serialize(destination, ref bytesWritten, item);
 			return true;
 		}
 		catch (Exception ex) when (IsCapacityException(ex))

--- a/Synqra.BinarySerializer.Abstractions/ISBXSerializer.cs
+++ b/Synqra.BinarySerializer.Abstractions/ISBXSerializer.cs
@@ -10,23 +10,23 @@ public interface ISbxSerializer
 
 	#region SERIALIZE
 
-	void Serialize<T>(in Span<byte> buffer, in T value, ref int pos);
+	void Serialize<T>(in Span<byte> buffer, ref int pos, in T value);
 
-	void Serialize(in Span<byte> buffer, long value, ref int pos);
-	void Serialize(in Span<byte> buffer, ulong value, ref int pos);
-	// void Serialize(in Span<byte> buffer, string? value, ref int pos); // here string is nullable intentionally // it is disabled intentionally as nullable renamed and this one is duplicated from object nullability standpoint
-	void Serialize(in Span<byte> buffer, Guid value, ref int pos); // There is no "in" for guid, becuase Guid logic uses stack copy for quick unsafe operations
-	void Serialize(in Span<byte> buffer, float data, ref int pos);
-	void Serialize(in Span<byte> buffer, double data, ref int pos);
+	void Serialize(in Span<byte> buffer, ref int pos, long value);
+	void Serialize(in Span<byte> buffer, ref int pos, ulong value);
+	// void Serialize(in Span<byte> buffer, ref int pos, string? value); // here string is nullable intentionally // it is disabled intentionally as nullable renamed and this one is duplicated from object nullability standpoint
+	void Serialize(in Span<byte> buffer, ref int pos, Guid value); // There is no "in" for guid, becuase Guid logic uses stack copy for quick unsafe operations
+	void Serialize(in Span<byte> buffer, ref int pos, float data);
+	void Serialize(in Span<byte> buffer, ref int pos, double data);
 
 	#region Nullable
 
-	void Serialize(in Span<byte> buffer, long? data, ref int pos);
-	void Serialize(in Span<byte> buffer, ulong? data, ref int pos);
-	void Serialize(in Span<byte> buffer, string? data, ref int pos);
-	void Serialize(in Span<byte> buffer, Guid? data, ref int pos);
-	void Serialize(in Span<byte> buffer, float? data, ref int pos);
-	void Serialize(in Span<byte> buffer, double? data, ref int pos);
+	void Serialize(in Span<byte> buffer, ref int pos, long? data);
+	void Serialize(in Span<byte> buffer, ref int pos, ulong? data);
+	void Serialize(in Span<byte> buffer, ref int pos, string? data);
+	void Serialize(in Span<byte> buffer, ref int pos, Guid? data);
+	void Serialize(in Span<byte> buffer, ref int pos, float? data);
+	void Serialize(in Span<byte> buffer, ref int pos, double? data);
 
 	#endregion
 
@@ -57,7 +57,7 @@ public interface ISbxSerializer
 	#endregion
 
 	// it will go <T> route and will emit proper prefixes
-	// void Serialize<T>(in Span<byte> buffer, in IEnumerable<T> value, ref int pos);
+	// void Serialize<T>(in Span<byte> buffer, ref int pos, in IEnumerable<T> value);
 	IList<T> DeserializeList<T>(in ReadOnlySpan<byte> buffer, ref int pos);
 	IDictionary<TK, TV> DeserializeDict<TK, TV>(in ReadOnlySpan<byte> buffer, ref int pos);
 }

--- a/Synqra.BinarySerializer.SourceGenerator/SbxBindingGenerator.cs
+++ b/Synqra.BinarySerializer.SourceGenerator/SbxBindingGenerator.cs
@@ -801,7 +801,7 @@ public class SbxBindingGenerator : IIncrementalGenerator
 				var access = (!doesSupportField && SymbolEqualityComparer.Default.Equals(pro.ContainingType, containingType))
 					? GetFieldName(pro, doesSupportField: false)
 					: "this." + pro.Name;
-				body.AppendLine($"\t\t\tserializer.Serialize(in buffer, {access}, ref pos);");
+				body.AppendLine($"\t\t\tserializer.Serialize(in buffer, ref pos, {access});");
 			}
 			body.AppendLine($"\t\t}}");
 			els = "else ";

--- a/Synqra.BinarySerializer/SBXSerializer.cs
+++ b/Synqra.BinarySerializer/SBXSerializer.cs
@@ -288,8 +288,8 @@ public class SbxSerializer : ISbxSerializer
 	{
 		public void Get(KeyValuePair<TK, TV> model, ISbxSerializer serializer, float schemaVersion, in Span<byte> buffer, ref int pos)
 		{
-			serializer.Serialize(buffer, model.Key, ref pos);
-			serializer.Serialize(buffer, model.Value, ref pos);
+			serializer.Serialize(buffer, ref pos, model.Key);
+			serializer.Serialize(buffer, ref pos, model.Value);
 		}
 
 		public void Get(object model, ISbxSerializer serializer, float schemaVersion, in Span<byte> buffer, ref int pos)
@@ -373,24 +373,24 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] T>(
 		  in Span<byte> buffer
-		, in T? obj
 		, ref int pos
+		, in T? obj
 		)
 	{
-		Serialize(buffer, obj, ref pos, typeof(T));
+		Serialize(buffer, ref pos, obj, typeof(T));
 	}
 
 	public void Serialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] T>(
 		  in Span<byte> buffer
-		, in T? obj
 		, ref int pos
+		, in T? obj
 		, bool? emitTypeId = null
 		)
 	{
 		Serialize(
 			  buffer
-			, obj
 			, ref pos
+			, obj
 			, typeof(T)
 			, emitTypeId
 			);
@@ -398,8 +398,8 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(
 		  in Span<byte> buffer
-		, in object? obj
 		, ref int pos
+		, in object? obj
 		, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type requestedType
 		, bool? emitTypeId = null
 		)
@@ -461,14 +461,14 @@ public class SbxSerializer : ISbxSerializer
 				{
 					var (IdForList, SpecList, ListTSpecified, SharedElementType) = GetTypeIdForList(requestedType, obj);
 					typeId = IdForList;
-					Serialize(in buffer, (long)typeId, ref pos
+					Serialize(in buffer, ref pos, (long)typeId
 #if DEBUG
 						, $"List TypeId for requested {requestedType.FullName}, actual {actualType?.FullName}, SpecList={SpecList}, ListTSpecified={ListTSpecified}, SharedElementType={SharedElementType}"
 #endif
 						);
 					if (SpecList != null)
 					{
-						Serialize(in buffer, (int)SpecList.Value, ref pos
+						Serialize(in buffer, ref pos, (int)SpecList.Value
 #if DEBUG
 							, $"SpecList"
 #endif
@@ -476,7 +476,7 @@ public class SbxSerializer : ISbxSerializer
 					}
 					if (ListTSpecified != null)
 					{
-						Serialize(in buffer, (int)ListTSpecified.Value, ref pos
+						Serialize(in buffer, ref pos, (int)ListTSpecified.Value
 #if DEBUG
 							, $"ListTSpecified"
 #endif
@@ -484,7 +484,7 @@ public class SbxSerializer : ISbxSerializer
 					}
 					if (SharedElementType != null)
 					{
-						Serialize(in buffer, (int)SharedElementType.Value, ref pos
+						Serialize(in buffer, ref pos, (int)SharedElementType.Value
 #if DEBUG
 							, $"SharedElementType"
 #endif
@@ -493,7 +493,7 @@ public class SbxSerializer : ISbxSerializer
 				}
 				else
 				{
-					Serialize(in buffer, (long)typeId, ref pos
+					Serialize(in buffer, ref pos, (long)typeId
 #if DEBUG
 							, $"typeId"
 #endif
@@ -504,22 +504,22 @@ public class SbxSerializer : ISbxSerializer
 					var aqn = actualType.AssemblyQualifiedName;
 					aqn = aqn[0..aqn.IndexOf(',', aqn.IndexOf(',') + 1)]; // trim assembly part
 
-					Serialize(buffer, aqn ?? throw new NotSupportedException(), ref pos);
+					Serialize(buffer, ref pos, aqn ?? throw new NotSupportedException());
 				}
 			}
 			else if (obj == null)
 			{
-				Serialize(in buffer, (long)TypeId.Null, ref pos);
+				Serialize(in buffer, ref pos, (long)TypeId.Null);
 			}
 			/*
 			else if (typeId == TypeId.Unknown)
 			{
-				Serialize(in buffer, (int)TypeId.AsRequested, ref pos);
+				Serialize(in buffer, ref pos, (int)TypeId.AsRequested);
 			}
 			*/
 			else
 			{
-				Serialize(in buffer, (int)TypeId.AsRequested, ref pos);
+				Serialize(in buffer, ref pos, (int)TypeId.AsRequested);
 			}
 		}
 		else if (obj == null)
@@ -533,7 +533,7 @@ public class SbxSerializer : ISbxSerializer
 			*/
 			if (requestedType.IsAssignableTo(typeof(IEnumerable)))
 			{
-				Serialize(buffer, (ulong?)null, ref pos);
+				Serialize(buffer, ref pos, (ulong?)null);
 				return;
 			}
 			throw new NotSupportedException("Need to track capability of a type to encode null state inside value. You likely hitting generic overload of Serialize instead of some specific type capable to encode nullability.");
@@ -558,45 +558,45 @@ public class SbxSerializer : ISbxSerializer
 		}
 		else if (obj is int i)
 		{
-			Serialize(in buffer, (long)i, ref pos);
+			Serialize(in buffer, ref pos, (long)i);
 		}
 		else if (obj is long l)
 		{
-			Serialize(in buffer, (long)l, ref pos);
+			Serialize(in buffer, ref pos, (long)l);
 		}
 		else if (obj is uint ui)
 		{
-			Serialize(in buffer, (ulong)ui, ref pos);
+			Serialize(in buffer, ref pos, (ulong)ui);
 		}
 		else if (obj is ulong ul)
 		{
-			Serialize(in buffer, (ulong)ul, ref pos);
+			Serialize(in buffer, ref pos, (ulong)ul);
 		}
 		else if (obj is float f)
 		{
-			Serialize(in buffer, f, ref pos);
+			Serialize(in buffer, ref pos, f);
 		}
 		else if (obj is double d)
 		{
-			Serialize(in buffer, d, ref pos);
+			Serialize(in buffer, ref pos, d);
 		}
 		else if (obj is Guid g)
 		{
-			Serialize(in buffer, g, ref pos);
+			Serialize(in buffer, ref pos, g);
 		}
 		else if (obj is string s)
 		{
-			Serialize(in buffer, s, ref pos);
+			Serialize(in buffer, ref pos, s);
 		}
 		else if (obj is KeyValuePair<string, string> ks)
 		{
-			Serialize(in buffer, ks.Key, ref pos);
-			Serialize(in buffer, ks.Value, ref pos);
+			Serialize(in buffer, ref pos, ks.Key);
+			Serialize(in buffer, ref pos, ks.Value);
 		}
 		else if (obj is KeyValuePair<string, object> ko)
 		{
-			Serialize(in buffer, ko.Key, ref pos);
-			Serialize(in buffer, ko.Value, ref pos);
+			Serialize(in buffer, ref pos, ko.Key);
+			Serialize(in buffer, ref pos, ko.Value);
 		}
 		else if (obj is IEnumerable enumerable)
 		{
@@ -611,12 +611,12 @@ public class SbxSerializer : ISbxSerializer
 				(bool SpecList, bool CustomT, ListItemTypeId ItemsType) = Decompose(listTypeId);
 				if (ItemsType != ListItemTypeId.Empty)
 				{
-					Serialize(in buffer, enumerable, ref pos/*, requestedCollectionType: requestedType*/, emitTypePerElement: ItemsType == ListItemTypeId.Heterogen);
+					Serialize(in buffer, ref pos, enumerable/*, requestedCollectionType: requestedType*/, emitTypePerElement: ItemsType == ListItemTypeId.Heterogen);
 				}
 			}
 			else // statically known!
 			{
-				Serialize(in buffer, enumerable, ref pos/*, requestedCollectionType: requestedType*/, emitTypePerElement: false);
+				Serialize(in buffer, ref pos, enumerable/*, requestedCollectionType: requestedType*/, emitTypePerElement: false);
 				// throw new Exception($"List type expected but typeId is {typeId}");
 			}
 		}
@@ -653,12 +653,12 @@ public class SbxSerializer : ISbxSerializer
 				var val = item.GetValue(obj);
 				if (val != null)
 				{
-					Serialize(in buffer, item.Name, ref pos);
-					Serialize(in buffer, val, ref pos);
+					Serialize(in buffer, ref pos, item.Name);
+					Serialize(in buffer, ref pos, val);
 				}
 			}
 			// we keep reading strings for the next property name! So let empty string be EndOfObject
-			Serialize(in buffer, "", ref pos);
+			Serialize(in buffer, ref pos, "");
 		}
 	}
 
@@ -977,14 +977,14 @@ public class SbxSerializer : ISbxSerializer
 	/*
 	public void Serialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] T>(
 		  in Span<byte> buffer
-		, in IEnumerable<T> list
 		, ref int pos
+		, in IEnumerable<T> list
 		)
 	{
 		Serialize(
 			  buffer
-			, list
 			, ref pos
+			, list
 			, requestedCollectionType: typeof(T)
 			);
 	}
@@ -992,8 +992,8 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(
 		  in Span<byte> buffer
-		, in IEnumerable enumerable
 		, ref int pos
+		, in IEnumerable enumerable
 		, bool emitTypePerElement
 		// , [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type? requestedCollectionType = null
 		)
@@ -1053,7 +1053,7 @@ public class SbxSerializer : ISbxSerializer
 
 		if (enumerable is null)
 		{
-			Serialize(buffer, (ulong?)null, ref pos);
+			Serialize(buffer, ref pos, (ulong?)null);
 			return;
 		}
 
@@ -1062,11 +1062,11 @@ public class SbxSerializer : ISbxSerializer
 		var cnt = materialized.Count;
 		// if (cnt > 0)
 		{
-			Serialize(buffer, (ulong?)cnt, ref pos);
+			Serialize(buffer, ref pos, (ulong?)cnt);
 		}
 		foreach (var item in materialized)
 		{
-			Serialize(buffer, item, ref pos, emitTypeId: emitTypePerElement);
+			Serialize(buffer, ref pos, item, emitTypeId: emitTypePerElement);
 		}
 	}
 
@@ -1392,14 +1392,14 @@ public class SbxSerializer : ISbxSerializer
 		};
 	}
 
-	public void Serialize(in Span<byte> buffer, Type type, ref int pos)
+	public void Serialize(in Span<byte> buffer, ref int pos, Type type)
 	{
 		var typeId = GetTypeId(type);
-		Serialize(buffer, typeId, ref pos);
+		Serialize(buffer, ref pos, typeId);
 		if (typeId == TypeId.Unknown)
 		{
 			var typeName = type.FullName ?? throw new Exception("Type has no full name: " + type.Name);
-			Serialize(buffer, typeName, ref pos);
+			Serialize(buffer, ref pos, typeName);
 		}
 	}
 
@@ -1503,7 +1503,7 @@ public class SbxSerializer : ISbxSerializer
 		}
 	}
 
-	public void Serialize(in Span<byte> buffer, string? data, ref int pos)
+	public void Serialize(in Span<byte> buffer, ref int pos, string? data)
 	{
 		if (data == null)
 		{
@@ -1571,7 +1571,7 @@ public class SbxSerializer : ISbxSerializer
 	/*
 	public void Serialize(ref Span<byte> buffer, string data)
 	{
-		// Serialize(buffer, (uint)data.Length, ref pos);
+		// Serialize(buffer, ref pos, (uint)data.Length);
 		var pos = _utf8.GetBytes(data, buffer);
 		buffer[pos++] = 0; // null terminator
 		buffer = buffer[pos..];
@@ -1588,7 +1588,7 @@ public class SbxSerializer : ISbxSerializer
 
 	#region Floating Point
 
-	public unsafe void Serialize(in Span<byte> buffer, float data, ref int pos)
+	public unsafe void Serialize(in Span<byte> buffer, ref int pos, float data)
 	{
 		var bytes = (byte*)&data;
 		buffer[pos++] = bytes[0];
@@ -1596,14 +1596,14 @@ public class SbxSerializer : ISbxSerializer
 		buffer[pos++] = bytes[2];
 		buffer[pos++] = bytes[3];
 	}
-	public unsafe void Serialize(in Span<byte> buffer, double data, ref int pos)
+	public unsafe void Serialize(in Span<byte> buffer, ref int pos, double data)
 	{
 		/*
 		// test single downgrade
 		var single = Convert.ToSingle(data);
 		if (single == data)
 		{
-			Serialize(buffer, single, ref pos);
+			Serialize(buffer, ref pos, single);
 		}
 		else
 		{
@@ -1620,34 +1620,34 @@ public class SbxSerializer : ISbxSerializer
 		buffer[pos++] = bytes[6];
 		buffer[pos++] = bytes[7];
 	}
-	public unsafe void Serialize(in Span<byte> buffer, float? data, ref int pos)
+	public unsafe void Serialize(in Span<byte> buffer, ref int pos, float? data)
 	{
 		if (data == null)
 		{
-			Serialize(buffer, float.NegativeZero, ref pos);
+			Serialize(buffer, ref pos, float.NegativeZero);
 		}
 		else if (data == 0f)
 		{
-			Serialize(buffer, 0f, ref pos); // silent normalization of nezative zero
+			Serialize(buffer, ref pos, 0f); // silent normalization of nezative zero
 		}
 		else
 		{
-			Serialize(buffer, data.Value, ref pos);
+			Serialize(buffer, ref pos, data.Value);
 		}
 	}
-	public void Serialize(in Span<byte> buffer, double? data, ref int pos)
+	public void Serialize(in Span<byte> buffer, ref int pos, double? data)
 	{
 		if (data == null)
 		{
-			Serialize(buffer, double.NegativeZero, ref pos);
+			Serialize(buffer, ref pos, double.NegativeZero);
 		}
 		else if (data == 0d)
 		{
-			Serialize(buffer, 0d, ref pos); // silent normalization of nezative zero
+			Serialize(buffer, ref pos, 0d); // silent normalization of nezative zero
 		}
 		else
 		{
-			Serialize(buffer, data.Value, ref pos);
+			Serialize(buffer, ref pos, data.Value);
 		}
 	}
 	public unsafe float DeserializeSingle(in ReadOnlySpan<byte> buffer, ref int pos)
@@ -1692,12 +1692,12 @@ public class SbxSerializer : ISbxSerializer
 
 	#region Nullable Signed Integer
 
-	public void Serialize(in Span<byte> buffer, long? data, ref int pos)
+	public void Serialize(in Span<byte> buffer, ref int pos, long? data)
 	{
 		// ZigZag encode the signed int with null offset
 		if (data == null)
 		{
-			Serialize(buffer, (ulong)0, ref pos);
+			Serialize(buffer, ref pos, (ulong)0);
 			return;
 		}
 		if (data > 0)
@@ -1742,23 +1742,23 @@ public class SbxSerializer : ISbxSerializer
 
 	#region Signed Integer
 
-	private void Serialize(in Span<byte> buffer, TypeId data, ref int pos)
+	private void Serialize(in Span<byte> buffer, ref int pos, TypeId data)
 	{
-		Serialize(buffer, (long)data, ref pos);
+		Serialize(buffer, ref pos, (long)data);
 	}
 
 #if DEBUG
 	public List<(int, int, string)> Tokens = new List<(int, int, string)>();
 
-	public void Serialize(in Span<byte> buffer, long data, ref int pos, string tokenDebugData)
+	public void Serialize(in Span<byte> buffer, ref int pos, long data, string tokenDebugData)
 	{
 		var start = pos;
-		Serialize(in buffer, in data, ref pos);
+		Serialize(in buffer, ref pos, in data);
 		Tokens.Add((start, pos, tokenDebugData));
 	}
 #endif
 
-	public void Serialize(in Span<byte> buffer, long data, ref int pos)
+	public void Serialize(in Span<byte> buffer, ref int pos, long data)
 	{
 		// ZigZag encode the signed int
 		ulong zigzag = (ulong)(data << 1 ^ data >> 63);
@@ -1820,7 +1820,7 @@ public class SbxSerializer : ISbxSerializer
 
 	#region Nullable Unsigned Integer
 
-	public void Serialize(in Span<byte> buffer, ulong? value, ref int pos)
+	public void Serialize(in Span<byte> buffer, ref int pos, ulong? value)
 	{
 		if (value == null)
 		{
@@ -1830,7 +1830,7 @@ public class SbxSerializer : ISbxSerializer
 		{
 			value++;
 		}
-		Serialize(buffer, value.Value, ref pos);
+		Serialize(buffer, ref pos, value.Value);
 	}
 
 	public ulong? DeserializeNullableUnsigned(in ReadOnlySpan<byte> buffer, ref int pos)
@@ -1850,7 +1850,7 @@ public class SbxSerializer : ISbxSerializer
 
 	#region Unsigned Integer
 
-	public void Serialize(in Span<byte> buffer, ulong value, ref int pos)
+	public void Serialize(in Span<byte> buffer, ref int pos, ulong value)
 	{
 		// Protobuf-style varint encoding for uint32 (little-endian, 7 bits per byte, MSB=1 means more)
 		while (value >= 0x80)
@@ -1930,7 +1930,7 @@ public class SbxSerializer : ISbxSerializer
 
 	#region Guid
 
-	public void Serialize(in Span<byte> buffer, Guid? data, ref int pos)
+	public void Serialize(in Span<byte> buffer, ref int pos, Guid? data)
 	{
 		if (data == null)
 		{
@@ -1938,11 +1938,11 @@ public class SbxSerializer : ISbxSerializer
 		}
 		else
 		{
-			Serialize<Guid?>(buffer, data, ref pos);
+			Serialize<Guid?>(buffer, ref pos, data);
 		}
 	}
 
-	public unsafe void Serialize(in Span<byte> buffer, Guid data, ref int pos)
+	public unsafe void Serialize(in Span<byte> buffer, ref int pos, Guid data)
 	{
 		// In scope of Synqra and SBX we only use Guid v4, v5, v7, v8
 		// In guid v4 there is nothing to compress
@@ -2076,7 +2076,7 @@ public class SbxSerializer : ISbxSerializer
 							time = _streamBaseTime.AddMilliseconds(dms);
 							// Console.WriteLine($">> time2_ {time:HH:mm:ss.fffff}");
 							// Console.WriteLine(">> dms_ " + (ulong)dms);
-							Serialize(buffer, dms, ref pos);
+							Serialize(buffer, ref pos, dms);
 							buffer[pos++] = bytes[6]; // rand_a_low
 							buffer[pos++] = (byte)((bytes[7] & 0x0C) << 4 | bytes[8] & 0x3F); // packed8 rand_a_high 2 other bit + byte8
 							// buffer[pos++] = 0;

--- a/Synqra.Projection.CommonStoreSupport/SynqraPocoTrackingExtensions.cs
+++ b/Synqra.Projection.CommonStoreSupport/SynqraPocoTrackingExtensions.cs
@@ -66,7 +66,7 @@ public static class SynqraPocoTrackingExtensions
 			_serializer.Reset();
 			Span<byte> buffer = stackalloc byte[10240];
 			var pos = 0;
-			_serializer.Serialize(buffer, item, ref pos);
+			_serializer.Serialize(buffer, ref pos, item);
 			_originalsSerialized[item] = buffer[..pos].ToArray();
 		}
 
@@ -89,7 +89,7 @@ public static class SynqraPocoTrackingExtensions
 				// serialzie again
 				_serializer.Reset();
 				var pos = 0;
-				_serializer.Serialize(buffer, kvp.Key, ref pos);
+				_serializer.Serialize(buffer, ref pos, kvp.Key);
 				if (!buffer[..pos].SequenceEqual(kvp.Value))
 				{
 					// changed!!

--- a/Synqra/INetworkSerializationService.cs
+++ b/Synqra/INetworkSerializationService.cs
@@ -83,7 +83,7 @@ public class SbxNetworkSerializationService : INetworkSerializationService
 
 		ArraySegment<byte> span = buffer == default ? new byte[EventReplicationService.DefaultFrameSize] : buffer; // stackalloc byte[EventReplicationService.DefaultFrameSize];
 		int pos = 0;
-		_sbxSerializerSender.Serialize(span, obj, ref pos);
+		_sbxSerializerSender.Serialize(span, ref pos, obj);
 		span = span[..pos];
 
 #if DEBUG

--- a/Tests/Synqra.BinarySerializer.Tests/BinarySerializationTests.cs
+++ b/Tests/Synqra.BinarySerializer.Tests/BinarySerializationTests.cs
@@ -47,7 +47,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 		var ser = new SbxSerializer();
 		ser.SetTimeBase(new DateTime(2025, 10, 7, 15, 17, 38, DateTimeKind.Utc));
 		int pos = 0;
-		ser.Serialize(buffer, guid, ref pos);
+		ser.Serialize(buffer, ref pos, guid);
 		var pos2 = 0;
 		HexDump(buffer.Slice(0, pos));
 		var deserialized = ser.DeserializeGuid(buffer[0..pos], ref pos2);
@@ -72,7 +72,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 			int pos = 0;
 			
 			var original = new GuidExtensions.Generator().CreateVersion7(i);
-			ser.Serialize(buffer, original, ref pos);
+			ser.Serialize(buffer, ref pos, original);
 
 			if (pos > lastLen)
 			{
@@ -116,7 +116,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 		ser.SetTimeBase(new DateTime(2025, 10, 7, 15, 17, 38, DateTimeKind.Utc));
 		Span<byte> buffer = stackalloc byte[20];
 		int pos = 0;
-		ser.Serialize(buffer, id, ref pos);
+		ser.Serialize(buffer, ref pos, id);
 		int rpos = 0;
 		var back = ser.DeserializeGuid(buffer[..pos], ref rpos);
 		Assert.That(back).IsEqualTo(id).GetAwaiter().GetResult();
@@ -140,7 +140,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 			var guid = GuidExtensions.CreateVersion7();
 #endif
 			int pos = 0;
-			ser.Serialize(buffer, guid, ref pos);
+			ser.Serialize(buffer, ref pos, guid);
 			int pos2 = 0;
 			var deserialized = ser.DeserializeGuid(buffer[..pos], ref pos2);
 			Assert.That(pos2).IsEqualTo(pos).GetAwaiter().GetResult();
@@ -177,7 +177,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 		{
 			var guid = new GuidExtensions.Generator().CreateVersion7(date);
 			int pos = 0;
-			ser.Serialize(buffer, guid, ref pos);
+			ser.Serialize(buffer, ref pos, guid);
 			int pos2 = 0;
 			var deserialized = ser.DeserializeGuid(buffer[..pos], ref pos2);
 			Assert.That(pos2).IsEqualTo(pos).GetAwaiter().GetResult();
@@ -208,7 +208,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 		{
 			var guid = GuidExtensions.CreateVersion8_Sha256_Dns(Guid.NewGuid().ToString());
 			int pos = 0;
-			ser.Serialize(buffer, guid, ref pos);
+			ser.Serialize(buffer, ref pos, guid);
 			int pos2 = 0;
 			var deserialized = ser.DeserializeGuid(buffer, ref pos2);
 			try
@@ -258,7 +258,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 #endif
 
 			int pos = 0;
-			ser.Serialize(buffer, guid, ref pos);
+			ser.Serialize(buffer, ref pos, guid);
 			int pos2 = 0;
 			var deserialized = ser.DeserializeGuid(buffer, ref pos2);
 			try
@@ -292,7 +292,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 		{
 			var guid = Guid.NewGuid();
 			int pos = 0;
-			ser.Serialize(buffer, guid, ref pos);
+			ser.Serialize(buffer, ref pos, guid);
 			int pos2 = 0;
 			var deserialized = ser.DeserializeGuid(buffer, ref pos2);
 			using (Assert.Multiple())
@@ -321,7 +321,7 @@ internal class BinarySerializationFloatingPointTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10];
 		var ser = new SbxSerializer();
 		int pos = 0;
-		ser.Serialize(buffer, f, ref pos);
+		ser.Serialize(buffer, ref pos, f);
 		Assert.That(pos).IsLessThan(5).GetAwaiter().GetResult();
 		var pos2 = 0;
 		var deserialized = ser.DeserializeNullableSingle(buffer, ref pos2);
@@ -344,7 +344,7 @@ internal class BinarySerializationFloatingPointTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10];
 		var ser = new SbxSerializer();
 		int pos = 0;
-		ser.Serialize(buffer, f, ref pos);
+		ser.Serialize(buffer, ref pos, f);
 		Assert.That(pos).IsLessThan(9).GetAwaiter().GetResult();
 		var pos2 = 0;
 		var deserialized = ser.DeserializeNullableDouble(buffer, ref pos2);
@@ -388,7 +388,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10];
 		var ser = new SbxSerializer();
 		int pos = 0;
-		ser.Serialize(buffer, i, ref pos);
+		ser.Serialize(buffer, ref pos, i);
 		Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
 		var pos2 = 0;
 		var deserialized = ser.DeserializeSigned(buffer, ref pos2);
@@ -410,7 +410,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10];
 		int pos = 0;
 		var ser = new SbxSerializer();
-		ser.Serialize(buffer, i, ref pos);
+		ser.Serialize(buffer, ref pos, i);
 		ReadOnlySpan<byte> buffer2 = buffer;
 		int pos2 = 0;
 		var deserialized = ser.DeserializeSigned(buffer2, ref pos2);
@@ -432,7 +432,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10];
 		int pos = 0;
 		var ser = new SbxSerializer();
-		ser.Serialize(buffer, (long?)i, ref pos);
+		ser.Serialize(buffer, ref pos, (long?)i);
 		ReadOnlySpan<byte> buffer2 = buffer;
 		int pos2 = 0;
 		var deserialized = ser.DeserializeNullableSigned(buffer2, ref pos2);
@@ -449,7 +449,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 		for (int i = short.MinValue; i <= short.MaxValue; i++)
 		{
 			int pos = 0;
-			ser.Serialize(buffer, i, ref pos);
+			ser.Serialize(buffer, ref pos, i);
 			ReadOnlySpan<byte> buffer2 = buffer;
 			int pos2 = 0;
 			var deserialized = ser.DeserializeSigned(buffer2, ref pos2);
@@ -467,7 +467,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 		for (int i = -200; i <= 200; i++)
 		{
 			int pos = 0;
-			ser.Serialize(buffer, i, ref pos);
+			ser.Serialize(buffer, ref pos, i);
 			int pos2 = 0;
 			var deserialized = ser.DeserializeSigned(buffer, ref pos2);
 			Assert.That(deserialized).IsEqualTo(i).GetAwaiter().GetResult();
@@ -493,7 +493,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 		var ser = new SbxSerializer();
 		Span<byte> buffer = stackalloc byte[20];
 		int pos = 0;
-		ser.Serialize(buffer, data, ref pos);
+		ser.Serialize(buffer, ref pos, data);
 		Assert.That(pos).IsEqualTo(hex.Length / 2).GetAwaiter().GetResult();
 
 		var pos2 = 0;
@@ -510,7 +510,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 
 		var serBuf = buffer;
 		int pos4 = pos;
-		ser.Serialize(serBuf, data, ref pos4);
+		ser.Serialize(serBuf, ref pos4, data);
 		if (hex.Length > 2) // 1 byte strings are not interned, it's a glyph or char or special value, so useless to intern
 		{
 			Assert.That(pos4).IsEqualTo(pos + 1).GetAwaiter().GetResult(); // interning
@@ -531,7 +531,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 		var data = new List<string> { "Three", "", "Three" };
-		ser.Serialize(buffer, data, ref pos);
+		ser.Serialize(buffer, ref pos, data);
 		buffer = buffer[0..pos];
 		HexDump(buffer);
 
@@ -549,7 +549,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 		var data = new List<string> { "Three", "", "Three" };
-		ser.Serialize(buffer, data, ref pos);
+		ser.Serialize(buffer, ref pos, data);
 		buffer = buffer[0..pos];
 		HexDump(buffer);
 
@@ -578,7 +578,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 			{
 				var str = Random.Shared.Next(200).ToString("000"); // 200 strings should be shufled between 66 interning slots, so we will have some hits and some misses
 				var prePos = pos;
-				ser.Serialize(buffer, str, ref pos);
+				ser.Serialize(buffer, ref pos, str);
 				ref var cnt = ref CollectionsMarshal.GetValueRefOrAddDefault(stat, pos - prePos, out _);
 				cnt++;
 
@@ -619,7 +619,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 
 		int data = 4;
 
-		ser.Serialize<int>(buffer, data, ref pos, emitTypeId: false);
+		ser.Serialize<int>(buffer, ref pos, data, emitTypeId: false);
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -642,7 +642,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 
 		var data = 4.44f;
 
-		ser.Serialize<float>(buffer, data, ref pos, emitTypeId: false);
+		ser.Serialize<float>(buffer, ref pos, data, emitTypeId: false);
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -665,7 +665,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 
 		var data = 4.44d;
 
-		ser.Serialize<double>(buffer, data, ref pos, emitTypeId: false);
+		ser.Serialize<double>(buffer, ref pos, data, emitTypeId: false);
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -688,7 +688,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 
 		int data = 4;
 
-		ser.Serialize<int>(buffer, data, ref pos, emitTypeId: true);
+		ser.Serialize<int>(buffer, ref pos, data, emitTypeId: true);
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -711,7 +711,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 
 		int data = 4;
 
-		ser.Serialize<object>(buffer, data, ref pos);
+		ser.Serialize<object>(buffer, ref pos, data);
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -902,7 +902,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
-		ser.Serialize<object>(buffer, model, ref pos);
+		ser.Serialize<object>(buffer, ref pos, model);
 
 		buffer = buffer[0..pos];
 		Console.WriteLine(Convert.ToHexString(buffer));
@@ -937,7 +937,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 			var listTypeId = (ListTypeId)(i);
 			var typeId = (TypeId)(TypeId.ListTypeFrom - i);
 			int pos = 0;
-			ser.Serialize(buffer, (long)typeId, ref pos);
+			ser.Serialize(buffer, ref pos, (long)typeId);
 			Assert.That(pos).IsEqualTo(1).GetAwaiter().GetResult();
 			Console.WriteLine($"{i,2} {listTypeId,12} <--> {(int)typeId,3} 0z{buffer[0],2:X2} {typeId,12}"); // z - for ZigZag
 			Assert.That(typeId.ToString()).Contains(listTypeId.ToString()).GetAwaiter().GetResult();
@@ -961,7 +961,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 
 		var data = new List<uint> { 1, 2, 3 };
 
-		ser.Serialize(buffer, data, ref pos);
+		ser.Serialize(buffer, ref pos, data);
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -985,7 +985,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 
 		var data = new List<string> { "One", "Two", "Three" };
 
-		ser.Serialize(buffer, data, ref pos);
+		ser.Serialize(buffer, ref pos, data);
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -1009,7 +1009,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 
 		var data = new List<string> { "Three", "", "Three" };
 
-		ser.Serialize(buffer, data, ref pos);
+		ser.Serialize(buffer, ref pos, data);
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -1038,7 +1038,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 			{ "Key3", "Value3" }
 		};
 
-		ser.Serialize(buffer, data, ref pos);
+		ser.Serialize(buffer, ref pos, data);
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -1060,7 +1060,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
-		ser.Serialize(buffer, "п", ref pos);
+		ser.Serialize(buffer, ref pos, "п");
 
 		buffer = buffer[0..pos];
 		HexDump(buffer);
@@ -1090,7 +1090,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10];
 		var ser = new SbxSerializer();
 		int pos = 0;
-		ser.Serialize(buffer, i, ref pos);
+		ser.Serialize(buffer, ref pos, i);
 		Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
 		var pos2 = 0;
 		var deserialized = ser.DeserializeUnsigned(buffer, ref pos2);
@@ -1111,7 +1111,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10];
 		var ser = new SbxSerializer();
 		int pos = 0;
-		ser.Serialize(buffer, i, ref pos);
+		ser.Serialize(buffer, ref pos, i);
 		Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
 		var pos2 = 0;
 		var deserialized = ser.DeserializeUnsigned(buffer, ref pos2);
@@ -1129,7 +1129,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 		for (uint i = 0; i < ushort.MaxValue; i++)
 		{
 			int pos = 0;
-			ser.Serialize(buffer, i, ref pos);
+			ser.Serialize(buffer, ref pos, i);
 			Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
 			var pos2 = 0;
 			var deserialized = ser.DeserializeUnsigned(buffer, ref pos2);
@@ -1146,7 +1146,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 		for (ulong i = 0; i < ushort.MaxValue; i++)
 		{
 			int pos = 0;
-			ser.Serialize(buffer, i, ref pos);
+			ser.Serialize(buffer, ref pos, i);
 			Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
 			var pos2 = 0;
 			var deserialized = ser.DeserializeUnsigned(buffer, ref pos2);
@@ -1163,7 +1163,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 		for (uint? i = 0; i < ushort.MaxValue; i++)
 		{
 			int pos = 0;
-			ser.Serialize(buffer, (ulong?)i, ref pos);
+			ser.Serialize(buffer, ref pos, (ulong?)i);
 			Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
 			var pos2 = 0;
 			var deserialized = ser.DeserializeNullableUnsigned(buffer, ref pos2);
@@ -1172,7 +1172,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 		}
 		{
 			int pos = 0;
-			ser.Serialize(buffer, (ulong?)null, ref pos);
+			ser.Serialize(buffer, ref pos, (ulong?)null);
 			Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
 			var pos2 = 0;
 			var deserialized = ser.DeserializeNullableUnsigned(buffer, ref pos2);
@@ -1192,7 +1192,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 			int pos = 0;
 			// for (int i = 0; i < 1024; i++)
 			{
-				ser.Serialize(buffer, 777U, ref pos);
+				ser.Serialize(buffer, ref pos, 777U);
 			}
 		});
 		Console.WriteLine(ops);
@@ -1268,7 +1268,7 @@ public class BinarySerializationTests : SbxBaseTest
 		// Act
 		Span<byte> buffer = stackalloc byte[10240];
 		int pos = 0;
-		ser.Serialize<object>(buffer, testData, ref pos);
+		ser.Serialize<object>(buffer, ref pos, testData);
 		buffer = buffer[..pos];
 
 		// var hex = Convert.ToHexString(buffer.Slice(0, pos).ToArray());
@@ -1300,7 +1300,7 @@ public class BinarySerializationTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10240];
 		ReadOnlySpan<byte> rbuffer = buffer;
 		int pos = 0;
-		ser.Serialize(buffer, testData, ref pos);
+		ser.Serialize(buffer, ref pos, testData);
 		buffer = buffer[..pos];
 
 		// var hex = Convert.ToHexString(buffer.Slice(0, pos).ToArray());
@@ -1335,7 +1335,7 @@ public class BinarySerializationTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10240];
 		ReadOnlySpan<byte> rbuffer = buffer;
 		int pos = 0;
-		ser.Serialize(in buffer, data, ref pos);
+		ser.Serialize(in buffer, ref pos, data);
 		// buffer = buffer[..pos];
 
 		// Assert
@@ -1373,7 +1373,7 @@ public class BinarySerializationTests : SbxBaseTest
 		Span<byte> buffer = stackalloc byte[10240];
 		ReadOnlySpan<byte> rbuffer = buffer;
 		int pos = 0;
-		ser.Serialize<TransportOperation>(buffer, data, ref pos);
+		ser.Serialize<TransportOperation>(buffer, ref pos, data);
 		buffer = buffer[..pos];
 
 		// Assert
@@ -1408,7 +1408,7 @@ public class BinarySerializationSchemaEvolutionTests : SbxBaseTest
 			OldName = "Test",
 		};
 
-		_ser.Serialize(_buffer, item, ref pos);
+		_ser.Serialize(_buffer, ref pos, item);
 		var hex = _buffer.Hex(0, pos);
 
 		Console.WriteLine(hex);

--- a/Tests/Synqra.BinarySerializer.Tests/SampleModels/SamplePublicModel_custom.cs
+++ b/Tests/Synqra.BinarySerializer.Tests/SampleModels/SamplePublicModel_custom.cs
@@ -34,7 +34,7 @@ public class SampleFieldListBaseModel_ : IBindableModel
 
 	public void Get(ISbxSerializer serializer, float schemaVersion, in Span<byte> buffer, ref int pos)
 	{
-		serializer.Serialize(in buffer, Data, ref pos); // TODO need to pass whether this list requires typeId or not
+		serializer.Serialize(in buffer, ref pos, Data); // TODO need to pass whether this list requires typeId or not
 	}
 
 	public void Set(ISbxSerializer serializer, float schemaVersion, in ReadOnlySpan<byte> buffer, ref int pos)
@@ -65,7 +65,7 @@ public class SampleFieldEnumerableBaseModel_ : IBindableModel
 
 	public void Get(ISbxSerializer serializer, float schemaVersion, in Span<byte> buffer, ref int pos)
 	{
-		serializer.Serialize(in buffer, Data, ref pos); // TODO need to pass whether this list requires typeId or not
+		serializer.Serialize(in buffer, ref pos, Data); // TODO need to pass whether this list requires typeId or not
 	}
 
 	public void Set(ISbxSerializer serializer, float schemaVersion, in ReadOnlySpan<byte> buffer, ref int pos)
@@ -215,7 +215,7 @@ partial class SamplePublicModel_ : INotifyPropertyChanging, INotifyPropertyChang
 	public void Get(ISbxSerializer serializer, float version, in Span<byte> buffer, ref int pos)
 	{
 		// Positional Fields: Name
-		serializer.Serialize(in buffer, __name, ref pos);
+		serializer.Serialize(in buffer, ref pos, __name);
 
 		// Optional Presence Mask Fields: (??)
 		// Keyed Fields: (??)

--- a/Tests/Synqra.Tests/SampleModels/Binding/SamplePublicModel_custom.cs
+++ b/Tests/Synqra.Tests/SampleModels/Binding/SamplePublicModel_custom.cs
@@ -34,7 +34,7 @@ public class SampleFieldListBaseModel_ : IBindableModel
 
 	public void Get(ISbxSerializer serializer, float schemaVersion, in Span<byte> buffer, ref int pos)
 	{
-		serializer.Serialize(in buffer, Data, ref pos); // TODO need to pass whether this list requires typeId or not
+		serializer.Serialize(in buffer, ref pos, Data); // TODO need to pass whether this list requires typeId or not
 	}
 
 	public void Set(ISbxSerializer serializer, float schemaVersion, in ReadOnlySpan<byte> buffer, ref int pos)
@@ -65,7 +65,7 @@ public class SampleFieldEnumerableBaseModel_ : IBindableModel
 
 	public void Get(ISbxSerializer serializer, float schemaVersion, in Span<byte> buffer, ref int pos)
 	{
-		serializer.Serialize(in buffer, Data, ref pos); // TODO need to pass whether this list requires typeId or not
+		serializer.Serialize(in buffer, ref pos, Data); // TODO need to pass whether this list requires typeId or not
 	}
 
 	public void Set(ISbxSerializer serializer, float schemaVersion, in ReadOnlySpan<byte> buffer, ref int pos)
@@ -215,7 +215,7 @@ partial class SamplePublicModel_ : INotifyPropertyChanging, INotifyPropertyChang
 	public void Get(ISbxSerializer serializer, float version, in Span<byte> buffer, ref int pos)
 	{
 		// Positional Fields: Name
-		serializer.Serialize(in buffer, __name, ref pos);
+		serializer.Serialize(in buffer, ref pos, __name);
 
 		// Optional Presence Mask Fields: (??)
 		// Keyed Fields: (??)

--- a/Tests/Synqra.Tests/SqliteStorageTests.cs
+++ b/Tests/Synqra.Tests/SqliteStorageTests.cs
@@ -16,7 +16,7 @@ namespace Synqra.Tests;
 /// </summary>
 file class TestBinarySerializer : ISbxSerializer
 {
-	public void Serialize<T>(in Span<byte> buffer, in T value, ref int pos)
+	public void Serialize<T>(in Span<byte> buffer, ref int pos, in T value)
 	{
 		if (value is SqliteTestItem item)
 		{
@@ -51,18 +51,18 @@ file class TestBinarySerializer : ISbxSerializer
 	public void Reset() { }
 
 	//// SERIALIZE
-	public void Serialize(in Span<byte> buffer, long value, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, ulong value, ref int pos) => throw new NotImplementedException();
-	// public void Serialize(in Span<byte> buffer, string value, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, Guid data, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, float data, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, double data, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, long? value, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, ulong? value, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, string? data, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, Guid? data, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, float? data, ref int pos) => throw new NotImplementedException();
-	public void Serialize(in Span<byte> buffer, double? data, ref int pos) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, long value) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, ulong value) => throw new NotImplementedException();
+	// public void Serialize(in Span<byte> buffer, ref int pos, string value) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, Guid data) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, float data) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, double data) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, long? value) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, ulong? value) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, string? data) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, Guid? data) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, float? data) => throw new NotImplementedException();
+	public void Serialize(in Span<byte> buffer, ref int pos, double? data) => throw new NotImplementedException();
 
 	//// DESERIALIZE
 	public long DeserializeSigned(in ReadOnlySpan<byte> buffer, ref int pos) => throw new NotImplementedException();


### PR DESCRIPTION
## What

Reorders every `SbxSerializer.Serialize` overload — signature **and** call site — from:

```csharp
Serialize(span, data, ref pos)
```

to:

```csharp
Serialize(span, ref pos, data)
```

So the write cursor (`ref int pos`) travels immediately after the buffer, and the payload comes last. This mirrors `Deserialize`, which already leads with `(buffer, ref pos, …)`.

## Scope

- `ISbxSerializer` contract (all overloads)
- `SbxSerializer` implementation (incl. multiline `#if DEBUG` token overloads and the enumerable/list path)
- The source generator emit (`serializer.Serialize(in buffer, ref pos, {access})`)
- The SQLite test-stub `ISbxSerializer` implementation
- All internal, test, and consumer call sites (`INetworkSerializationService`, `BlobAppendStorage`, POCO tracking, sample models)

**Untouched:** `Deserialize`, `IBindableModel.Get/Set`, and `IModelBinder` — none of those had a data argument sitting between the buffer and `pos`.

## Safety

Pure parameter-order change; **wire format is unchanged**. All 140 binary-serializer tests pass (the 2 failing `Humanish/OverallInterfaceTests` are separate untracked WIP scratch tests failing on test logic — unmapped model / empty assertion lambda — not this change).