### PR TITLE
feat(sbx): segment schema — model auto-tracking, write-freeze, no-schema guard

### DIFF
--- a/Synqra.BinarySerializer/SBXSerializer.cs
+++ b/Synqra.BinarySerializer/SBXSerializer.cs
@@ -250,9 +250,14 @@ public class SbxSerializer : ISbxSerializer
 		Map(-75, typeof(AddLinkCommand));
 		Map(-76, typeof(RemoveLinkCommand));
 		Map(-77, typeof(DeleteObjectCommand));
+
+		_building = false; // built-ins registered; from here Map()/auto-track counts as configuring the segment schema
 	}
 
 	SbxSerializer? _spanshotPrimitives;
+	bool _frozen; // once a segment starts writing (or is snapshotted) its schema (rule set) is locked against further Map()
+	bool _building = true; // true only during construction, while the framework built-in rules are registered
+	bool _segmentSchemaConfigured; // set once a user Map() (or model auto-tracking) adds a rule to this segment
 
 	public void Snapshot()
 	{
@@ -262,6 +267,7 @@ public class SbxSerializer : ISbxSerializer
 		{
 			throw new Exception("Snapshot already exists");
 		}
+		_frozen = true;
 		_spanshotPrimitives = (SbxSerializer)MemberwiseClone();
 		if (_stringById.Count > 0) throw new Exception("Strings must be empty");
 		if (_stringByValue.Count > 0) throw new Exception("Strings must be empty");
@@ -331,25 +337,46 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Map(int typeId, double schemaVersion, Type type, IModelBinder? binder = null)
 	{
+		if (_frozen)
+		{
+			throw new InvalidOperationException($"Cannot Map {type.Name} after serialization has started — the segment's schema is frozen.");
+		}
+		if (!_building)
+		{
+			_segmentSchemaConfigured = true; // a user rule was added to the segment schema
+		}
 		if (schemaVersion == 0)
 		{
-			// if (!type.IsAbstract && !type.IsInterface)
-			{
-				var schemaAttribute = (SchemaAttribute)type.GetCustomAttributes(typeof(SchemaAttribute), false)
-					.Cast<SchemaAttribute>()
-					.OrderByDescending(x => x.Version)
-					.FirstOrDefault()
-					;
-				if (schemaAttribute is null)
-				{
-					throw new Exception($"Can not detect latest version, no schema defined for {type.Name}");
-				}
-				schemaVersion = schemaAttribute.Version;
-			}
+			schemaVersion = TryGetLatestSchemaVersion(type)
+				?? throw new Exception($"Can not detect latest version, no schema defined for {type.Name}");
 		}
 		var schemaVersionF = (float)schemaVersion;
 		_typeById[typeId] = (schemaVersionF, type, binder);
 		_idByType[type] = (typeId, schemaVersionF, binder);
+	}
+
+	/// <summary>Latest [Schema] version stamped on a type, or null if it carries no schema at all.</summary>
+	static float? TryGetLatestSchemaVersion(Type type)
+	{
+		var schemaAttribute = type.GetCustomAttributes(typeof(SchemaAttribute), false)
+			.Cast<SchemaAttribute>()
+			.OrderByDescending(x => x.Version)
+			.FirstOrDefault();
+		return schemaAttribute is null ? (float?)null : (float)schemaAttribute.Version;
+	}
+
+	/// <summary>
+	/// A segment's schema is the set of rules (type-id mappings among them) established via Map() or model auto-tracking.
+	/// It is "configured" once it holds at least one rule beyond the framework built-ins.
+	/// </summary>
+	bool HasSegmentSchema => _segmentSchemaConfigured;
+
+	void RequireSegmentSchema()
+	{
+		if (!HasSegmentSchema)
+		{
+			throw new InvalidOperationException("No schemas configured.");
+		}
 	}
 
 	/*
@@ -404,6 +431,7 @@ public class SbxSerializer : ISbxSerializer
 		, bool? emitTypeId = null
 		)
 	{
+		_frozen = true; // first write freezes the session's type/schema table
 		// TODO: Actually utf8 is not efficient encoding, it is very verbose. Consider to reencode this as varints sequence. On top of that - delata encoding and offset pointer(s) might give huge benefit for different countries, e.g. imagine to use 2 bytes to refer to 32K of most typical hyeroglyphs!
 		//  0x0000 –   0x007F: utf8: 1 bytes, varint_array: 1 bytes
 		//  0x0080 –   0x07FF: utf8: 2 bytes, varint_array: 2 bytes
@@ -419,6 +447,22 @@ public class SbxSerializer : ISbxSerializer
 		// If this is level 3, the reset of the fields are in alphabetical order by field name (to ensure canonical normalization for auto-repairs & hash tree)
 
 		var actualType = obj?.GetType();
+
+		// Segment-schema gate (point 3). A model brings its own [Schema] into the segment's rule set
+		// (auto-tracking), so it's always allowed; anything else requires the segment to already carry a
+		// schema. Registering the model here — before the type-id is emitted — keeps nested field writes valid.
+		if (obj is IBindableModel && !_idByType.ContainsKey(actualType!))
+		{
+			var autoVersion = TryGetLatestSchemaVersion(actualType!)
+				?? throw new InvalidOperationException($"Cannot serialize {actualType!.FullName}: it is an IBindableModel with no [Schema] and was never registered via Map(). A segment needs a derivable schema for every type it writes.");
+			_idByType[actualType!] = (0, autoVersion, null); // 0 = self-describing (emitted by name); rule tracked for the segment/header
+			_segmentSchemaConfigured = true;
+		}
+		else if (!HasSegmentSchema)
+		{
+			throw new InvalidOperationException("No schemas configured.");
+		}
+
 		if (emitTypeId == null)
 		{
 			var testType = requestedType;
@@ -548,7 +592,8 @@ public class SbxSerializer : ISbxSerializer
 			}
 			else
 			{
-				throw new Exception($"BindableModel {obj.GetType().Name} type id is not registered");
+				// Unreachable: the hub hoists/registers any IBindableModel into the segment schema before this point.
+				throw new InvalidOperationException($"BindableModel {obj.GetType().Name} was not tracked into the segment schema");
 			}
 		}
 		else if (obj is null)
@@ -1394,6 +1439,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(in Span<byte> buffer, ref int pos, Type type)
 	{
+		RequireSegmentSchema();
 		var typeId = GetTypeId(type);
 		Serialize(buffer, ref pos, typeId);
 		if (typeId == TypeId.Unknown)
@@ -1505,6 +1551,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(in Span<byte> buffer, ref int pos, string? data)
 	{
+		RequireSegmentSchema();
 		if (data == null)
 		{
 			buffer[pos++] = 0xFF; // special value for null string. This value is outside of legit UTF8 space
@@ -1590,6 +1637,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public unsafe void Serialize(in Span<byte> buffer, ref int pos, float data)
 	{
+		RequireSegmentSchema();
 		var bytes = (byte*)&data;
 		buffer[pos++] = bytes[0];
 		buffer[pos++] = bytes[1];
@@ -1598,6 +1646,7 @@ public class SbxSerializer : ISbxSerializer
 	}
 	public unsafe void Serialize(in Span<byte> buffer, ref int pos, double data)
 	{
+		RequireSegmentSchema();
 		/*
 		// test single downgrade
 		var single = Convert.ToSingle(data);
@@ -1622,6 +1671,7 @@ public class SbxSerializer : ISbxSerializer
 	}
 	public unsafe void Serialize(in Span<byte> buffer, ref int pos, float? data)
 	{
+		RequireSegmentSchema();
 		if (data == null)
 		{
 			Serialize(buffer, ref pos, float.NegativeZero);
@@ -1637,6 +1687,7 @@ public class SbxSerializer : ISbxSerializer
 	}
 	public void Serialize(in Span<byte> buffer, ref int pos, double? data)
 	{
+		RequireSegmentSchema();
 		if (data == null)
 		{
 			Serialize(buffer, ref pos, double.NegativeZero);
@@ -1694,6 +1745,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(in Span<byte> buffer, ref int pos, long? data)
 	{
+		RequireSegmentSchema();
 		// ZigZag encode the signed int with null offset
 		if (data == null)
 		{
@@ -1744,6 +1796,7 @@ public class SbxSerializer : ISbxSerializer
 
 	private void Serialize(in Span<byte> buffer, ref int pos, TypeId data)
 	{
+		RequireSegmentSchema();
 		Serialize(buffer, ref pos, (long)data);
 	}
 
@@ -1752,6 +1805,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(in Span<byte> buffer, ref int pos, long data, string tokenDebugData)
 	{
+		RequireSegmentSchema();
 		var start = pos;
 		Serialize(in buffer, ref pos, in data);
 		Tokens.Add((start, pos, tokenDebugData));
@@ -1760,6 +1814,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(in Span<byte> buffer, ref int pos, long data)
 	{
+		RequireSegmentSchema();
 		// ZigZag encode the signed int
 		ulong zigzag = (ulong)(data << 1 ^ data >> 63);
 		while (zigzag >= 0x80UL)
@@ -1822,6 +1877,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(in Span<byte> buffer, ref int pos, ulong? value)
 	{
+		RequireSegmentSchema();
 		if (value == null)
 		{
 			value = 0;
@@ -1852,6 +1908,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(in Span<byte> buffer, ref int pos, ulong value)
 	{
+		RequireSegmentSchema();
 		// Protobuf-style varint encoding for uint32 (little-endian, 7 bits per byte, MSB=1 means more)
 		while (value >= 0x80)
 		{
@@ -1932,6 +1989,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public void Serialize(in Span<byte> buffer, ref int pos, Guid? data)
 	{
+		RequireSegmentSchema();
 		if (data == null)
 		{
 			buffer[pos++] = 0x03; // glyph 0x03 - NULL object guid
@@ -1944,6 +2002,7 @@ public class SbxSerializer : ISbxSerializer
 
 	public unsafe void Serialize(in Span<byte> buffer, ref int pos, Guid data)
 	{
+		RequireSegmentSchema();
 		// In scope of Synqra and SBX we only use Guid v4, v5, v7, v8
 		// In guid v4 there is nothing to compress
 		// In guid v5 there is nothing to compress

--- a/Tests/Synqra.BinarySerializer.Tests/BinarySerializationTests.cs
+++ b/Tests/Synqra.BinarySerializer.Tests/BinarySerializationTests.cs
@@ -44,7 +44,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 
 		var guid = new Guid(guidString);
 		Span<byte> buffer = stackalloc byte[20];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		ser.SetTimeBase(new DateTime(2025, 10, 7, 15, 17, 38, DateTimeKind.Utc));
 		int pos = 0;
 		ser.Serialize(buffer, ref pos, guid);
@@ -60,7 +60,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 	[Test]
 	public void Should_compress_time()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		var baseTime = new DateTime(2000, 01, 01, 00, 00, 00, DateTimeKind.Utc);
 		ser.SetTimeBase(baseTime);
 		Span<byte> buffer = stackalloc byte[20];
@@ -112,7 +112,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 		Console.WriteLine(backStamp);
 		Assert.That(id.ToString("N")[..12]).IsEqualTo(backStamp.ToString("N")[..12]).GetAwaiter().GetResult();
 
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		ser.SetTimeBase(new DateTime(2025, 10, 7, 15, 17, 38, DateTimeKind.Utc));
 		Span<byte> buffer = stackalloc byte[20];
 		int pos = 0;
@@ -128,7 +128,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 	[Arguments(true)]
 	public void Should_serialize_v7_guids(bool? sign)
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		ser.SetTimeBase(DateTime.UtcNow.AddHours(sign != null ? (sign.Value ? 1 : -1) : 0)); // need to guarantee one of 2 paths: compressed unsigned vs signed to avoid flakiness
 		Span<byte> buffer = stackalloc byte[20];
 		Console.WriteLine("V7 compression");
@@ -169,7 +169,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 	public async Task Should_serialize_v7_at_all_times()
 	{
 		Span<byte> buffer = stackalloc byte[20];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		ser.SetTimeBase(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
 
 
@@ -201,7 +201,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 	[Test]
 	public void Should_serialize_random_guids_v8()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[20];
 		Console.WriteLine("V8 high entropy");
 		for (int i = 0; i < 1000; i++)
@@ -239,7 +239,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 		Assert.That(g1.Version).IsEqualTo(7); // this is not V7 !!! this is .Net BUG!! Variant is wrong!!
 #endif
 
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[20];
 		Console.WriteLine("V8 high entropy");
 		Span<byte> buf = stackalloc byte[2];
@@ -285,7 +285,7 @@ internal class BinarySerializationGuidTests : SbxBaseTest
 	[Test]
 	public void Should_serialize_random_guids_v4()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[20];
 		Console.WriteLine("V4");
 		for (int i = 0; i < 1000; i++)
@@ -319,7 +319,7 @@ internal class BinarySerializationFloatingPointTests : SbxBaseTest
 	public void Should_serialize_single_floats_with_test_vectors(int id, float? f, string hex)
 	{
 		Span<byte> buffer = stackalloc byte[10];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		int pos = 0;
 		ser.Serialize(buffer, ref pos, f);
 		Assert.That(pos).IsLessThan(5).GetAwaiter().GetResult();
@@ -342,7 +342,7 @@ internal class BinarySerializationFloatingPointTests : SbxBaseTest
 	public void Should_serialize_double_floats_with_test_vectors(int id, double? f, string hex)
 	{
 		Span<byte> buffer = stackalloc byte[10];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		int pos = 0;
 		ser.Serialize(buffer, ref pos, f);
 		Assert.That(pos).IsLessThan(9).GetAwaiter().GetResult();
@@ -386,7 +386,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 	public void Should_serialize_signed_integers_with_test_vectors(int id, int i, string hex)
 	{
 		Span<byte> buffer = stackalloc byte[10];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		int pos = 0;
 		ser.Serialize(buffer, ref pos, i);
 		Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
@@ -409,7 +409,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 	{
 		Span<byte> buffer = stackalloc byte[10];
 		int pos = 0;
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		ser.Serialize(buffer, ref pos, i);
 		ReadOnlySpan<byte> buffer2 = buffer;
 		int pos2 = 0;
@@ -431,7 +431,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 	{
 		Span<byte> buffer = stackalloc byte[10];
 		int pos = 0;
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		ser.Serialize(buffer, ref pos, (long?)i);
 		ReadOnlySpan<byte> buffer2 = buffer;
 		int pos2 = 0;
@@ -444,7 +444,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 	[Test]
 	public void Should_serialize_signed_integers()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[10];
 		for (int i = short.MinValue; i <= short.MaxValue; i++)
 		{
@@ -462,7 +462,7 @@ internal class BinarySerializationSignedTests : SbxBaseTest
 	[Test]
 	public void Should_serialize_signed_integers_print()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[10];
 		for (int i = -200; i <= 200; i++)
 		{
@@ -490,7 +490,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 	[Arguments(null, "FF")]
 	public void Should_serialize_strings_with_test_vectors(string? data, string hex)
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[20];
 		int pos = 0;
 		ser.Serialize(buffer, ref pos, data);
@@ -502,7 +502,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 		Assert.That(pos2).IsEqualTo(pos).GetAwaiter().GetResult();
 		Assert.That(Convert.ToHexString(buffer.Slice(0, pos))).IsEqualTo(hex).GetAwaiter().GetResult();
 
-		var deser = new SbxSerializer();
+		var deser = NewSchemaSerializer();
 		var deserPos = 0;
 		var deserialized2 = deser.DeserializeString(buffer, ref deserPos);
 		Assert.That(deserialized2).IsEqualTo(data).GetAwaiter().GetResult();
@@ -527,7 +527,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 	[Test]
 	public void Should_17_make_string_interning()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 		var data = new List<string> { "Three", "", "Three" };
@@ -535,7 +535,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 		buffer = buffer[0..pos];
 		HexDump(buffer);
 
-		var deser = new SbxSerializer();
+		var deser = NewSchemaSerializer();
 		var pos2 = 0;
 		var deserialized = deser.Deserialize<List<string>>(buffer, ref pos2);
 		Assert.That(deserialized).IsEquivalentTo(data).GetAwaiter().GetResult();
@@ -545,7 +545,7 @@ internal class BinarySerializationStringTests : SbxBaseTest
 	[Test]
 	public void Should_18_make_string_interning()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 		var data = new List<string> { "Three", "", "Three" };
@@ -562,8 +562,8 @@ internal class BinarySerializationStringTests : SbxBaseTest
 	[Test]
 	public async Task Should_serialize_strings_with_heavy_interning()
 	{
-		var ser = new SbxSerializer();
-		var deser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
+		var deser = NewSchemaSerializer();
 
 		var iterations = 3000;
 
@@ -613,7 +613,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 	[Test]
 	public void Should_10_serialize_generic_int_without_type()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -636,7 +636,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 	[Test]
 	public void Should_11_serialize_generic_float_without_type()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -659,7 +659,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 	[Test]
 	public void Should_12_serialize_generic_double_without_type()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -682,7 +682,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 	[Test]
 	public void Should_10_serialize_generic_int_with_type()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -705,7 +705,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 	[Test]
 	public void Should_10_serialize_boxed_int()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -878,7 +878,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 		var modelJson = doubleCheckJson ? JsonSerializer.Serialize(model, options) : null;
 		Console.WriteLine(modelJson);
 
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		ser.Map( 1 /* 02 */, typeof(SampleFieldSealedModel));
 		ser.Map( 2 /* 04 */, typeof(SampleSealedModel));
 		ser.Map( 3 /* 06 */, typeof(SampleFieldBaseModel));
@@ -930,7 +930,7 @@ internal class BinarySerializationObjectPropertyTests : SbxBaseTest
 		Console.WriteLine(".");
 		var count = (int)ListTypeId.MAX;
 		Assert.That(count).IsEqualTo(16).GetAwaiter().GetResult();
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<Byte> buffer = stackalloc byte[1];
 		for (int i = 0; i < count; i++)
 		{
@@ -955,7 +955,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 	[Test]
 	public void Should_15_serialize_list_of_int()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -979,7 +979,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 	[Test]
 	public void Should_15_serialize_list_of_string()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -1003,7 +1003,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 	[Test]
 	public void Should_17_make_string_interning()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -1027,7 +1027,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 	[Test]
 	public void Should_20_serialize_dictionary_of_string()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -1056,7 +1056,7 @@ internal class BinarySerializationListDictionaryTests : SbxBaseTest
 	[Test]
 	public void Should_print_cyrillic_utf8_codes()
 	{
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		Span<byte> buffer = stackalloc byte[1024];
 		int pos = 0;
 
@@ -1088,7 +1088,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 	public void Should_serialize_unsigned_integers_with_test_vectors(uint i, string hex)
 	{
 		Span<byte> buffer = stackalloc byte[10];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		int pos = 0;
 		ser.Serialize(buffer, ref pos, i);
 		Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
@@ -1109,7 +1109,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 	public void Should_serialize_unsigned_integers_with_test_vectors_long(ulong i, string hex)
 	{
 		Span<byte> buffer = stackalloc byte[10];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		int pos = 0;
 		ser.Serialize(buffer, ref pos, i);
 		Assert.That(pos).IsLessThan(4).GetAwaiter().GetResult();
@@ -1125,7 +1125,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 	public void Should_serialize_unsigned_integers()
 	{
 		Span<byte> buffer = stackalloc byte[10];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		for (uint i = 0; i < ushort.MaxValue; i++)
 		{
 			int pos = 0;
@@ -1142,7 +1142,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 	public void Should_serialize_unsigned_integers_long()
 	{
 		Span<byte> buffer = stackalloc byte[10];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		for (ulong i = 0; i < ushort.MaxValue; i++)
 		{
 			int pos = 0;
@@ -1159,7 +1159,7 @@ internal class BinarySerializationUnsignedTests : SbxBaseTest
 	public void Should_serialize_nullable_unsigned_integers()
 	{
 		Span<byte> buffer = stackalloc byte[10];
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		for (uint? i = 0; i < ushort.MaxValue; i++)
 		{
 			int pos = 0;
@@ -1264,7 +1264,7 @@ public class BinarySerializationTests : SbxBaseTest
 			// Tags = new List<string> { "Tag1", "Tag2" }
 		};
 
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		// Act
 		Span<byte> buffer = stackalloc byte[10240];
 		int pos = 0;
@@ -1295,7 +1295,7 @@ public class BinarySerializationTests : SbxBaseTest
 			// Tags = new List<string> { "Tag1", "Tag2" }
 		};
 
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		// Act
 		Span<byte> buffer = stackalloc byte[10240];
 		ReadOnlySpan<byte> rbuffer = buffer;
@@ -1322,7 +1322,7 @@ public class BinarySerializationTests : SbxBaseTest
 	public async Task Should_serialize_generated_class_by_field_names_as_known()
 	{
 		// Arrange
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		var data = new SampleTestSynqraModel
 		{
 			Id = 7,
@@ -1353,7 +1353,7 @@ public class BinarySerializationTests : SbxBaseTest
 	public async Task Should_serialize_well_known_class_by_field_names_as_known2()
 	{
 		// Arrange
-		var ser = new SbxSerializer();
+		var ser = NewSchemaSerializer();
 		var data = new NewEvent1
 		{
 			Event = new ComponentAddedEvent
@@ -1395,8 +1395,8 @@ public class BinarySerializationSchemaEvolutionTests : SbxBaseTest
 	byte[] _buffer = new byte[10240];
 	int pos = 0;
 	int depos = 0;
-	SbxSerializer _ser = new SbxSerializer();
-	SbxSerializer _deser = new SbxSerializer();
+	SbxSerializer _ser = NewSchemaSerializer();
+	SbxSerializer _deser = NewSchemaSerializer();
 	byte[] _v1Test = "5465737400".Hex(); // see Should_10_serialize_simple_field
 
 	[Test]

--- a/Tests/Synqra.BinarySerializer.Tests/Humanish/OverallInterfaceTests.cs
+++ b/Tests/Synqra.BinarySerializer.Tests/Humanish/OverallInterfaceTests.cs
@@ -1,0 +1,71 @@
+﻿using Synqra.Tests.SampleModels.Syncronization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Synqra.BinarySerializer.Tests.Humanish;
+
+internal class OverallInterfaceTests
+{
+	[Test]
+	public async Task Should_10_binary_serialize()
+	{
+		var sbx = new SbxSerializer();
+		Span<byte> bytes = stackalloc byte[1024];
+		int pos = 0;
+		sbx.Serialize(in bytes, ref pos, new SampleTaskModel { Number = 7, Subject = "Sample 1" });
+		// Should now froze and not allow changes to metadata!!
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			sbx.Map(777, typeof(SampleTaskModel));
+		});
+	}
+
+	[Test]
+	public async Task Should_11_autopopulate_header_metadata()
+	{
+		// Pre-configured metadata for SampleTaskModel
+		var sbx = new SbxSerializer();
+		sbx.Map(777, typeof(SampleTaskModel));
+
+		Span<byte> bytes = stackalloc byte[1024];
+		int pos = 0;
+
+		sbx.Serialize(in bytes, ref pos, "Test");
+		sbx.Serialize(in bytes, ref pos, new SampleTaskModel { Number = 7, Subject = "Sample 1" });
+		pos = 0;
+
+		sbx = new SbxSerializer();
+		sbx.Map(777, typeof(SampleTaskModel));
+
+	}
+
+	[Test]
+	public async Task Should_12_autopopulate_header_metadata()
+	{
+		// Pre-configured metadata for SampleTaskModel
+		var sbx = new SbxSerializer();
+		sbx.Map(777, typeof(SampleTaskModel));
+
+		Span<byte> bytes = stackalloc byte[1024];
+		int pos = 0;
+
+		sbx.Serialize(in bytes, ref pos, "Test");
+		sbx.Serialize(in bytes, ref pos, new SampleTaskModel { Number = 7, Subject = "Sample 1" });
+	}
+
+	[Test]
+	public async Task Should_13_not_allow_serialization_untill_metadata_configured()
+	{
+		var sbx = new SbxSerializer();
+
+		var ex = Assert.Throws<InvalidOperationException>(() =>
+		{
+			Span<byte> bytes = stackalloc byte[1024];
+			int pos = 0;
+			sbx.Serialize(in bytes, ref pos, "Test");
+		});
+
+		await Assert.That(ex.Message).IsEqualTo("No schemas configured.");
+	}
+}

--- a/Tests/Synqra.BinarySerializer.Tests/Humanish/README.md
+++ b/Tests/Synqra.BinarySerializer.Tests/Humanish/README.md
@@ -1,0 +1,6 @@
+﻿# SbxSerializer Lifecycle
+
+## Header
+Contains a schema version that is essentially a map to type mapping and dictionaries.
+
+## Segment (e.g. 25MB segment for click house style or for network - entire connection. For mongo - up to you, per document or per stream)

--- a/Tests/Synqra.BinarySerializer.Tests/SbxBaseTest.cs
+++ b/Tests/Synqra.BinarySerializer.Tests/SbxBaseTest.cs
@@ -1,4 +1,5 @@
 using Synqra.BinarySerializer;
+using Synqra.Tests.SampleModels.Syncronization;
 using System.Text.Json;
 
 namespace Synqra.BinarySerializer.Tests;
@@ -10,6 +11,18 @@ namespace Synqra.BinarySerializer.Tests;
 public class SbxBaseTest
 {
 	public HexDumpWriter HexDumpWriter = new HexDumpWriter();
+
+	/// <summary>
+	/// A serializer whose segment already carries a schema, so low-level codec tests can drive the
+	/// primitive encoders directly. A segment refuses to serialize anything until its schema (rule set)
+	/// is configured; id 99 is unused by any test, so it never collides with a test's own Map() calls.
+	/// </summary>
+	public static SbxSerializer NewSchemaSerializer()
+	{
+		var s = new SbxSerializer();
+		s.Map(99, typeof(SampleTaskModel));
+		return s;
+	}
 
 	public void HexDump(ReadOnlySpan<byte> data, SbxSerializer? serializer = null)
 	{


### PR DESCRIPTION
First slice of the SbxSerializer *segment* model: a serializer instance is a segment whose **schema** (a rule set — type-id mappings among them) must be established before it will write.

### Behavior
- **Auto-track** — serializing an `[Schema]`-bearing `IBindableModel` no longer requires an explicit `Map()`. The model's schema is derived and folded into the segment's rule set on first use (hoisted *before* the type-id is emitted, so nested field writes remain valid). A model with **no** `[Schema]` is a hard error.
- **Freeze** — the first write (or `Snapshot()`) locks the segment's schema; `Map()` afterward throws `InvalidOperationException`.
- **No-schema guard (point 3)** — a top-level `Serialize` into a segment with no configured schema throws `InvalidOperationException("No schemas configured.")`. Framework built-ins registered in the constructor do **not** count as a user/segment schema.

Drives `Humanish/OverallInterfaceTests` (`Should_10`..`Should_13`) and the design note in `Humanish/README.md`.

### Test fallout
Low-level codec tests drive the primitive encoders directly, so under the guard they now go through `NewSchemaSerializer()` — a serializer with a segment schema pre-configured on an unused id (99) that can't collide with any test's own maps.

### Still TODO (step B, follow-up)
Self-describing **inline schema records** (write schema-first so a chunk decodes with no prior context) + explicit **`WriteHeader`/`ReadHeader`** for negotiated/stored headers. That step commits wire format and is held pending the encoding decision.

All 144 binary-serializer tests and the full `Synqra.Tests` suite pass.